### PR TITLE
update: removed all the pointers and indirection

### DIFF
--- a/rfc5424/machine.go
+++ b/rfc5424/machine.go
@@ -1,10 +1,9 @@
-
 //line rfc5424/machine.go.rl:1
 package rfc5424
 
 import (
-	"time"
 	"fmt"
+	"time"
 )
 
 var (
@@ -25,10 +24,7 @@ var (
 	errParse          = "parsing error [col %d]"
 )
 
-
 //line rfc5424/machine.go.rl:346
-
-
 
 //line rfc5424/machine.go:34
 const rfc5424_start int = 1
@@ -38,16 +34,13 @@ const rfc5424_error int = 0
 const rfc5424_en_fail int = 607
 const rfc5424_en_main int = 1
 
-
 //line rfc5424/machine.go.rl:349
-
 type machine struct {
 	data         []byte
 	cs           int
 	p, pe, eof   int
 	pb           int
 	err          error
-	output       *SyslogMessage
 	currentelem  string
 	currentparam string
 	msg_at       int
@@ -58,17 +51,12 @@ type machine struct {
 func NewMachine() *machine {
 	m := &machine{}
 
-	
 //line rfc5424/machine.go.rl:368
-	
-//line rfc5424/machine.go.rl:369
-	
-//line rfc5424/machine.go.rl:370
-	
-//line rfc5424/machine.go.rl:371
-	
-//line rfc5424/machine.go.rl:372
 
+//line rfc5424/machine.go.rl:369
+//line rfc5424/machine.go.rl:370
+//line rfc5424/machine.go.rl:371
+//line rfc5424/machine.go.rl:372
 	return m
 }
 
@@ -90,7 +78,7 @@ func (m *machine) text() []byte {
 //
 // It can also partially parse input messages returning a partially valid structured representation
 // and the error that stopped the parsing.
-func (m *machine) Parse(input []byte, bestEffort *bool) (*SyslogMessage, error) {
+func (m *machine) Parse(input []byte, bestEffort bool) (output SyslogMessage, err error) {
 	m.data = input
 	m.p = 0
 	m.pb = 0
@@ -99,1760 +87,1774 @@ func (m *machine) Parse(input []byte, bestEffort *bool) (*SyslogMessage, error) 
 	m.pe = len(input)
 	m.eof = len(input)
 	m.err = nil
-	m.output = &SyslogMessage{}
 
-    
 //line rfc5424/machine.go:106
 	{
-	 m.cs = rfc5424_start
+		m.cs = rfc5424_start
 	}
 
 //line rfc5424/machine.go.rl:406
-    
+
 //line rfc5424/machine.go:113
 	{
-	if ( m.p) == ( m.pe) {
-		goto _test_eof
-	}
-	switch  m.cs {
-	case 1:
-		goto st_case_1
-	case 0:
-		goto st_case_0
-	case 2:
-		goto st_case_2
-	case 3:
-		goto st_case_3
-	case 4:
-		goto st_case_4
-	case 5:
-		goto st_case_5
-	case 6:
-		goto st_case_6
-	case 7:
-		goto st_case_7
-	case 8:
-		goto st_case_8
-	case 9:
-		goto st_case_9
-	case 10:
-		goto st_case_10
-	case 11:
-		goto st_case_11
-	case 12:
-		goto st_case_12
-	case 13:
-		goto st_case_13
-	case 14:
-		goto st_case_14
-	case 15:
-		goto st_case_15
-	case 16:
-		goto st_case_16
-	case 603:
-		goto st_case_603
-	case 604:
-		goto st_case_604
-	case 605:
-		goto st_case_605
-	case 17:
-		goto st_case_17
-	case 18:
-		goto st_case_18
-	case 19:
-		goto st_case_19
-	case 20:
-		goto st_case_20
-	case 21:
-		goto st_case_21
-	case 22:
-		goto st_case_22
-	case 23:
-		goto st_case_23
-	case 24:
-		goto st_case_24
-	case 25:
-		goto st_case_25
-	case 26:
-		goto st_case_26
-	case 27:
-		goto st_case_27
-	case 28:
-		goto st_case_28
-	case 29:
-		goto st_case_29
-	case 30:
-		goto st_case_30
-	case 31:
-		goto st_case_31
-	case 32:
-		goto st_case_32
-	case 33:
-		goto st_case_33
-	case 34:
-		goto st_case_34
-	case 35:
-		goto st_case_35
-	case 36:
-		goto st_case_36
-	case 37:
-		goto st_case_37
-	case 38:
-		goto st_case_38
-	case 39:
-		goto st_case_39
-	case 40:
-		goto st_case_40
-	case 41:
-		goto st_case_41
-	case 42:
-		goto st_case_42
-	case 43:
-		goto st_case_43
-	case 44:
-		goto st_case_44
-	case 45:
-		goto st_case_45
-	case 46:
-		goto st_case_46
-	case 47:
-		goto st_case_47
-	case 48:
-		goto st_case_48
-	case 49:
-		goto st_case_49
-	case 50:
-		goto st_case_50
-	case 51:
-		goto st_case_51
-	case 52:
-		goto st_case_52
-	case 53:
-		goto st_case_53
-	case 54:
-		goto st_case_54
-	case 55:
-		goto st_case_55
-	case 56:
-		goto st_case_56
-	case 57:
-		goto st_case_57
-	case 58:
-		goto st_case_58
-	case 59:
-		goto st_case_59
-	case 60:
-		goto st_case_60
-	case 61:
-		goto st_case_61
-	case 62:
-		goto st_case_62
-	case 606:
-		goto st_case_606
-	case 63:
-		goto st_case_63
-	case 64:
-		goto st_case_64
-	case 65:
-		goto st_case_65
-	case 66:
-		goto st_case_66
-	case 67:
-		goto st_case_67
-	case 68:
-		goto st_case_68
-	case 69:
-		goto st_case_69
-	case 70:
-		goto st_case_70
-	case 71:
-		goto st_case_71
-	case 72:
-		goto st_case_72
-	case 73:
-		goto st_case_73
-	case 74:
-		goto st_case_74
-	case 75:
-		goto st_case_75
-	case 76:
-		goto st_case_76
-	case 77:
-		goto st_case_77
-	case 78:
-		goto st_case_78
-	case 79:
-		goto st_case_79
-	case 80:
-		goto st_case_80
-	case 81:
-		goto st_case_81
-	case 82:
-		goto st_case_82
-	case 83:
-		goto st_case_83
-	case 84:
-		goto st_case_84
-	case 85:
-		goto st_case_85
-	case 86:
-		goto st_case_86
-	case 87:
-		goto st_case_87
-	case 88:
-		goto st_case_88
-	case 89:
-		goto st_case_89
-	case 90:
-		goto st_case_90
-	case 91:
-		goto st_case_91
-	case 92:
-		goto st_case_92
-	case 93:
-		goto st_case_93
-	case 94:
-		goto st_case_94
-	case 95:
-		goto st_case_95
-	case 96:
-		goto st_case_96
-	case 97:
-		goto st_case_97
-	case 98:
-		goto st_case_98
-	case 99:
-		goto st_case_99
-	case 100:
-		goto st_case_100
-	case 101:
-		goto st_case_101
-	case 102:
-		goto st_case_102
-	case 103:
-		goto st_case_103
-	case 104:
-		goto st_case_104
-	case 105:
-		goto st_case_105
-	case 106:
-		goto st_case_106
-	case 107:
-		goto st_case_107
-	case 108:
-		goto st_case_108
-	case 109:
-		goto st_case_109
-	case 110:
-		goto st_case_110
-	case 111:
-		goto st_case_111
-	case 112:
-		goto st_case_112
-	case 113:
-		goto st_case_113
-	case 114:
-		goto st_case_114
-	case 115:
-		goto st_case_115
-	case 116:
-		goto st_case_116
-	case 117:
-		goto st_case_117
-	case 118:
-		goto st_case_118
-	case 119:
-		goto st_case_119
-	case 120:
-		goto st_case_120
-	case 121:
-		goto st_case_121
-	case 122:
-		goto st_case_122
-	case 123:
-		goto st_case_123
-	case 124:
-		goto st_case_124
-	case 125:
-		goto st_case_125
-	case 126:
-		goto st_case_126
-	case 127:
-		goto st_case_127
-	case 128:
-		goto st_case_128
-	case 129:
-		goto st_case_129
-	case 130:
-		goto st_case_130
-	case 131:
-		goto st_case_131
-	case 132:
-		goto st_case_132
-	case 133:
-		goto st_case_133
-	case 134:
-		goto st_case_134
-	case 135:
-		goto st_case_135
-	case 136:
-		goto st_case_136
-	case 137:
-		goto st_case_137
-	case 138:
-		goto st_case_138
-	case 139:
-		goto st_case_139
-	case 140:
-		goto st_case_140
-	case 141:
-		goto st_case_141
-	case 142:
-		goto st_case_142
-	case 143:
-		goto st_case_143
-	case 144:
-		goto st_case_144
-	case 145:
-		goto st_case_145
-	case 146:
-		goto st_case_146
-	case 147:
-		goto st_case_147
-	case 148:
-		goto st_case_148
-	case 149:
-		goto st_case_149
-	case 150:
-		goto st_case_150
-	case 151:
-		goto st_case_151
-	case 152:
-		goto st_case_152
-	case 153:
-		goto st_case_153
-	case 154:
-		goto st_case_154
-	case 155:
-		goto st_case_155
-	case 156:
-		goto st_case_156
-	case 157:
-		goto st_case_157
-	case 158:
-		goto st_case_158
-	case 159:
-		goto st_case_159
-	case 160:
-		goto st_case_160
-	case 161:
-		goto st_case_161
-	case 162:
-		goto st_case_162
-	case 163:
-		goto st_case_163
-	case 164:
-		goto st_case_164
-	case 165:
-		goto st_case_165
-	case 166:
-		goto st_case_166
-	case 167:
-		goto st_case_167
-	case 168:
-		goto st_case_168
-	case 169:
-		goto st_case_169
-	case 170:
-		goto st_case_170
-	case 171:
-		goto st_case_171
-	case 172:
-		goto st_case_172
-	case 173:
-		goto st_case_173
-	case 174:
-		goto st_case_174
-	case 175:
-		goto st_case_175
-	case 176:
-		goto st_case_176
-	case 177:
-		goto st_case_177
-	case 178:
-		goto st_case_178
-	case 179:
-		goto st_case_179
-	case 180:
-		goto st_case_180
-	case 181:
-		goto st_case_181
-	case 182:
-		goto st_case_182
-	case 183:
-		goto st_case_183
-	case 184:
-		goto st_case_184
-	case 185:
-		goto st_case_185
-	case 186:
-		goto st_case_186
-	case 187:
-		goto st_case_187
-	case 188:
-		goto st_case_188
-	case 189:
-		goto st_case_189
-	case 190:
-		goto st_case_190
-	case 191:
-		goto st_case_191
-	case 192:
-		goto st_case_192
-	case 193:
-		goto st_case_193
-	case 194:
-		goto st_case_194
-	case 195:
-		goto st_case_195
-	case 196:
-		goto st_case_196
-	case 197:
-		goto st_case_197
-	case 198:
-		goto st_case_198
-	case 199:
-		goto st_case_199
-	case 200:
-		goto st_case_200
-	case 201:
-		goto st_case_201
-	case 202:
-		goto st_case_202
-	case 203:
-		goto st_case_203
-	case 204:
-		goto st_case_204
-	case 205:
-		goto st_case_205
-	case 206:
-		goto st_case_206
-	case 207:
-		goto st_case_207
-	case 208:
-		goto st_case_208
-	case 209:
-		goto st_case_209
-	case 210:
-		goto st_case_210
-	case 211:
-		goto st_case_211
-	case 212:
-		goto st_case_212
-	case 213:
-		goto st_case_213
-	case 214:
-		goto st_case_214
-	case 215:
-		goto st_case_215
-	case 216:
-		goto st_case_216
-	case 217:
-		goto st_case_217
-	case 218:
-		goto st_case_218
-	case 219:
-		goto st_case_219
-	case 220:
-		goto st_case_220
-	case 221:
-		goto st_case_221
-	case 222:
-		goto st_case_222
-	case 223:
-		goto st_case_223
-	case 224:
-		goto st_case_224
-	case 225:
-		goto st_case_225
-	case 226:
-		goto st_case_226
-	case 227:
-		goto st_case_227
-	case 228:
-		goto st_case_228
-	case 229:
-		goto st_case_229
-	case 230:
-		goto st_case_230
-	case 231:
-		goto st_case_231
-	case 232:
-		goto st_case_232
-	case 233:
-		goto st_case_233
-	case 234:
-		goto st_case_234
-	case 235:
-		goto st_case_235
-	case 236:
-		goto st_case_236
-	case 237:
-		goto st_case_237
-	case 238:
-		goto st_case_238
-	case 239:
-		goto st_case_239
-	case 240:
-		goto st_case_240
-	case 241:
-		goto st_case_241
-	case 242:
-		goto st_case_242
-	case 243:
-		goto st_case_243
-	case 244:
-		goto st_case_244
-	case 245:
-		goto st_case_245
-	case 246:
-		goto st_case_246
-	case 247:
-		goto st_case_247
-	case 248:
-		goto st_case_248
-	case 249:
-		goto st_case_249
-	case 250:
-		goto st_case_250
-	case 251:
-		goto st_case_251
-	case 252:
-		goto st_case_252
-	case 253:
-		goto st_case_253
-	case 254:
-		goto st_case_254
-	case 255:
-		goto st_case_255
-	case 256:
-		goto st_case_256
-	case 257:
-		goto st_case_257
-	case 258:
-		goto st_case_258
-	case 259:
-		goto st_case_259
-	case 260:
-		goto st_case_260
-	case 261:
-		goto st_case_261
-	case 262:
-		goto st_case_262
-	case 263:
-		goto st_case_263
-	case 264:
-		goto st_case_264
-	case 265:
-		goto st_case_265
-	case 266:
-		goto st_case_266
-	case 267:
-		goto st_case_267
-	case 268:
-		goto st_case_268
-	case 269:
-		goto st_case_269
-	case 270:
-		goto st_case_270
-	case 271:
-		goto st_case_271
-	case 272:
-		goto st_case_272
-	case 273:
-		goto st_case_273
-	case 274:
-		goto st_case_274
-	case 275:
-		goto st_case_275
-	case 276:
-		goto st_case_276
-	case 277:
-		goto st_case_277
-	case 278:
-		goto st_case_278
-	case 279:
-		goto st_case_279
-	case 280:
-		goto st_case_280
-	case 281:
-		goto st_case_281
-	case 282:
-		goto st_case_282
-	case 283:
-		goto st_case_283
-	case 284:
-		goto st_case_284
-	case 285:
-		goto st_case_285
-	case 286:
-		goto st_case_286
-	case 287:
-		goto st_case_287
-	case 288:
-		goto st_case_288
-	case 289:
-		goto st_case_289
-	case 290:
-		goto st_case_290
-	case 291:
-		goto st_case_291
-	case 292:
-		goto st_case_292
-	case 293:
-		goto st_case_293
-	case 294:
-		goto st_case_294
-	case 295:
-		goto st_case_295
-	case 296:
-		goto st_case_296
-	case 297:
-		goto st_case_297
-	case 298:
-		goto st_case_298
-	case 299:
-		goto st_case_299
-	case 300:
-		goto st_case_300
-	case 301:
-		goto st_case_301
-	case 302:
-		goto st_case_302
-	case 303:
-		goto st_case_303
-	case 304:
-		goto st_case_304
-	case 305:
-		goto st_case_305
-	case 306:
-		goto st_case_306
-	case 307:
-		goto st_case_307
-	case 308:
-		goto st_case_308
-	case 309:
-		goto st_case_309
-	case 310:
-		goto st_case_310
-	case 311:
-		goto st_case_311
-	case 312:
-		goto st_case_312
-	case 313:
-		goto st_case_313
-	case 314:
-		goto st_case_314
-	case 315:
-		goto st_case_315
-	case 316:
-		goto st_case_316
-	case 317:
-		goto st_case_317
-	case 318:
-		goto st_case_318
-	case 319:
-		goto st_case_319
-	case 320:
-		goto st_case_320
-	case 321:
-		goto st_case_321
-	case 322:
-		goto st_case_322
-	case 323:
-		goto st_case_323
-	case 324:
-		goto st_case_324
-	case 325:
-		goto st_case_325
-	case 326:
-		goto st_case_326
-	case 327:
-		goto st_case_327
-	case 328:
-		goto st_case_328
-	case 329:
-		goto st_case_329
-	case 330:
-		goto st_case_330
-	case 331:
-		goto st_case_331
-	case 332:
-		goto st_case_332
-	case 333:
-		goto st_case_333
-	case 334:
-		goto st_case_334
-	case 335:
-		goto st_case_335
-	case 336:
-		goto st_case_336
-	case 337:
-		goto st_case_337
-	case 338:
-		goto st_case_338
-	case 339:
-		goto st_case_339
-	case 340:
-		goto st_case_340
-	case 341:
-		goto st_case_341
-	case 342:
-		goto st_case_342
-	case 343:
-		goto st_case_343
-	case 344:
-		goto st_case_344
-	case 345:
-		goto st_case_345
-	case 346:
-		goto st_case_346
-	case 347:
-		goto st_case_347
-	case 348:
-		goto st_case_348
-	case 349:
-		goto st_case_349
-	case 350:
-		goto st_case_350
-	case 351:
-		goto st_case_351
-	case 352:
-		goto st_case_352
-	case 353:
-		goto st_case_353
-	case 354:
-		goto st_case_354
-	case 355:
-		goto st_case_355
-	case 356:
-		goto st_case_356
-	case 357:
-		goto st_case_357
-	case 358:
-		goto st_case_358
-	case 359:
-		goto st_case_359
-	case 360:
-		goto st_case_360
-	case 361:
-		goto st_case_361
-	case 362:
-		goto st_case_362
-	case 363:
-		goto st_case_363
-	case 364:
-		goto st_case_364
-	case 365:
-		goto st_case_365
-	case 366:
-		goto st_case_366
-	case 367:
-		goto st_case_367
-	case 368:
-		goto st_case_368
-	case 369:
-		goto st_case_369
-	case 370:
-		goto st_case_370
-	case 371:
-		goto st_case_371
-	case 372:
-		goto st_case_372
-	case 373:
-		goto st_case_373
-	case 374:
-		goto st_case_374
-	case 375:
-		goto st_case_375
-	case 376:
-		goto st_case_376
-	case 377:
-		goto st_case_377
-	case 378:
-		goto st_case_378
-	case 379:
-		goto st_case_379
-	case 380:
-		goto st_case_380
-	case 381:
-		goto st_case_381
-	case 382:
-		goto st_case_382
-	case 383:
-		goto st_case_383
-	case 384:
-		goto st_case_384
-	case 385:
-		goto st_case_385
-	case 386:
-		goto st_case_386
-	case 387:
-		goto st_case_387
-	case 388:
-		goto st_case_388
-	case 389:
-		goto st_case_389
-	case 390:
-		goto st_case_390
-	case 391:
-		goto st_case_391
-	case 392:
-		goto st_case_392
-	case 393:
-		goto st_case_393
-	case 394:
-		goto st_case_394
-	case 395:
-		goto st_case_395
-	case 396:
-		goto st_case_396
-	case 397:
-		goto st_case_397
-	case 398:
-		goto st_case_398
-	case 399:
-		goto st_case_399
-	case 400:
-		goto st_case_400
-	case 401:
-		goto st_case_401
-	case 402:
-		goto st_case_402
-	case 403:
-		goto st_case_403
-	case 404:
-		goto st_case_404
-	case 405:
-		goto st_case_405
-	case 406:
-		goto st_case_406
-	case 407:
-		goto st_case_407
-	case 408:
-		goto st_case_408
-	case 409:
-		goto st_case_409
-	case 410:
-		goto st_case_410
-	case 411:
-		goto st_case_411
-	case 412:
-		goto st_case_412
-	case 413:
-		goto st_case_413
-	case 414:
-		goto st_case_414
-	case 415:
-		goto st_case_415
-	case 416:
-		goto st_case_416
-	case 417:
-		goto st_case_417
-	case 418:
-		goto st_case_418
-	case 419:
-		goto st_case_419
-	case 420:
-		goto st_case_420
-	case 421:
-		goto st_case_421
-	case 422:
-		goto st_case_422
-	case 423:
-		goto st_case_423
-	case 424:
-		goto st_case_424
-	case 425:
-		goto st_case_425
-	case 426:
-		goto st_case_426
-	case 427:
-		goto st_case_427
-	case 428:
-		goto st_case_428
-	case 429:
-		goto st_case_429
-	case 430:
-		goto st_case_430
-	case 431:
-		goto st_case_431
-	case 432:
-		goto st_case_432
-	case 433:
-		goto st_case_433
-	case 434:
-		goto st_case_434
-	case 435:
-		goto st_case_435
-	case 436:
-		goto st_case_436
-	case 437:
-		goto st_case_437
-	case 438:
-		goto st_case_438
-	case 439:
-		goto st_case_439
-	case 440:
-		goto st_case_440
-	case 441:
-		goto st_case_441
-	case 442:
-		goto st_case_442
-	case 443:
-		goto st_case_443
-	case 444:
-		goto st_case_444
-	case 445:
-		goto st_case_445
-	case 446:
-		goto st_case_446
-	case 447:
-		goto st_case_447
-	case 448:
-		goto st_case_448
-	case 449:
-		goto st_case_449
-	case 450:
-		goto st_case_450
-	case 451:
-		goto st_case_451
-	case 452:
-		goto st_case_452
-	case 453:
-		goto st_case_453
-	case 454:
-		goto st_case_454
-	case 455:
-		goto st_case_455
-	case 456:
-		goto st_case_456
-	case 457:
-		goto st_case_457
-	case 458:
-		goto st_case_458
-	case 459:
-		goto st_case_459
-	case 460:
-		goto st_case_460
-	case 461:
-		goto st_case_461
-	case 462:
-		goto st_case_462
-	case 463:
-		goto st_case_463
-	case 464:
-		goto st_case_464
-	case 465:
-		goto st_case_465
-	case 466:
-		goto st_case_466
-	case 467:
-		goto st_case_467
-	case 468:
-		goto st_case_468
-	case 469:
-		goto st_case_469
-	case 470:
-		goto st_case_470
-	case 471:
-		goto st_case_471
-	case 472:
-		goto st_case_472
-	case 473:
-		goto st_case_473
-	case 474:
-		goto st_case_474
-	case 475:
-		goto st_case_475
-	case 476:
-		goto st_case_476
-	case 477:
-		goto st_case_477
-	case 478:
-		goto st_case_478
-	case 479:
-		goto st_case_479
-	case 480:
-		goto st_case_480
-	case 481:
-		goto st_case_481
-	case 482:
-		goto st_case_482
-	case 483:
-		goto st_case_483
-	case 484:
-		goto st_case_484
-	case 485:
-		goto st_case_485
-	case 486:
-		goto st_case_486
-	case 487:
-		goto st_case_487
-	case 488:
-		goto st_case_488
-	case 489:
-		goto st_case_489
-	case 490:
-		goto st_case_490
-	case 491:
-		goto st_case_491
-	case 492:
-		goto st_case_492
-	case 493:
-		goto st_case_493
-	case 494:
-		goto st_case_494
-	case 495:
-		goto st_case_495
-	case 496:
-		goto st_case_496
-	case 497:
-		goto st_case_497
-	case 498:
-		goto st_case_498
-	case 499:
-		goto st_case_499
-	case 500:
-		goto st_case_500
-	case 501:
-		goto st_case_501
-	case 502:
-		goto st_case_502
-	case 503:
-		goto st_case_503
-	case 504:
-		goto st_case_504
-	case 505:
-		goto st_case_505
-	case 506:
-		goto st_case_506
-	case 507:
-		goto st_case_507
-	case 508:
-		goto st_case_508
-	case 509:
-		goto st_case_509
-	case 510:
-		goto st_case_510
-	case 511:
-		goto st_case_511
-	case 512:
-		goto st_case_512
-	case 513:
-		goto st_case_513
-	case 514:
-		goto st_case_514
-	case 515:
-		goto st_case_515
-	case 516:
-		goto st_case_516
-	case 517:
-		goto st_case_517
-	case 518:
-		goto st_case_518
-	case 519:
-		goto st_case_519
-	case 520:
-		goto st_case_520
-	case 521:
-		goto st_case_521
-	case 522:
-		goto st_case_522
-	case 523:
-		goto st_case_523
-	case 524:
-		goto st_case_524
-	case 525:
-		goto st_case_525
-	case 526:
-		goto st_case_526
-	case 527:
-		goto st_case_527
-	case 528:
-		goto st_case_528
-	case 529:
-		goto st_case_529
-	case 530:
-		goto st_case_530
-	case 531:
-		goto st_case_531
-	case 532:
-		goto st_case_532
-	case 533:
-		goto st_case_533
-	case 534:
-		goto st_case_534
-	case 535:
-		goto st_case_535
-	case 536:
-		goto st_case_536
-	case 537:
-		goto st_case_537
-	case 538:
-		goto st_case_538
-	case 539:
-		goto st_case_539
-	case 540:
-		goto st_case_540
-	case 541:
-		goto st_case_541
-	case 542:
-		goto st_case_542
-	case 543:
-		goto st_case_543
-	case 544:
-		goto st_case_544
-	case 545:
-		goto st_case_545
-	case 546:
-		goto st_case_546
-	case 547:
-		goto st_case_547
-	case 548:
-		goto st_case_548
-	case 549:
-		goto st_case_549
-	case 550:
-		goto st_case_550
-	case 551:
-		goto st_case_551
-	case 552:
-		goto st_case_552
-	case 553:
-		goto st_case_553
-	case 554:
-		goto st_case_554
-	case 555:
-		goto st_case_555
-	case 556:
-		goto st_case_556
-	case 557:
-		goto st_case_557
-	case 558:
-		goto st_case_558
-	case 559:
-		goto st_case_559
-	case 560:
-		goto st_case_560
-	case 561:
-		goto st_case_561
-	case 562:
-		goto st_case_562
-	case 563:
-		goto st_case_563
-	case 564:
-		goto st_case_564
-	case 565:
-		goto st_case_565
-	case 566:
-		goto st_case_566
-	case 567:
-		goto st_case_567
-	case 568:
-		goto st_case_568
-	case 569:
-		goto st_case_569
-	case 570:
-		goto st_case_570
-	case 571:
-		goto st_case_571
-	case 572:
-		goto st_case_572
-	case 573:
-		goto st_case_573
-	case 574:
-		goto st_case_574
-	case 575:
-		goto st_case_575
-	case 576:
-		goto st_case_576
-	case 577:
-		goto st_case_577
-	case 578:
-		goto st_case_578
-	case 579:
-		goto st_case_579
-	case 580:
-		goto st_case_580
-	case 581:
-		goto st_case_581
-	case 582:
-		goto st_case_582
-	case 583:
-		goto st_case_583
-	case 584:
-		goto st_case_584
-	case 585:
-		goto st_case_585
-	case 586:
-		goto st_case_586
-	case 587:
-		goto st_case_587
-	case 588:
-		goto st_case_588
-	case 589:
-		goto st_case_589
-	case 590:
-		goto st_case_590
-	case 591:
-		goto st_case_591
-	case 592:
-		goto st_case_592
-	case 593:
-		goto st_case_593
-	case 594:
-		goto st_case_594
-	case 595:
-		goto st_case_595
-	case 596:
-		goto st_case_596
-	case 597:
-		goto st_case_597
-	case 598:
-		goto st_case_598
-	case 599:
-		goto st_case_599
-	case 600:
-		goto st_case_600
-	case 601:
-		goto st_case_601
-	case 602:
-		goto st_case_602
-	case 607:
-		goto st_case_607
-	}
-	goto st_out
+		if (m.p) == (m.pe) {
+			goto _test_eof
+		}
+		switch m.cs {
+		case 1:
+			goto st_case_1
+		case 0:
+			goto st_case_0
+		case 2:
+			goto st_case_2
+		case 3:
+			goto st_case_3
+		case 4:
+			goto st_case_4
+		case 5:
+			goto st_case_5
+		case 6:
+			goto st_case_6
+		case 7:
+			goto st_case_7
+		case 8:
+			goto st_case_8
+		case 9:
+			goto st_case_9
+		case 10:
+			goto st_case_10
+		case 11:
+			goto st_case_11
+		case 12:
+			goto st_case_12
+		case 13:
+			goto st_case_13
+		case 14:
+			goto st_case_14
+		case 15:
+			goto st_case_15
+		case 16:
+			goto st_case_16
+		case 603:
+			goto st_case_603
+		case 604:
+			goto st_case_604
+		case 605:
+			goto st_case_605
+		case 17:
+			goto st_case_17
+		case 18:
+			goto st_case_18
+		case 19:
+			goto st_case_19
+		case 20:
+			goto st_case_20
+		case 21:
+			goto st_case_21
+		case 22:
+			goto st_case_22
+		case 23:
+			goto st_case_23
+		case 24:
+			goto st_case_24
+		case 25:
+			goto st_case_25
+		case 26:
+			goto st_case_26
+		case 27:
+			goto st_case_27
+		case 28:
+			goto st_case_28
+		case 29:
+			goto st_case_29
+		case 30:
+			goto st_case_30
+		case 31:
+			goto st_case_31
+		case 32:
+			goto st_case_32
+		case 33:
+			goto st_case_33
+		case 34:
+			goto st_case_34
+		case 35:
+			goto st_case_35
+		case 36:
+			goto st_case_36
+		case 37:
+			goto st_case_37
+		case 38:
+			goto st_case_38
+		case 39:
+			goto st_case_39
+		case 40:
+			goto st_case_40
+		case 41:
+			goto st_case_41
+		case 42:
+			goto st_case_42
+		case 43:
+			goto st_case_43
+		case 44:
+			goto st_case_44
+		case 45:
+			goto st_case_45
+		case 46:
+			goto st_case_46
+		case 47:
+			goto st_case_47
+		case 48:
+			goto st_case_48
+		case 49:
+			goto st_case_49
+		case 50:
+			goto st_case_50
+		case 51:
+			goto st_case_51
+		case 52:
+			goto st_case_52
+		case 53:
+			goto st_case_53
+		case 54:
+			goto st_case_54
+		case 55:
+			goto st_case_55
+		case 56:
+			goto st_case_56
+		case 57:
+			goto st_case_57
+		case 58:
+			goto st_case_58
+		case 59:
+			goto st_case_59
+		case 60:
+			goto st_case_60
+		case 61:
+			goto st_case_61
+		case 62:
+			goto st_case_62
+		case 606:
+			goto st_case_606
+		case 63:
+			goto st_case_63
+		case 64:
+			goto st_case_64
+		case 65:
+			goto st_case_65
+		case 66:
+			goto st_case_66
+		case 67:
+			goto st_case_67
+		case 68:
+			goto st_case_68
+		case 69:
+			goto st_case_69
+		case 70:
+			goto st_case_70
+		case 71:
+			goto st_case_71
+		case 72:
+			goto st_case_72
+		case 73:
+			goto st_case_73
+		case 74:
+			goto st_case_74
+		case 75:
+			goto st_case_75
+		case 76:
+			goto st_case_76
+		case 77:
+			goto st_case_77
+		case 78:
+			goto st_case_78
+		case 79:
+			goto st_case_79
+		case 80:
+			goto st_case_80
+		case 81:
+			goto st_case_81
+		case 82:
+			goto st_case_82
+		case 83:
+			goto st_case_83
+		case 84:
+			goto st_case_84
+		case 85:
+			goto st_case_85
+		case 86:
+			goto st_case_86
+		case 87:
+			goto st_case_87
+		case 88:
+			goto st_case_88
+		case 89:
+			goto st_case_89
+		case 90:
+			goto st_case_90
+		case 91:
+			goto st_case_91
+		case 92:
+			goto st_case_92
+		case 93:
+			goto st_case_93
+		case 94:
+			goto st_case_94
+		case 95:
+			goto st_case_95
+		case 96:
+			goto st_case_96
+		case 97:
+			goto st_case_97
+		case 98:
+			goto st_case_98
+		case 99:
+			goto st_case_99
+		case 100:
+			goto st_case_100
+		case 101:
+			goto st_case_101
+		case 102:
+			goto st_case_102
+		case 103:
+			goto st_case_103
+		case 104:
+			goto st_case_104
+		case 105:
+			goto st_case_105
+		case 106:
+			goto st_case_106
+		case 107:
+			goto st_case_107
+		case 108:
+			goto st_case_108
+		case 109:
+			goto st_case_109
+		case 110:
+			goto st_case_110
+		case 111:
+			goto st_case_111
+		case 112:
+			goto st_case_112
+		case 113:
+			goto st_case_113
+		case 114:
+			goto st_case_114
+		case 115:
+			goto st_case_115
+		case 116:
+			goto st_case_116
+		case 117:
+			goto st_case_117
+		case 118:
+			goto st_case_118
+		case 119:
+			goto st_case_119
+		case 120:
+			goto st_case_120
+		case 121:
+			goto st_case_121
+		case 122:
+			goto st_case_122
+		case 123:
+			goto st_case_123
+		case 124:
+			goto st_case_124
+		case 125:
+			goto st_case_125
+		case 126:
+			goto st_case_126
+		case 127:
+			goto st_case_127
+		case 128:
+			goto st_case_128
+		case 129:
+			goto st_case_129
+		case 130:
+			goto st_case_130
+		case 131:
+			goto st_case_131
+		case 132:
+			goto st_case_132
+		case 133:
+			goto st_case_133
+		case 134:
+			goto st_case_134
+		case 135:
+			goto st_case_135
+		case 136:
+			goto st_case_136
+		case 137:
+			goto st_case_137
+		case 138:
+			goto st_case_138
+		case 139:
+			goto st_case_139
+		case 140:
+			goto st_case_140
+		case 141:
+			goto st_case_141
+		case 142:
+			goto st_case_142
+		case 143:
+			goto st_case_143
+		case 144:
+			goto st_case_144
+		case 145:
+			goto st_case_145
+		case 146:
+			goto st_case_146
+		case 147:
+			goto st_case_147
+		case 148:
+			goto st_case_148
+		case 149:
+			goto st_case_149
+		case 150:
+			goto st_case_150
+		case 151:
+			goto st_case_151
+		case 152:
+			goto st_case_152
+		case 153:
+			goto st_case_153
+		case 154:
+			goto st_case_154
+		case 155:
+			goto st_case_155
+		case 156:
+			goto st_case_156
+		case 157:
+			goto st_case_157
+		case 158:
+			goto st_case_158
+		case 159:
+			goto st_case_159
+		case 160:
+			goto st_case_160
+		case 161:
+			goto st_case_161
+		case 162:
+			goto st_case_162
+		case 163:
+			goto st_case_163
+		case 164:
+			goto st_case_164
+		case 165:
+			goto st_case_165
+		case 166:
+			goto st_case_166
+		case 167:
+			goto st_case_167
+		case 168:
+			goto st_case_168
+		case 169:
+			goto st_case_169
+		case 170:
+			goto st_case_170
+		case 171:
+			goto st_case_171
+		case 172:
+			goto st_case_172
+		case 173:
+			goto st_case_173
+		case 174:
+			goto st_case_174
+		case 175:
+			goto st_case_175
+		case 176:
+			goto st_case_176
+		case 177:
+			goto st_case_177
+		case 178:
+			goto st_case_178
+		case 179:
+			goto st_case_179
+		case 180:
+			goto st_case_180
+		case 181:
+			goto st_case_181
+		case 182:
+			goto st_case_182
+		case 183:
+			goto st_case_183
+		case 184:
+			goto st_case_184
+		case 185:
+			goto st_case_185
+		case 186:
+			goto st_case_186
+		case 187:
+			goto st_case_187
+		case 188:
+			goto st_case_188
+		case 189:
+			goto st_case_189
+		case 190:
+			goto st_case_190
+		case 191:
+			goto st_case_191
+		case 192:
+			goto st_case_192
+		case 193:
+			goto st_case_193
+		case 194:
+			goto st_case_194
+		case 195:
+			goto st_case_195
+		case 196:
+			goto st_case_196
+		case 197:
+			goto st_case_197
+		case 198:
+			goto st_case_198
+		case 199:
+			goto st_case_199
+		case 200:
+			goto st_case_200
+		case 201:
+			goto st_case_201
+		case 202:
+			goto st_case_202
+		case 203:
+			goto st_case_203
+		case 204:
+			goto st_case_204
+		case 205:
+			goto st_case_205
+		case 206:
+			goto st_case_206
+		case 207:
+			goto st_case_207
+		case 208:
+			goto st_case_208
+		case 209:
+			goto st_case_209
+		case 210:
+			goto st_case_210
+		case 211:
+			goto st_case_211
+		case 212:
+			goto st_case_212
+		case 213:
+			goto st_case_213
+		case 214:
+			goto st_case_214
+		case 215:
+			goto st_case_215
+		case 216:
+			goto st_case_216
+		case 217:
+			goto st_case_217
+		case 218:
+			goto st_case_218
+		case 219:
+			goto st_case_219
+		case 220:
+			goto st_case_220
+		case 221:
+			goto st_case_221
+		case 222:
+			goto st_case_222
+		case 223:
+			goto st_case_223
+		case 224:
+			goto st_case_224
+		case 225:
+			goto st_case_225
+		case 226:
+			goto st_case_226
+		case 227:
+			goto st_case_227
+		case 228:
+			goto st_case_228
+		case 229:
+			goto st_case_229
+		case 230:
+			goto st_case_230
+		case 231:
+			goto st_case_231
+		case 232:
+			goto st_case_232
+		case 233:
+			goto st_case_233
+		case 234:
+			goto st_case_234
+		case 235:
+			goto st_case_235
+		case 236:
+			goto st_case_236
+		case 237:
+			goto st_case_237
+		case 238:
+			goto st_case_238
+		case 239:
+			goto st_case_239
+		case 240:
+			goto st_case_240
+		case 241:
+			goto st_case_241
+		case 242:
+			goto st_case_242
+		case 243:
+			goto st_case_243
+		case 244:
+			goto st_case_244
+		case 245:
+			goto st_case_245
+		case 246:
+			goto st_case_246
+		case 247:
+			goto st_case_247
+		case 248:
+			goto st_case_248
+		case 249:
+			goto st_case_249
+		case 250:
+			goto st_case_250
+		case 251:
+			goto st_case_251
+		case 252:
+			goto st_case_252
+		case 253:
+			goto st_case_253
+		case 254:
+			goto st_case_254
+		case 255:
+			goto st_case_255
+		case 256:
+			goto st_case_256
+		case 257:
+			goto st_case_257
+		case 258:
+			goto st_case_258
+		case 259:
+			goto st_case_259
+		case 260:
+			goto st_case_260
+		case 261:
+			goto st_case_261
+		case 262:
+			goto st_case_262
+		case 263:
+			goto st_case_263
+		case 264:
+			goto st_case_264
+		case 265:
+			goto st_case_265
+		case 266:
+			goto st_case_266
+		case 267:
+			goto st_case_267
+		case 268:
+			goto st_case_268
+		case 269:
+			goto st_case_269
+		case 270:
+			goto st_case_270
+		case 271:
+			goto st_case_271
+		case 272:
+			goto st_case_272
+		case 273:
+			goto st_case_273
+		case 274:
+			goto st_case_274
+		case 275:
+			goto st_case_275
+		case 276:
+			goto st_case_276
+		case 277:
+			goto st_case_277
+		case 278:
+			goto st_case_278
+		case 279:
+			goto st_case_279
+		case 280:
+			goto st_case_280
+		case 281:
+			goto st_case_281
+		case 282:
+			goto st_case_282
+		case 283:
+			goto st_case_283
+		case 284:
+			goto st_case_284
+		case 285:
+			goto st_case_285
+		case 286:
+			goto st_case_286
+		case 287:
+			goto st_case_287
+		case 288:
+			goto st_case_288
+		case 289:
+			goto st_case_289
+		case 290:
+			goto st_case_290
+		case 291:
+			goto st_case_291
+		case 292:
+			goto st_case_292
+		case 293:
+			goto st_case_293
+		case 294:
+			goto st_case_294
+		case 295:
+			goto st_case_295
+		case 296:
+			goto st_case_296
+		case 297:
+			goto st_case_297
+		case 298:
+			goto st_case_298
+		case 299:
+			goto st_case_299
+		case 300:
+			goto st_case_300
+		case 301:
+			goto st_case_301
+		case 302:
+			goto st_case_302
+		case 303:
+			goto st_case_303
+		case 304:
+			goto st_case_304
+		case 305:
+			goto st_case_305
+		case 306:
+			goto st_case_306
+		case 307:
+			goto st_case_307
+		case 308:
+			goto st_case_308
+		case 309:
+			goto st_case_309
+		case 310:
+			goto st_case_310
+		case 311:
+			goto st_case_311
+		case 312:
+			goto st_case_312
+		case 313:
+			goto st_case_313
+		case 314:
+			goto st_case_314
+		case 315:
+			goto st_case_315
+		case 316:
+			goto st_case_316
+		case 317:
+			goto st_case_317
+		case 318:
+			goto st_case_318
+		case 319:
+			goto st_case_319
+		case 320:
+			goto st_case_320
+		case 321:
+			goto st_case_321
+		case 322:
+			goto st_case_322
+		case 323:
+			goto st_case_323
+		case 324:
+			goto st_case_324
+		case 325:
+			goto st_case_325
+		case 326:
+			goto st_case_326
+		case 327:
+			goto st_case_327
+		case 328:
+			goto st_case_328
+		case 329:
+			goto st_case_329
+		case 330:
+			goto st_case_330
+		case 331:
+			goto st_case_331
+		case 332:
+			goto st_case_332
+		case 333:
+			goto st_case_333
+		case 334:
+			goto st_case_334
+		case 335:
+			goto st_case_335
+		case 336:
+			goto st_case_336
+		case 337:
+			goto st_case_337
+		case 338:
+			goto st_case_338
+		case 339:
+			goto st_case_339
+		case 340:
+			goto st_case_340
+		case 341:
+			goto st_case_341
+		case 342:
+			goto st_case_342
+		case 343:
+			goto st_case_343
+		case 344:
+			goto st_case_344
+		case 345:
+			goto st_case_345
+		case 346:
+			goto st_case_346
+		case 347:
+			goto st_case_347
+		case 348:
+			goto st_case_348
+		case 349:
+			goto st_case_349
+		case 350:
+			goto st_case_350
+		case 351:
+			goto st_case_351
+		case 352:
+			goto st_case_352
+		case 353:
+			goto st_case_353
+		case 354:
+			goto st_case_354
+		case 355:
+			goto st_case_355
+		case 356:
+			goto st_case_356
+		case 357:
+			goto st_case_357
+		case 358:
+			goto st_case_358
+		case 359:
+			goto st_case_359
+		case 360:
+			goto st_case_360
+		case 361:
+			goto st_case_361
+		case 362:
+			goto st_case_362
+		case 363:
+			goto st_case_363
+		case 364:
+			goto st_case_364
+		case 365:
+			goto st_case_365
+		case 366:
+			goto st_case_366
+		case 367:
+			goto st_case_367
+		case 368:
+			goto st_case_368
+		case 369:
+			goto st_case_369
+		case 370:
+			goto st_case_370
+		case 371:
+			goto st_case_371
+		case 372:
+			goto st_case_372
+		case 373:
+			goto st_case_373
+		case 374:
+			goto st_case_374
+		case 375:
+			goto st_case_375
+		case 376:
+			goto st_case_376
+		case 377:
+			goto st_case_377
+		case 378:
+			goto st_case_378
+		case 379:
+			goto st_case_379
+		case 380:
+			goto st_case_380
+		case 381:
+			goto st_case_381
+		case 382:
+			goto st_case_382
+		case 383:
+			goto st_case_383
+		case 384:
+			goto st_case_384
+		case 385:
+			goto st_case_385
+		case 386:
+			goto st_case_386
+		case 387:
+			goto st_case_387
+		case 388:
+			goto st_case_388
+		case 389:
+			goto st_case_389
+		case 390:
+			goto st_case_390
+		case 391:
+			goto st_case_391
+		case 392:
+			goto st_case_392
+		case 393:
+			goto st_case_393
+		case 394:
+			goto st_case_394
+		case 395:
+			goto st_case_395
+		case 396:
+			goto st_case_396
+		case 397:
+			goto st_case_397
+		case 398:
+			goto st_case_398
+		case 399:
+			goto st_case_399
+		case 400:
+			goto st_case_400
+		case 401:
+			goto st_case_401
+		case 402:
+			goto st_case_402
+		case 403:
+			goto st_case_403
+		case 404:
+			goto st_case_404
+		case 405:
+			goto st_case_405
+		case 406:
+			goto st_case_406
+		case 407:
+			goto st_case_407
+		case 408:
+			goto st_case_408
+		case 409:
+			goto st_case_409
+		case 410:
+			goto st_case_410
+		case 411:
+			goto st_case_411
+		case 412:
+			goto st_case_412
+		case 413:
+			goto st_case_413
+		case 414:
+			goto st_case_414
+		case 415:
+			goto st_case_415
+		case 416:
+			goto st_case_416
+		case 417:
+			goto st_case_417
+		case 418:
+			goto st_case_418
+		case 419:
+			goto st_case_419
+		case 420:
+			goto st_case_420
+		case 421:
+			goto st_case_421
+		case 422:
+			goto st_case_422
+		case 423:
+			goto st_case_423
+		case 424:
+			goto st_case_424
+		case 425:
+			goto st_case_425
+		case 426:
+			goto st_case_426
+		case 427:
+			goto st_case_427
+		case 428:
+			goto st_case_428
+		case 429:
+			goto st_case_429
+		case 430:
+			goto st_case_430
+		case 431:
+			goto st_case_431
+		case 432:
+			goto st_case_432
+		case 433:
+			goto st_case_433
+		case 434:
+			goto st_case_434
+		case 435:
+			goto st_case_435
+		case 436:
+			goto st_case_436
+		case 437:
+			goto st_case_437
+		case 438:
+			goto st_case_438
+		case 439:
+			goto st_case_439
+		case 440:
+			goto st_case_440
+		case 441:
+			goto st_case_441
+		case 442:
+			goto st_case_442
+		case 443:
+			goto st_case_443
+		case 444:
+			goto st_case_444
+		case 445:
+			goto st_case_445
+		case 446:
+			goto st_case_446
+		case 447:
+			goto st_case_447
+		case 448:
+			goto st_case_448
+		case 449:
+			goto st_case_449
+		case 450:
+			goto st_case_450
+		case 451:
+			goto st_case_451
+		case 452:
+			goto st_case_452
+		case 453:
+			goto st_case_453
+		case 454:
+			goto st_case_454
+		case 455:
+			goto st_case_455
+		case 456:
+			goto st_case_456
+		case 457:
+			goto st_case_457
+		case 458:
+			goto st_case_458
+		case 459:
+			goto st_case_459
+		case 460:
+			goto st_case_460
+		case 461:
+			goto st_case_461
+		case 462:
+			goto st_case_462
+		case 463:
+			goto st_case_463
+		case 464:
+			goto st_case_464
+		case 465:
+			goto st_case_465
+		case 466:
+			goto st_case_466
+		case 467:
+			goto st_case_467
+		case 468:
+			goto st_case_468
+		case 469:
+			goto st_case_469
+		case 470:
+			goto st_case_470
+		case 471:
+			goto st_case_471
+		case 472:
+			goto st_case_472
+		case 473:
+			goto st_case_473
+		case 474:
+			goto st_case_474
+		case 475:
+			goto st_case_475
+		case 476:
+			goto st_case_476
+		case 477:
+			goto st_case_477
+		case 478:
+			goto st_case_478
+		case 479:
+			goto st_case_479
+		case 480:
+			goto st_case_480
+		case 481:
+			goto st_case_481
+		case 482:
+			goto st_case_482
+		case 483:
+			goto st_case_483
+		case 484:
+			goto st_case_484
+		case 485:
+			goto st_case_485
+		case 486:
+			goto st_case_486
+		case 487:
+			goto st_case_487
+		case 488:
+			goto st_case_488
+		case 489:
+			goto st_case_489
+		case 490:
+			goto st_case_490
+		case 491:
+			goto st_case_491
+		case 492:
+			goto st_case_492
+		case 493:
+			goto st_case_493
+		case 494:
+			goto st_case_494
+		case 495:
+			goto st_case_495
+		case 496:
+			goto st_case_496
+		case 497:
+			goto st_case_497
+		case 498:
+			goto st_case_498
+		case 499:
+			goto st_case_499
+		case 500:
+			goto st_case_500
+		case 501:
+			goto st_case_501
+		case 502:
+			goto st_case_502
+		case 503:
+			goto st_case_503
+		case 504:
+			goto st_case_504
+		case 505:
+			goto st_case_505
+		case 506:
+			goto st_case_506
+		case 507:
+			goto st_case_507
+		case 508:
+			goto st_case_508
+		case 509:
+			goto st_case_509
+		case 510:
+			goto st_case_510
+		case 511:
+			goto st_case_511
+		case 512:
+			goto st_case_512
+		case 513:
+			goto st_case_513
+		case 514:
+			goto st_case_514
+		case 515:
+			goto st_case_515
+		case 516:
+			goto st_case_516
+		case 517:
+			goto st_case_517
+		case 518:
+			goto st_case_518
+		case 519:
+			goto st_case_519
+		case 520:
+			goto st_case_520
+		case 521:
+			goto st_case_521
+		case 522:
+			goto st_case_522
+		case 523:
+			goto st_case_523
+		case 524:
+			goto st_case_524
+		case 525:
+			goto st_case_525
+		case 526:
+			goto st_case_526
+		case 527:
+			goto st_case_527
+		case 528:
+			goto st_case_528
+		case 529:
+			goto st_case_529
+		case 530:
+			goto st_case_530
+		case 531:
+			goto st_case_531
+		case 532:
+			goto st_case_532
+		case 533:
+			goto st_case_533
+		case 534:
+			goto st_case_534
+		case 535:
+			goto st_case_535
+		case 536:
+			goto st_case_536
+		case 537:
+			goto st_case_537
+		case 538:
+			goto st_case_538
+		case 539:
+			goto st_case_539
+		case 540:
+			goto st_case_540
+		case 541:
+			goto st_case_541
+		case 542:
+			goto st_case_542
+		case 543:
+			goto st_case_543
+		case 544:
+			goto st_case_544
+		case 545:
+			goto st_case_545
+		case 546:
+			goto st_case_546
+		case 547:
+			goto st_case_547
+		case 548:
+			goto st_case_548
+		case 549:
+			goto st_case_549
+		case 550:
+			goto st_case_550
+		case 551:
+			goto st_case_551
+		case 552:
+			goto st_case_552
+		case 553:
+			goto st_case_553
+		case 554:
+			goto st_case_554
+		case 555:
+			goto st_case_555
+		case 556:
+			goto st_case_556
+		case 557:
+			goto st_case_557
+		case 558:
+			goto st_case_558
+		case 559:
+			goto st_case_559
+		case 560:
+			goto st_case_560
+		case 561:
+			goto st_case_561
+		case 562:
+			goto st_case_562
+		case 563:
+			goto st_case_563
+		case 564:
+			goto st_case_564
+		case 565:
+			goto st_case_565
+		case 566:
+			goto st_case_566
+		case 567:
+			goto st_case_567
+		case 568:
+			goto st_case_568
+		case 569:
+			goto st_case_569
+		case 570:
+			goto st_case_570
+		case 571:
+			goto st_case_571
+		case 572:
+			goto st_case_572
+		case 573:
+			goto st_case_573
+		case 574:
+			goto st_case_574
+		case 575:
+			goto st_case_575
+		case 576:
+			goto st_case_576
+		case 577:
+			goto st_case_577
+		case 578:
+			goto st_case_578
+		case 579:
+			goto st_case_579
+		case 580:
+			goto st_case_580
+		case 581:
+			goto st_case_581
+		case 582:
+			goto st_case_582
+		case 583:
+			goto st_case_583
+		case 584:
+			goto st_case_584
+		case 585:
+			goto st_case_585
+		case 586:
+			goto st_case_586
+		case 587:
+			goto st_case_587
+		case 588:
+			goto st_case_588
+		case 589:
+			goto st_case_589
+		case 590:
+			goto st_case_590
+		case 591:
+			goto st_case_591
+		case 592:
+			goto st_case_592
+		case 593:
+			goto st_case_593
+		case 594:
+			goto st_case_594
+		case 595:
+			goto st_case_595
+		case 596:
+			goto st_case_596
+		case 597:
+			goto st_case_597
+		case 598:
+			goto st_case_598
+		case 599:
+			goto st_case_599
+		case 600:
+			goto st_case_600
+		case 601:
+			goto st_case_601
+		case 602:
+			goto st_case_602
+		case 607:
+			goto st_case_607
+		}
+		goto st_out
 	st_case_1:
-		if ( m.data)[( m.p)] == 60 {
+		if (m.data)[(m.p)] == 60 {
 			goto st2
 		}
 		goto tr0
-tr0:
+	tr0:
 //line rfc5424/machine.go.rl:148
+		m.err = fmt.Errorf(errPri, m.p)
+		(m.p)--
 
-	m.err = fmt.Errorf(errPri, m.p)
-	( m.p)--
+		{
+			goto st607
+		}
 
-    {goto st607 }
-
-	goto st0
-tr2:
+		goto st0
+	tr2:
 //line rfc5424/machine.go.rl:142
+		m.err = fmt.Errorf(errPrival, m.p)
+		(m.p)--
 
-	m.err = fmt.Errorf(errPrival, m.p)
-	( m.p)--
-
-    {goto st607 }
+		{
+			goto st607
+		}
 
 //line rfc5424/machine.go.rl:148
+		m.err = fmt.Errorf(errPri, m.p)
+		(m.p)--
 
-	m.err = fmt.Errorf(errPri, m.p)
-	( m.p)--
+		{
+			goto st607
+		}
 
-    {goto st607 }
-
-	goto st0
-tr7:
+		goto st0
+	tr7:
 //line rfc5424/machine.go.rl:154
+		m.err = fmt.Errorf(errVersion, m.p)
+		(m.p)--
 
-	m.err = fmt.Errorf(errVersion, m.p)
-	( m.p)--
+		{
+			goto st607
+		}
 
-    {goto st607 }
-
-	goto st0
-tr15:
+		goto st0
+	tr15:
 //line rfc5424/machine.go.rl:166
+		m.err = fmt.Errorf(errHostname, m.p)
+		(m.p)--
 
-	m.err = fmt.Errorf(errHostname, m.p)
-	( m.p)--
+		{
+			goto st607
+		}
 
-    {goto st607 }
-
-	goto st0
-tr19:
+		goto st0
+	tr19:
 //line rfc5424/machine.go.rl:172
+		m.err = fmt.Errorf(errAppname, m.p)
+		(m.p)--
 
-	m.err = fmt.Errorf(errAppname, m.p)
-	( m.p)--
+		{
+			goto st607
+		}
 
-    {goto st607 }
-
-	goto st0
-tr23:
+		goto st0
+	tr23:
 //line rfc5424/machine.go.rl:178
+		m.err = fmt.Errorf(errProcid, m.p)
+		(m.p)--
 
-	m.err = fmt.Errorf(errProcid, m.p)
-	( m.p)--
+		{
+			goto st607
+		}
 
-    {goto st607 }
-
-	goto st0
-tr27:
+		goto st0
+	tr27:
 //line rfc5424/machine.go.rl:184
+		m.err = fmt.Errorf(errMsgid, m.p)
+		(m.p)--
 
-	m.err = fmt.Errorf(errMsgid, m.p)
-	( m.p)--
+		{
+			goto st607
+		}
 
-    {goto st607 }
-
-	goto st0
-tr31:
+		goto st0
+	tr31:
 //line rfc5424/machine.go.rl:190
+		m.err = fmt.Errorf(errStructuredData, m.p)
+		(m.p)--
 
-	m.err = fmt.Errorf(errStructuredData, m.p)
-	( m.p)--
+		{
+			goto st607
+		}
 
-    {goto st607 }
-
-	goto st0
-tr34:
+		goto st0
+	tr34:
 //line rfc5424/machine.go.rl:215
 
-	// If error encountered within the message rule ...
-	if m.msg_at > 0 {
-		// Save the text until valid (m.p is where the parser has stopped)
-		if trunc := string(m.data[m.msg_at:m.p]); trunc != "" {
-			m.output.Message = &trunc
+		// If error encountered within the message rule ...
+		if m.msg_at > 0 {
+			// Save the text until valid (m.p is where the parser has stopped)
+			if trunc := string(m.data[m.msg_at:m.p]); trunc != "" {
+				output.Message = trunc
+			}
 		}
-	}
 
-	m.err = fmt.Errorf(errMsg, m.p)
-	( m.p)--
+		m.err = fmt.Errorf(errMsg, m.p)
+		(m.p)--
 
-    {goto st607 }
+		{
+			goto st607
+		}
 
 //line rfc5424/machine.go.rl:235
+		m.err = fmt.Errorf(errParse, m.p)
+		(m.p)--
 
-	m.err = fmt.Errorf(errParse, m.p)
-	( m.p)--
+		{
+			goto st607
+		}
 
-    {goto st607 }
-
-	goto st0
-tr38:
+		goto st0
+	tr38:
 //line rfc5424/machine.go.rl:196
+		delete(output.StructuredData, m.currentelem)
+		if len(output.StructuredData) == 0 {
+			output.StructuredData = nil
+		}
+		m.err = fmt.Errorf(errSdID, m.p)
+		(m.p)--
 
-	delete(*m.output.StructuredData, m.currentelem)
-	if len(*m.output.StructuredData) == 0 {
-		m.output.StructuredData = nil
-	}
-	m.err = fmt.Errorf(errSdID, m.p)
-	( m.p)--
-
-    {goto st607 }
+		{
+			goto st607
+		}
 
 //line rfc5424/machine.go.rl:190
+		m.err = fmt.Errorf(errStructuredData, m.p)
+		(m.p)--
 
-	m.err = fmt.Errorf(errStructuredData, m.p)
-	( m.p)--
+		{
+			goto st607
+		}
 
-    {goto st607 }
-
-	goto st0
-tr40:
+		goto st0
+	tr40:
 //line rfc5424/machine.go.rl:87
+		if elements, ok := interface{}(output.StructuredData).(map[string]map[string]string); ok {
+			id := string(m.text())
+			if _, ok := (elements)[id]; ok {
+				// As per RFC5424 section 6.3.2 SD-ID MUST NOT exist more than once in a message
+				m.err = fmt.Errorf(errSdIDDuplicated, m.p)
+				(m.p)--
 
-	if elements, ok := interface{}(m.output.StructuredData).(*map[string]map[string]string); ok {
-		id := string(m.text())
-		if _, ok := (*elements)[id]; ok {
-			// As per RFC5424 section 6.3.2 SD-ID MUST NOT exist more than once in a message
-			m.err = fmt.Errorf(errSdIDDuplicated, m.p)
-			( m.p)--
-
-			{goto st607 }
-		} else {
-			(*elements)[id] = map[string]string{}
-			m.currentelem = id
+				{
+					goto st607
+				}
+			} else {
+				(elements)[id] = map[string]string{}
+				m.currentelem = id
+			}
 		}
-	}
 
 //line rfc5424/machine.go.rl:196
+		delete(output.StructuredData, m.currentelem)
+		if len(output.StructuredData) == 0 {
+			output.StructuredData = nil
+		}
+		m.err = fmt.Errorf(errSdID, m.p)
+		(m.p)--
 
-	delete(*m.output.StructuredData, m.currentelem)
-	if len(*m.output.StructuredData) == 0 {
-		m.output.StructuredData = nil
-	}
-	m.err = fmt.Errorf(errSdID, m.p)
-	( m.p)--
-
-    {goto st607 }
+		{
+			goto st607
+		}
 
 //line rfc5424/machine.go.rl:190
+		m.err = fmt.Errorf(errStructuredData, m.p)
+		(m.p)--
 
-	m.err = fmt.Errorf(errStructuredData, m.p)
-	( m.p)--
+		{
+			goto st607
+		}
 
-    {goto st607 }
-
-	goto st0
-tr44:
+		goto st0
+	tr44:
 //line rfc5424/machine.go.rl:206
+		if elements, ok := interface{}(output.StructuredData).(map[string]map[string]string); ok {
+			delete((elements)[m.currentelem], m.currentparam)
+		}
+		m.err = fmt.Errorf(errSdParam, m.p)
+		(m.p)--
 
-	if elements, ok := interface{}(m.output.StructuredData).(*map[string]map[string]string); ok {
-		delete((*elements)[m.currentelem], m.currentparam)
-	}
-	m.err = fmt.Errorf(errSdParam, m.p)
-	( m.p)--
-
-    {goto st607 }
+		{
+			goto st607
+		}
 
 //line rfc5424/machine.go.rl:190
+		m.err = fmt.Errorf(errStructuredData, m.p)
+		(m.p)--
 
-	m.err = fmt.Errorf(errStructuredData, m.p)
-	( m.p)--
+		{
+			goto st607
+		}
 
-    {goto st607 }
-
-	goto st0
-tr82:
+		goto st0
+	tr82:
 //line rfc5424/machine.go.rl:229
+		m.err = fmt.Errorf(errEscape, m.p)
+		(m.p)--
 
-	m.err = fmt.Errorf(errEscape, m.p)
-	( m.p)--
-
-    {goto st607 }
+		{
+			goto st607
+		}
 
 //line rfc5424/machine.go.rl:206
+		if elements, ok := interface{}(output.StructuredData).(map[string]map[string]string); ok {
+			delete((elements)[m.currentelem], m.currentparam)
+		}
+		m.err = fmt.Errorf(errSdParam, m.p)
+		(m.p)--
 
-	if elements, ok := interface{}(m.output.StructuredData).(*map[string]map[string]string); ok {
-		delete((*elements)[m.currentelem], m.currentparam)
-	}
-	m.err = fmt.Errorf(errSdParam, m.p)
-	( m.p)--
-
-    {goto st607 }
+		{
+			goto st607
+		}
 
 //line rfc5424/machine.go.rl:190
+		m.err = fmt.Errorf(errStructuredData, m.p)
+		(m.p)--
 
-	m.err = fmt.Errorf(errStructuredData, m.p)
-	( m.p)--
+		{
+			goto st607
+		}
 
-    {goto st607 }
-
-	goto st0
-tr587:
+		goto st0
+	tr587:
 //line rfc5424/machine.go.rl:160
+		m.err = fmt.Errorf(errTimestamp, m.p)
+		(m.p)--
 
-	m.err = fmt.Errorf(errTimestamp, m.p)
-	( m.p)--
+		{
+			goto st607
+		}
 
-    {goto st607 }
-
-	goto st0
-tr618:
+		goto st0
+	tr618:
 //line rfc5424/machine.go.rl:48
+		if t, e := time.Parse(time.RFC3339Nano, string(m.text())); e != nil {
+			m.err = fmt.Errorf("%s [col %d]", e, m.p)
+			(m.p)--
 
-	if t, e := time.Parse(time.RFC3339Nano, string(m.text())); e != nil {
-        m.err = fmt.Errorf("%s [col %d]", e, m.p)
-		( m.p)--
+			{
+				goto st607
+			}
+		} else {
+			output.Timestamp = t
+		}
 
-    	{goto st607 }
-    } else {
-        m.output.Timestamp = &t
-    }
-
-	goto st0
-tr630:
+		goto st0
+	tr630:
 //line rfc5424/machine.go.rl:235
+		m.err = fmt.Errorf(errParse, m.p)
+		(m.p)--
 
-	m.err = fmt.Errorf(errParse, m.p)
-	( m.p)--
+		{
+			goto st607
+		}
 
-    {goto st607 }
-
-	goto st0
-tr645:
+		goto st0
+	tr645:
 //line rfc5424/machine.go.rl:190
+		m.err = fmt.Errorf(errStructuredData, m.p)
+		(m.p)--
 
-	m.err = fmt.Errorf(errStructuredData, m.p)
-	( m.p)--
-
-    {goto st607 }
+		{
+			goto st607
+		}
 
 //line rfc5424/machine.go.rl:235
+		m.err = fmt.Errorf(errParse, m.p)
+		(m.p)--
 
-	m.err = fmt.Errorf(errParse, m.p)
-	( m.p)--
+		{
+			goto st607
+		}
 
-    {goto st607 }
-
-	goto st0
+		goto st0
 //line rfc5424/machine.go:1593
-st_case_0:
+	st_case_0:
 	st0:
-		 m.cs = 0
+		m.cs = 0
 		goto _out
 	st2:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof2
 		}
 	st_case_2:
-		switch ( m.data)[( m.p)] {
+		switch (m.data)[(m.p)] {
 		case 48:
 			goto tr3
 		case 49:
 			goto tr4
 		}
-		if 50 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+		if 50 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 57 {
 			goto tr5
 		}
 		goto tr2
-tr3:
+	tr3:
 //line rfc5424/machine.go.rl:32
+		m.pb = m.p
 
-	m.pb = m.p
-
-	goto st3
+		goto st3
 	st3:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof3
 		}
 	st_case_3:
 //line rfc5424/machine.go.rl:40
-
-	m.output.SetPriority(uint8(unsafeUTF8DecimalCodePointsToInt(m.text())))
+		output.SetPriority(uint8(unsafeUTF8DecimalCodePointsToInt(m.text())))
 
 //line rfc5424/machine.go:1628
-		if ( m.data)[( m.p)] == 62 {
+		if (m.data)[(m.p)] == 62 {
 			goto st4
 		}
 		goto tr2
 	st4:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof4
 		}
 	st_case_4:
-		if 49 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+		if 49 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 57 {
 			goto tr8
 		}
 		goto tr7
-tr8:
+	tr8:
 //line rfc5424/machine.go.rl:32
+		m.pb = m.p
 
-	m.pb = m.p
-
-	goto st5
+		goto st5
 	st5:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof5
 		}
 	st_case_5:
 //line rfc5424/machine.go:1653
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr9
 		}
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+		if 48 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 57 {
 			goto st598
 		}
 		goto tr7
-tr9:
+	tr9:
 //line rfc5424/machine.go.rl:44
+		output.Version = uint16(unsafeUTF8DecimalCodePointsToInt(m.text()))
 
-	m.output.Version = uint16(unsafeUTF8DecimalCodePointsToInt(m.text()))
-
-	goto st6
+		goto st6
 	st6:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof6
 		}
 	st_case_6:
 //line rfc5424/machine.go:1672
-		if ( m.data)[( m.p)] == 45 {
+		if (m.data)[(m.p)] == 45 {
 			goto st7
 		}
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+		if 48 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 57 {
 			goto tr13
 		}
 		goto st0
 	st7:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof7
 		}
 	st_case_7:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto st8
 		}
 		goto st0
-tr619:
+	tr619:
 //line rfc5424/machine.go.rl:48
+		if t, e := time.Parse(time.RFC3339Nano, string(m.text())); e != nil {
+			m.err = fmt.Errorf("%s [col %d]", e, m.p)
+			(m.p)--
 
-	if t, e := time.Parse(time.RFC3339Nano, string(m.text())); e != nil {
-        m.err = fmt.Errorf("%s [col %d]", e, m.p)
-		( m.p)--
+			{
+				goto st607
+			}
+		} else {
+			output.Timestamp = t
+		}
 
-    	{goto st607 }
-    } else {
-        m.output.Timestamp = &t
-    }
-
-	goto st8
+		goto st8
 	st8:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof8
 		}
 	st_case_8:
 //line rfc5424/machine.go:1707
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto tr16
 		}
 		goto tr15
-tr16:
+	tr16:
 //line rfc5424/machine.go.rl:32
+		m.pb = m.p
 
-	m.pb = m.p
-
-	goto st9
+		goto st9
 	st9:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof9
 		}
 	st_case_9:
 //line rfc5424/machine.go:1723
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st307
 		}
 		goto tr15
-tr17:
+	tr17:
 //line rfc5424/machine.go.rl:58
+		if hostname := string(m.text()); hostname != "-" {
+			output.Hostname = hostname
+		}
 
-	if hostname := string(m.text()); hostname != "-" {
-		m.output.Hostname = &hostname
-	}
-
-	goto st10
+		goto st10
 	st10:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof10
 		}
 	st_case_10:
 //line rfc5424/machine.go:1744
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto tr20
 		}
 		goto tr19
-tr20:
+	tr20:
 //line rfc5424/machine.go.rl:32
+		m.pb = m.p
 
-	m.pb = m.p
-
-	goto st11
+		goto st11
 	st11:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof11
 		}
 	st_case_11:
 //line rfc5424/machine.go:1760
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr21
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st260
 		}
 		goto tr19
-tr21:
+	tr21:
 //line rfc5424/machine.go.rl:64
+		if appname := string(m.text()); appname != "-" {
+			output.Appname = appname
+		}
 
-	if appname := string(m.text()); appname != "-" {
-		m.output.Appname = &appname
-	}
-
-	goto st12
+		goto st12
 	st12:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof12
 		}
 	st_case_12:
 //line rfc5424/machine.go:1781
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto tr24
 		}
 		goto tr23
-tr24:
+	tr24:
 //line rfc5424/machine.go.rl:32
+		m.pb = m.p
 
-	m.pb = m.p
-
-	goto st13
+		goto st13
 	st13:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof13
 		}
 	st_case_13:
 //line rfc5424/machine.go:1797
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr25
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st133
 		}
 		goto tr23
-tr25:
+	tr25:
 //line rfc5424/machine.go.rl:70
+		if procid := string(m.text()); procid != "-" {
+			output.ProcID = procid
+		}
 
-	if procid := string(m.text()); procid != "-" {
-		m.output.ProcID = &procid
-	}
-
-	goto st14
+		goto st14
 	st14:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof14
 		}
 	st_case_14:
 //line rfc5424/machine.go:1818
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto tr28
 		}
 		goto tr27
-tr28:
+	tr28:
 //line rfc5424/machine.go.rl:32
+		m.pb = m.p
 
-	m.pb = m.p
-
-	goto st15
+		goto st15
 	st15:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof15
 		}
 	st_case_15:
 //line rfc5424/machine.go:1834
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr29
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st102
 		}
 		goto tr27
-tr29:
+	tr29:
 //line rfc5424/machine.go.rl:76
+		if msgid := string(m.text()); msgid != "-" {
+			output.MsgID = msgid
+		}
 
-	if msgid := string(m.text()); msgid != "-" {
-		m.output.MsgID = &msgid
-	}
-
-	goto st16
+		goto st16
 	st16:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof16
 		}
 	st_case_16:
 //line rfc5424/machine.go:1855
-		switch ( m.data)[( m.p)] {
+		switch (m.data)[(m.p)] {
 		case 45:
 			goto st603
 		case 91:
@@ -1860,20 +1862,20 @@ tr29:
 		}
 		goto tr31
 	st603:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof603
 		}
 	st_case_603:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto st604
 		}
 		goto tr630
 	st604:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof604
 		}
 	st_case_604:
-		switch ( m.data)[( m.p)] {
+		switch (m.data)[(m.p)] {
 		case 224:
 			goto tr634
 		case 237:
@@ -1884,45 +1886,43 @@ tr29:
 			goto tr639
 		}
 		switch {
-		case ( m.data)[( m.p)] < 225:
+		case (m.data)[(m.p)] < 225:
 			switch {
-			case ( m.data)[( m.p)] > 193:
-				if 194 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 223 {
+			case (m.data)[(m.p)] > 193:
+				if 194 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 223 {
 					goto tr633
 				}
-			case ( m.data)[( m.p)] >= 128:
+			case (m.data)[(m.p)] >= 128:
 				goto tr34
 			}
-		case ( m.data)[( m.p)] > 239:
+		case (m.data)[(m.p)] > 239:
 			switch {
-			case ( m.data)[( m.p)] > 243:
-				if 245 <= ( m.data)[( m.p)] {
+			case (m.data)[(m.p)] > 243:
+				if 245 <= (m.data)[(m.p)] {
 					goto tr34
 				}
-			case ( m.data)[( m.p)] >= 241:
+			case (m.data)[(m.p)] >= 241:
 				goto tr638
 			}
 		default:
 			goto tr635
 		}
 		goto tr632
-tr632:
+	tr632:
 //line rfc5424/machine.go.rl:32
-
-	m.pb = m.p
+		m.pb = m.p
 
 //line rfc5424/machine.go.rl:36
+		m.msg_at = m.p
 
-	m.msg_at = m.p
-
-	goto st605
+		goto st605
 	st605:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof605
 		}
 	st_case_605:
 //line rfc5424/machine.go:1925
-		switch ( m.data)[( m.p)] {
+		switch (m.data)[(m.p)] {
 		case 224:
 			goto st18
 		case 237:
@@ -1933,209 +1933,193 @@ tr632:
 			goto st23
 		}
 		switch {
-		case ( m.data)[( m.p)] < 225:
+		case (m.data)[(m.p)] < 225:
 			switch {
-			case ( m.data)[( m.p)] > 193:
-				if 194 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 223 {
+			case (m.data)[(m.p)] > 193:
+				if 194 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 223 {
 					goto st17
 				}
-			case ( m.data)[( m.p)] >= 128:
+			case (m.data)[(m.p)] >= 128:
 				goto tr34
 			}
-		case ( m.data)[( m.p)] > 239:
+		case (m.data)[(m.p)] > 239:
 			switch {
-			case ( m.data)[( m.p)] > 243:
-				if 245 <= ( m.data)[( m.p)] {
+			case (m.data)[(m.p)] > 243:
+				if 245 <= (m.data)[(m.p)] {
 					goto tr34
 				}
-			case ( m.data)[( m.p)] >= 241:
+			case (m.data)[(m.p)] >= 241:
 				goto st22
 			}
 		default:
 			goto st19
 		}
 		goto st605
-tr633:
+	tr633:
 //line rfc5424/machine.go.rl:32
-
-	m.pb = m.p
+		m.pb = m.p
 
 //line rfc5424/machine.go.rl:36
+		m.msg_at = m.p
 
-	m.msg_at = m.p
-
-	goto st17
+		goto st17
 	st17:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof17
 		}
 	st_case_17:
 //line rfc5424/machine.go:1974
-		if 128 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 191 {
+		if 128 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 191 {
 			goto st605
 		}
 		goto tr34
-tr634:
+	tr634:
 //line rfc5424/machine.go.rl:32
-
-	m.pb = m.p
+		m.pb = m.p
 
 //line rfc5424/machine.go.rl:36
+		m.msg_at = m.p
 
-	m.msg_at = m.p
-
-	goto st18
+		goto st18
 	st18:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof18
 		}
 	st_case_18:
 //line rfc5424/machine.go:1994
-		if 160 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 191 {
+		if 160 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 191 {
 			goto st17
 		}
 		goto tr34
-tr635:
+	tr635:
 //line rfc5424/machine.go.rl:32
-
-	m.pb = m.p
+		m.pb = m.p
 
 //line rfc5424/machine.go.rl:36
+		m.msg_at = m.p
 
-	m.msg_at = m.p
-
-	goto st19
+		goto st19
 	st19:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof19
 		}
 	st_case_19:
 //line rfc5424/machine.go:2014
-		if 128 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 191 {
+		if 128 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 191 {
 			goto st17
 		}
 		goto tr34
-tr636:
+	tr636:
 //line rfc5424/machine.go.rl:32
-
-	m.pb = m.p
+		m.pb = m.p
 
 //line rfc5424/machine.go.rl:36
+		m.msg_at = m.p
 
-	m.msg_at = m.p
-
-	goto st20
+		goto st20
 	st20:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof20
 		}
 	st_case_20:
 //line rfc5424/machine.go:2034
-		if 128 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 159 {
+		if 128 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 159 {
 			goto st17
 		}
 		goto tr34
-tr637:
+	tr637:
 //line rfc5424/machine.go.rl:32
-
-	m.pb = m.p
+		m.pb = m.p
 
 //line rfc5424/machine.go.rl:36
+		m.msg_at = m.p
 
-	m.msg_at = m.p
-
-	goto st21
+		goto st21
 	st21:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof21
 		}
 	st_case_21:
 //line rfc5424/machine.go:2054
-		if 144 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 191 {
+		if 144 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 191 {
 			goto st19
 		}
 		goto tr34
-tr638:
+	tr638:
 //line rfc5424/machine.go.rl:32
-
-	m.pb = m.p
+		m.pb = m.p
 
 //line rfc5424/machine.go.rl:36
+		m.msg_at = m.p
 
-	m.msg_at = m.p
-
-	goto st22
+		goto st22
 	st22:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof22
 		}
 	st_case_22:
 //line rfc5424/machine.go:2074
-		if 128 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 191 {
+		if 128 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 191 {
 			goto st19
 		}
 		goto tr34
-tr639:
+	tr639:
 //line rfc5424/machine.go.rl:32
-
-	m.pb = m.p
+		m.pb = m.p
 
 //line rfc5424/machine.go.rl:36
+		m.msg_at = m.p
 
-	m.msg_at = m.p
-
-	goto st23
+		goto st23
 	st23:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof23
 		}
 	st_case_23:
 //line rfc5424/machine.go:2094
-		if 128 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 143 {
+		if 128 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 143 {
 			goto st19
 		}
 		goto tr34
-tr33:
+	tr33:
 //line rfc5424/machine.go.rl:83
+		output.StructuredData = (map[string]map[string]string{})
 
-	m.output.StructuredData = &(map[string]map[string]string{})
-
-	goto st24
+		goto st24
 	st24:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof24
 		}
 	st_case_24:
 //line rfc5424/machine.go:2110
-		if ( m.data)[( m.p)] == 33 {
+		if (m.data)[(m.p)] == 33 {
 			goto tr39
 		}
 		switch {
-		case ( m.data)[( m.p)] < 62:
-			if 35 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 60 {
+		case (m.data)[(m.p)] < 62:
+			if 35 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 60 {
 				goto tr39
 			}
-		case ( m.data)[( m.p)] > 92:
-			if 94 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		case (m.data)[(m.p)] > 92:
+			if 94 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 				goto tr39
 			}
 		default:
 			goto tr39
 		}
 		goto tr38
-tr39:
+	tr39:
 //line rfc5424/machine.go.rl:32
+		m.pb = m.p
 
-	m.pb = m.p
-
-	goto st25
+		goto st25
 	st25:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof25
 		}
 	st_case_25:
 //line rfc5424/machine.go:2138
-		switch ( m.data)[( m.p)] {
+		switch (m.data)[(m.p)] {
 		case 32:
 			goto tr41
 		case 33:
@@ -2144,716 +2128,714 @@ tr39:
 			goto tr43
 		}
 		switch {
-		case ( m.data)[( m.p)] > 60:
-			if 62 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		case (m.data)[(m.p)] > 60:
+			if 62 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 				goto st71
 			}
-		case ( m.data)[( m.p)] >= 35:
+		case (m.data)[(m.p)] >= 35:
 			goto st71
 		}
 		goto tr40
-tr41:
+	tr41:
 //line rfc5424/machine.go.rl:87
+		if elements, ok := interface{}(output.StructuredData).(map[string]map[string]string); ok {
+			id := string(m.text())
+			if _, ok := (elements)[id]; ok {
+				// As per RFC5424 section 6.3.2 SD-ID MUST NOT exist more than once in a message
+				m.err = fmt.Errorf(errSdIDDuplicated, m.p)
+				(m.p)--
 
-	if elements, ok := interface{}(m.output.StructuredData).(*map[string]map[string]string); ok {
-		id := string(m.text())
-		if _, ok := (*elements)[id]; ok {
-			// As per RFC5424 section 6.3.2 SD-ID MUST NOT exist more than once in a message
-			m.err = fmt.Errorf(errSdIDDuplicated, m.p)
-			( m.p)--
-
-			{goto st607 }
-		} else {
-			(*elements)[id] = map[string]string{}
-			m.currentelem = id
+				{
+					goto st607
+				}
+			} else {
+				(elements)[id] = map[string]string{}
+				m.currentelem = id
+			}
 		}
-	}
 
-	goto st26
+		goto st26
 	st26:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof26
 		}
 	st_case_26:
 //line rfc5424/machine.go:2179
-		if ( m.data)[( m.p)] == 33 {
+		if (m.data)[(m.p)] == 33 {
 			goto tr45
 		}
 		switch {
-		case ( m.data)[( m.p)] < 62:
-			if 35 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 60 {
+		case (m.data)[(m.p)] < 62:
+			if 35 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 60 {
 				goto tr45
 			}
-		case ( m.data)[( m.p)] > 92:
-			if 94 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		case (m.data)[(m.p)] > 92:
+			if 94 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 				goto tr45
 			}
 		default:
 			goto tr45
 		}
 		goto tr44
-tr45:
+	tr45:
 //line rfc5424/machine.go.rl:102
-
-	m.backslash_at = []int{}
+		m.backslash_at = []int{}
 
 //line rfc5424/machine.go.rl:32
+		m.pb = m.p
 
-	m.pb = m.p
-
-	goto st27
+		goto st27
 	st27:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof27
 		}
 	st_case_27:
 //line rfc5424/machine.go:2211
-		switch ( m.data)[( m.p)] {
+		switch (m.data)[(m.p)] {
 		case 33:
 			goto st28
 		case 61:
 			goto tr47
 		}
 		switch {
-		case ( m.data)[( m.p)] > 92:
-			if 94 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		case (m.data)[(m.p)] > 92:
+			if 94 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 				goto st28
 			}
-		case ( m.data)[( m.p)] >= 35:
+		case (m.data)[(m.p)] >= 35:
 			goto st28
 		}
 		goto tr44
 	st28:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof28
 		}
 	st_case_28:
-		switch ( m.data)[( m.p)] {
+		switch (m.data)[(m.p)] {
 		case 33:
 			goto st29
 		case 61:
 			goto tr47
 		}
 		switch {
-		case ( m.data)[( m.p)] > 92:
-			if 94 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		case (m.data)[(m.p)] > 92:
+			if 94 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 				goto st29
 			}
-		case ( m.data)[( m.p)] >= 35:
+		case (m.data)[(m.p)] >= 35:
 			goto st29
 		}
 		goto tr44
 	st29:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof29
 		}
 	st_case_29:
-		switch ( m.data)[( m.p)] {
+		switch (m.data)[(m.p)] {
 		case 33:
 			goto st30
 		case 61:
 			goto tr47
 		}
 		switch {
-		case ( m.data)[( m.p)] > 92:
-			if 94 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		case (m.data)[(m.p)] > 92:
+			if 94 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 				goto st30
 			}
-		case ( m.data)[( m.p)] >= 35:
+		case (m.data)[(m.p)] >= 35:
 			goto st30
 		}
 		goto tr44
 	st30:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof30
 		}
 	st_case_30:
-		switch ( m.data)[( m.p)] {
+		switch (m.data)[(m.p)] {
 		case 33:
 			goto st31
 		case 61:
 			goto tr47
 		}
 		switch {
-		case ( m.data)[( m.p)] > 92:
-			if 94 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		case (m.data)[(m.p)] > 92:
+			if 94 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 				goto st31
 			}
-		case ( m.data)[( m.p)] >= 35:
+		case (m.data)[(m.p)] >= 35:
 			goto st31
 		}
 		goto tr44
 	st31:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof31
 		}
 	st_case_31:
-		switch ( m.data)[( m.p)] {
+		switch (m.data)[(m.p)] {
 		case 33:
 			goto st32
 		case 61:
 			goto tr47
 		}
 		switch {
-		case ( m.data)[( m.p)] > 92:
-			if 94 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		case (m.data)[(m.p)] > 92:
+			if 94 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 				goto st32
 			}
-		case ( m.data)[( m.p)] >= 35:
+		case (m.data)[(m.p)] >= 35:
 			goto st32
 		}
 		goto tr44
 	st32:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof32
 		}
 	st_case_32:
-		switch ( m.data)[( m.p)] {
+		switch (m.data)[(m.p)] {
 		case 33:
 			goto st33
 		case 61:
 			goto tr47
 		}
 		switch {
-		case ( m.data)[( m.p)] > 92:
-			if 94 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		case (m.data)[(m.p)] > 92:
+			if 94 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 				goto st33
 			}
-		case ( m.data)[( m.p)] >= 35:
+		case (m.data)[(m.p)] >= 35:
 			goto st33
 		}
 		goto tr44
 	st33:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof33
 		}
 	st_case_33:
-		switch ( m.data)[( m.p)] {
+		switch (m.data)[(m.p)] {
 		case 33:
 			goto st34
 		case 61:
 			goto tr47
 		}
 		switch {
-		case ( m.data)[( m.p)] > 92:
-			if 94 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		case (m.data)[(m.p)] > 92:
+			if 94 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 				goto st34
 			}
-		case ( m.data)[( m.p)] >= 35:
+		case (m.data)[(m.p)] >= 35:
 			goto st34
 		}
 		goto tr44
 	st34:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof34
 		}
 	st_case_34:
-		switch ( m.data)[( m.p)] {
+		switch (m.data)[(m.p)] {
 		case 33:
 			goto st35
 		case 61:
 			goto tr47
 		}
 		switch {
-		case ( m.data)[( m.p)] > 92:
-			if 94 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		case (m.data)[(m.p)] > 92:
+			if 94 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 				goto st35
 			}
-		case ( m.data)[( m.p)] >= 35:
+		case (m.data)[(m.p)] >= 35:
 			goto st35
 		}
 		goto tr44
 	st35:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof35
 		}
 	st_case_35:
-		switch ( m.data)[( m.p)] {
+		switch (m.data)[(m.p)] {
 		case 33:
 			goto st36
 		case 61:
 			goto tr47
 		}
 		switch {
-		case ( m.data)[( m.p)] > 92:
-			if 94 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		case (m.data)[(m.p)] > 92:
+			if 94 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 				goto st36
 			}
-		case ( m.data)[( m.p)] >= 35:
+		case (m.data)[(m.p)] >= 35:
 			goto st36
 		}
 		goto tr44
 	st36:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof36
 		}
 	st_case_36:
-		switch ( m.data)[( m.p)] {
+		switch (m.data)[(m.p)] {
 		case 33:
 			goto st37
 		case 61:
 			goto tr47
 		}
 		switch {
-		case ( m.data)[( m.p)] > 92:
-			if 94 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		case (m.data)[(m.p)] > 92:
+			if 94 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 				goto st37
 			}
-		case ( m.data)[( m.p)] >= 35:
+		case (m.data)[(m.p)] >= 35:
 			goto st37
 		}
 		goto tr44
 	st37:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof37
 		}
 	st_case_37:
-		switch ( m.data)[( m.p)] {
+		switch (m.data)[(m.p)] {
 		case 33:
 			goto st38
 		case 61:
 			goto tr47
 		}
 		switch {
-		case ( m.data)[( m.p)] > 92:
-			if 94 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		case (m.data)[(m.p)] > 92:
+			if 94 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 				goto st38
 			}
-		case ( m.data)[( m.p)] >= 35:
+		case (m.data)[(m.p)] >= 35:
 			goto st38
 		}
 		goto tr44
 	st38:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof38
 		}
 	st_case_38:
-		switch ( m.data)[( m.p)] {
+		switch (m.data)[(m.p)] {
 		case 33:
 			goto st39
 		case 61:
 			goto tr47
 		}
 		switch {
-		case ( m.data)[( m.p)] > 92:
-			if 94 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		case (m.data)[(m.p)] > 92:
+			if 94 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 				goto st39
 			}
-		case ( m.data)[( m.p)] >= 35:
+		case (m.data)[(m.p)] >= 35:
 			goto st39
 		}
 		goto tr44
 	st39:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof39
 		}
 	st_case_39:
-		switch ( m.data)[( m.p)] {
+		switch (m.data)[(m.p)] {
 		case 33:
 			goto st40
 		case 61:
 			goto tr47
 		}
 		switch {
-		case ( m.data)[( m.p)] > 92:
-			if 94 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		case (m.data)[(m.p)] > 92:
+			if 94 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 				goto st40
 			}
-		case ( m.data)[( m.p)] >= 35:
+		case (m.data)[(m.p)] >= 35:
 			goto st40
 		}
 		goto tr44
 	st40:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof40
 		}
 	st_case_40:
-		switch ( m.data)[( m.p)] {
+		switch (m.data)[(m.p)] {
 		case 33:
 			goto st41
 		case 61:
 			goto tr47
 		}
 		switch {
-		case ( m.data)[( m.p)] > 92:
-			if 94 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		case (m.data)[(m.p)] > 92:
+			if 94 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 				goto st41
 			}
-		case ( m.data)[( m.p)] >= 35:
+		case (m.data)[(m.p)] >= 35:
 			goto st41
 		}
 		goto tr44
 	st41:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof41
 		}
 	st_case_41:
-		switch ( m.data)[( m.p)] {
+		switch (m.data)[(m.p)] {
 		case 33:
 			goto st42
 		case 61:
 			goto tr47
 		}
 		switch {
-		case ( m.data)[( m.p)] > 92:
-			if 94 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		case (m.data)[(m.p)] > 92:
+			if 94 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 				goto st42
 			}
-		case ( m.data)[( m.p)] >= 35:
+		case (m.data)[(m.p)] >= 35:
 			goto st42
 		}
 		goto tr44
 	st42:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof42
 		}
 	st_case_42:
-		switch ( m.data)[( m.p)] {
+		switch (m.data)[(m.p)] {
 		case 33:
 			goto st43
 		case 61:
 			goto tr47
 		}
 		switch {
-		case ( m.data)[( m.p)] > 92:
-			if 94 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		case (m.data)[(m.p)] > 92:
+			if 94 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 				goto st43
 			}
-		case ( m.data)[( m.p)] >= 35:
+		case (m.data)[(m.p)] >= 35:
 			goto st43
 		}
 		goto tr44
 	st43:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof43
 		}
 	st_case_43:
-		switch ( m.data)[( m.p)] {
+		switch (m.data)[(m.p)] {
 		case 33:
 			goto st44
 		case 61:
 			goto tr47
 		}
 		switch {
-		case ( m.data)[( m.p)] > 92:
-			if 94 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		case (m.data)[(m.p)] > 92:
+			if 94 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 				goto st44
 			}
-		case ( m.data)[( m.p)] >= 35:
+		case (m.data)[(m.p)] >= 35:
 			goto st44
 		}
 		goto tr44
 	st44:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof44
 		}
 	st_case_44:
-		switch ( m.data)[( m.p)] {
+		switch (m.data)[(m.p)] {
 		case 33:
 			goto st45
 		case 61:
 			goto tr47
 		}
 		switch {
-		case ( m.data)[( m.p)] > 92:
-			if 94 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		case (m.data)[(m.p)] > 92:
+			if 94 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 				goto st45
 			}
-		case ( m.data)[( m.p)] >= 35:
+		case (m.data)[(m.p)] >= 35:
 			goto st45
 		}
 		goto tr44
 	st45:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof45
 		}
 	st_case_45:
-		switch ( m.data)[( m.p)] {
+		switch (m.data)[(m.p)] {
 		case 33:
 			goto st46
 		case 61:
 			goto tr47
 		}
 		switch {
-		case ( m.data)[( m.p)] > 92:
-			if 94 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		case (m.data)[(m.p)] > 92:
+			if 94 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 				goto st46
 			}
-		case ( m.data)[( m.p)] >= 35:
+		case (m.data)[(m.p)] >= 35:
 			goto st46
 		}
 		goto tr44
 	st46:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof46
 		}
 	st_case_46:
-		switch ( m.data)[( m.p)] {
+		switch (m.data)[(m.p)] {
 		case 33:
 			goto st47
 		case 61:
 			goto tr47
 		}
 		switch {
-		case ( m.data)[( m.p)] > 92:
-			if 94 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		case (m.data)[(m.p)] > 92:
+			if 94 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 				goto st47
 			}
-		case ( m.data)[( m.p)] >= 35:
+		case (m.data)[(m.p)] >= 35:
 			goto st47
 		}
 		goto tr44
 	st47:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof47
 		}
 	st_case_47:
-		switch ( m.data)[( m.p)] {
+		switch (m.data)[(m.p)] {
 		case 33:
 			goto st48
 		case 61:
 			goto tr47
 		}
 		switch {
-		case ( m.data)[( m.p)] > 92:
-			if 94 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		case (m.data)[(m.p)] > 92:
+			if 94 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 				goto st48
 			}
-		case ( m.data)[( m.p)] >= 35:
+		case (m.data)[(m.p)] >= 35:
 			goto st48
 		}
 		goto tr44
 	st48:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof48
 		}
 	st_case_48:
-		switch ( m.data)[( m.p)] {
+		switch (m.data)[(m.p)] {
 		case 33:
 			goto st49
 		case 61:
 			goto tr47
 		}
 		switch {
-		case ( m.data)[( m.p)] > 92:
-			if 94 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		case (m.data)[(m.p)] > 92:
+			if 94 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 				goto st49
 			}
-		case ( m.data)[( m.p)] >= 35:
+		case (m.data)[(m.p)] >= 35:
 			goto st49
 		}
 		goto tr44
 	st49:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof49
 		}
 	st_case_49:
-		switch ( m.data)[( m.p)] {
+		switch (m.data)[(m.p)] {
 		case 33:
 			goto st50
 		case 61:
 			goto tr47
 		}
 		switch {
-		case ( m.data)[( m.p)] > 92:
-			if 94 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		case (m.data)[(m.p)] > 92:
+			if 94 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 				goto st50
 			}
-		case ( m.data)[( m.p)] >= 35:
+		case (m.data)[(m.p)] >= 35:
 			goto st50
 		}
 		goto tr44
 	st50:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof50
 		}
 	st_case_50:
-		switch ( m.data)[( m.p)] {
+		switch (m.data)[(m.p)] {
 		case 33:
 			goto st51
 		case 61:
 			goto tr47
 		}
 		switch {
-		case ( m.data)[( m.p)] > 92:
-			if 94 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		case (m.data)[(m.p)] > 92:
+			if 94 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 				goto st51
 			}
-		case ( m.data)[( m.p)] >= 35:
+		case (m.data)[(m.p)] >= 35:
 			goto st51
 		}
 		goto tr44
 	st51:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof51
 		}
 	st_case_51:
-		switch ( m.data)[( m.p)] {
+		switch (m.data)[(m.p)] {
 		case 33:
 			goto st52
 		case 61:
 			goto tr47
 		}
 		switch {
-		case ( m.data)[( m.p)] > 92:
-			if 94 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		case (m.data)[(m.p)] > 92:
+			if 94 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 				goto st52
 			}
-		case ( m.data)[( m.p)] >= 35:
+		case (m.data)[(m.p)] >= 35:
 			goto st52
 		}
 		goto tr44
 	st52:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof52
 		}
 	st_case_52:
-		switch ( m.data)[( m.p)] {
+		switch (m.data)[(m.p)] {
 		case 33:
 			goto st53
 		case 61:
 			goto tr47
 		}
 		switch {
-		case ( m.data)[( m.p)] > 92:
-			if 94 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		case (m.data)[(m.p)] > 92:
+			if 94 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 				goto st53
 			}
-		case ( m.data)[( m.p)] >= 35:
+		case (m.data)[(m.p)] >= 35:
 			goto st53
 		}
 		goto tr44
 	st53:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof53
 		}
 	st_case_53:
-		switch ( m.data)[( m.p)] {
+		switch (m.data)[(m.p)] {
 		case 33:
 			goto st54
 		case 61:
 			goto tr47
 		}
 		switch {
-		case ( m.data)[( m.p)] > 92:
-			if 94 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		case (m.data)[(m.p)] > 92:
+			if 94 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 				goto st54
 			}
-		case ( m.data)[( m.p)] >= 35:
+		case (m.data)[(m.p)] >= 35:
 			goto st54
 		}
 		goto tr44
 	st54:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof54
 		}
 	st_case_54:
-		switch ( m.data)[( m.p)] {
+		switch (m.data)[(m.p)] {
 		case 33:
 			goto st55
 		case 61:
 			goto tr47
 		}
 		switch {
-		case ( m.data)[( m.p)] > 92:
-			if 94 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		case (m.data)[(m.p)] > 92:
+			if 94 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 				goto st55
 			}
-		case ( m.data)[( m.p)] >= 35:
+		case (m.data)[(m.p)] >= 35:
 			goto st55
 		}
 		goto tr44
 	st55:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof55
 		}
 	st_case_55:
-		switch ( m.data)[( m.p)] {
+		switch (m.data)[(m.p)] {
 		case 33:
 			goto st56
 		case 61:
 			goto tr47
 		}
 		switch {
-		case ( m.data)[( m.p)] > 92:
-			if 94 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		case (m.data)[(m.p)] > 92:
+			if 94 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 				goto st56
 			}
-		case ( m.data)[( m.p)] >= 35:
+		case (m.data)[(m.p)] >= 35:
 			goto st56
 		}
 		goto tr44
 	st56:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof56
 		}
 	st_case_56:
-		switch ( m.data)[( m.p)] {
+		switch (m.data)[(m.p)] {
 		case 33:
 			goto st57
 		case 61:
 			goto tr47
 		}
 		switch {
-		case ( m.data)[( m.p)] > 92:
-			if 94 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		case (m.data)[(m.p)] > 92:
+			if 94 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 				goto st57
 			}
-		case ( m.data)[( m.p)] >= 35:
+		case (m.data)[(m.p)] >= 35:
 			goto st57
 		}
 		goto tr44
 	st57:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof57
 		}
 	st_case_57:
-		switch ( m.data)[( m.p)] {
+		switch (m.data)[(m.p)] {
 		case 33:
 			goto st58
 		case 61:
 			goto tr47
 		}
 		switch {
-		case ( m.data)[( m.p)] > 92:
-			if 94 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		case (m.data)[(m.p)] > 92:
+			if 94 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 				goto st58
 			}
-		case ( m.data)[( m.p)] >= 35:
+		case (m.data)[(m.p)] >= 35:
 			goto st58
 		}
 		goto tr44
 	st58:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof58
 		}
 	st_case_58:
-		if ( m.data)[( m.p)] == 61 {
+		if (m.data)[(m.p)] == 61 {
 			goto tr47
 		}
 		goto tr44
-tr47:
+	tr47:
 //line rfc5424/machine.go.rl:110
+		m.currentparam = string(m.text())
 
-	m.currentparam = string(m.text())
-
-	goto st59
+		goto st59
 	st59:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof59
 		}
 	st_case_59:
 //line rfc5424/machine.go:2847
-		if ( m.data)[( m.p)] == 34 {
+		if (m.data)[(m.p)] == 34 {
 			goto st60
 		}
 		goto tr44
 	st60:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof60
 		}
 	st_case_60:
-		switch ( m.data)[( m.p)] {
+		switch (m.data)[(m.p)] {
 		case 34:
 			goto tr80
 		case 92:
@@ -2870,41 +2852,40 @@ tr47:
 			goto tr89
 		}
 		switch {
-		case ( m.data)[( m.p)] < 225:
+		case (m.data)[(m.p)] < 225:
 			switch {
-			case ( m.data)[( m.p)] > 193:
-				if 194 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 223 {
+			case (m.data)[(m.p)] > 193:
+				if 194 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 223 {
 					goto tr83
 				}
-			case ( m.data)[( m.p)] >= 128:
+			case (m.data)[(m.p)] >= 128:
 				goto tr82
 			}
-		case ( m.data)[( m.p)] > 239:
+		case (m.data)[(m.p)] > 239:
 			switch {
-			case ( m.data)[( m.p)] > 243:
-				if 245 <= ( m.data)[( m.p)] {
+			case (m.data)[(m.p)] > 243:
+				if 245 <= (m.data)[(m.p)] {
 					goto tr82
 				}
-			case ( m.data)[( m.p)] >= 241:
+			case (m.data)[(m.p)] >= 241:
 				goto tr88
 			}
 		default:
 			goto tr85
 		}
 		goto tr79
-tr79:
+	tr79:
 //line rfc5424/machine.go.rl:32
+		m.pb = m.p
 
-	m.pb = m.p
-
-	goto st61
+		goto st61
 	st61:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof61
 		}
 	st_case_61:
 //line rfc5424/machine.go:2907
-		switch ( m.data)[( m.p)] {
+		switch (m.data)[(m.p)] {
 		case 34:
 			goto tr91
 		case 92:
@@ -2921,271 +2902,259 @@ tr79:
 			goto st70
 		}
 		switch {
-		case ( m.data)[( m.p)] < 225:
+		case (m.data)[(m.p)] < 225:
 			switch {
-			case ( m.data)[( m.p)] > 193:
-				if 194 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 223 {
+			case (m.data)[(m.p)] > 193:
+				if 194 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 223 {
 					goto st64
 				}
-			case ( m.data)[( m.p)] >= 128:
+			case (m.data)[(m.p)] >= 128:
 				goto tr82
 			}
-		case ( m.data)[( m.p)] > 239:
+		case (m.data)[(m.p)] > 239:
 			switch {
-			case ( m.data)[( m.p)] > 243:
-				if 245 <= ( m.data)[( m.p)] {
+			case (m.data)[(m.p)] > 243:
+				if 245 <= (m.data)[(m.p)] {
 					goto tr82
 				}
-			case ( m.data)[( m.p)] >= 241:
+			case (m.data)[(m.p)] >= 241:
 				goto st69
 			}
 		default:
 			goto st66
 		}
 		goto st61
-tr80:
+	tr80:
 //line rfc5424/machine.go.rl:32
-
-	m.pb = m.p
+		m.pb = m.p
 
 //line rfc5424/machine.go.rl:114
+		if elements, ok := interface{}(output.StructuredData).(map[string]map[string]string); ok {
+			// (fixme) > what if SD-PARAM-NAME already exist for the current element (ie., current SD-ID)?
 
-	if elements, ok := interface{}(m.output.StructuredData).(*map[string]map[string]string); ok {
-		// (fixme) > what if SD-PARAM-NAME already exist for the current element (ie., current SD-ID)?
+			// Store text
+			text := m.text()
 
-		// Store text
-		text := m.text()
-		
-		// Strip backslashes only when there are ...
-		if len(m.backslash_at) > 0 {
-			// We need a copy here to not modify m.data
-			cp := append([]byte(nil), text...)
-			for _, pos := range m.backslash_at {
-				at := pos - m.pb
-				cp = append(cp[:at], cp[(at + 1):]...)
+			// Strip backslashes only when there are ...
+			if len(m.backslash_at) > 0 {
+				// We need a copy here to not modify m.data
+				cp := append([]byte(nil), text...)
+				for _, pos := range m.backslash_at {
+					at := pos - m.pb
+					cp = append(cp[:at], cp[(at+1):]...)
+				}
+
+				text = cp
 			}
-			
-			text = cp
+			(elements)[m.currentelem][m.currentparam] = string(text)
 		}
-		(*elements)[m.currentelem][m.currentparam] = string(text)
-	}
 
-	goto st62
-tr91:
+		goto st62
+	tr91:
 //line rfc5424/machine.go.rl:114
+		if elements, ok := interface{}(output.StructuredData).(map[string]map[string]string); ok {
+			// (fixme) > what if SD-PARAM-NAME already exist for the current element (ie., current SD-ID)?
 
-	if elements, ok := interface{}(m.output.StructuredData).(*map[string]map[string]string); ok {
-		// (fixme) > what if SD-PARAM-NAME already exist for the current element (ie., current SD-ID)?
+			// Store text
+			text := m.text()
 
-		// Store text
-		text := m.text()
-		
-		// Strip backslashes only when there are ...
-		if len(m.backslash_at) > 0 {
-			// We need a copy here to not modify m.data
-			cp := append([]byte(nil), text...)
-			for _, pos := range m.backslash_at {
-				at := pos - m.pb
-				cp = append(cp[:at], cp[(at + 1):]...)
+			// Strip backslashes only when there are ...
+			if len(m.backslash_at) > 0 {
+				// We need a copy here to not modify m.data
+				cp := append([]byte(nil), text...)
+				for _, pos := range m.backslash_at {
+					at := pos - m.pb
+					cp = append(cp[:at], cp[(at+1):]...)
+				}
+
+				text = cp
 			}
-			
-			text = cp
+			(elements)[m.currentelem][m.currentparam] = string(text)
 		}
-		(*elements)[m.currentelem][m.currentparam] = string(text)
-	}
 
-	goto st62
+		goto st62
 	st62:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof62
 		}
 	st_case_62:
 //line rfc5424/machine.go:3004
-		switch ( m.data)[( m.p)] {
+		switch (m.data)[(m.p)] {
 		case 32:
 			goto st26
 		case 93:
 			goto st606
 		}
 		goto tr44
-tr43:
+	tr43:
 //line rfc5424/machine.go.rl:87
+		if elements, ok := interface{}(output.StructuredData).(map[string]map[string]string); ok {
+			id := string(m.text())
+			if _, ok := (elements)[id]; ok {
+				// As per RFC5424 section 6.3.2 SD-ID MUST NOT exist more than once in a message
+				m.err = fmt.Errorf(errSdIDDuplicated, m.p)
+				(m.p)--
 
-	if elements, ok := interface{}(m.output.StructuredData).(*map[string]map[string]string); ok {
-		id := string(m.text())
-		if _, ok := (*elements)[id]; ok {
-			// As per RFC5424 section 6.3.2 SD-ID MUST NOT exist more than once in a message
-			m.err = fmt.Errorf(errSdIDDuplicated, m.p)
-			( m.p)--
-
-			{goto st607 }
-		} else {
-			(*elements)[id] = map[string]string{}
-			m.currentelem = id
+				{
+					goto st607
+				}
+			} else {
+				(elements)[id] = map[string]string{}
+				m.currentelem = id
+			}
 		}
-	}
 
-	goto st606
+		goto st606
 	st606:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof606
 		}
 	st_case_606:
 //line rfc5424/machine.go:3035
-		switch ( m.data)[( m.p)] {
+		switch (m.data)[(m.p)] {
 		case 32:
 			goto st604
 		case 91:
 			goto st24
 		}
 		goto tr645
-tr81:
+	tr81:
 //line rfc5424/machine.go.rl:32
-
-	m.pb = m.p
+		m.pb = m.p
 
 //line rfc5424/machine.go.rl:106
+		m.backslash_at = append(m.backslash_at, m.p)
 
-	m.backslash_at = append(m.backslash_at, m.p)
-
-	goto st63
-tr92:
+		goto st63
+	tr92:
 //line rfc5424/machine.go.rl:106
+		m.backslash_at = append(m.backslash_at, m.p)
 
-	m.backslash_at = append(m.backslash_at, m.p)
-
-	goto st63
+		goto st63
 	st63:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof63
 		}
 	st_case_63:
 //line rfc5424/machine.go:3064
-		if ( m.data)[( m.p)] == 34 {
+		if (m.data)[(m.p)] == 34 {
 			goto st61
 		}
-		if 92 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 93 {
+		if 92 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 93 {
 			goto st61
 		}
 		goto tr82
-tr83:
+	tr83:
 //line rfc5424/machine.go.rl:32
+		m.pb = m.p
 
-	m.pb = m.p
-
-	goto st64
+		goto st64
 	st64:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof64
 		}
 	st_case_64:
 //line rfc5424/machine.go:3083
-		if 128 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 191 {
+		if 128 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 191 {
 			goto st61
 		}
 		goto tr44
-tr84:
+	tr84:
 //line rfc5424/machine.go.rl:32
+		m.pb = m.p
 
-	m.pb = m.p
-
-	goto st65
+		goto st65
 	st65:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof65
 		}
 	st_case_65:
 //line rfc5424/machine.go:3099
-		if 160 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 191 {
+		if 160 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 191 {
 			goto st64
 		}
 		goto tr44
-tr85:
+	tr85:
 //line rfc5424/machine.go.rl:32
+		m.pb = m.p
 
-	m.pb = m.p
-
-	goto st66
+		goto st66
 	st66:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof66
 		}
 	st_case_66:
 //line rfc5424/machine.go:3115
-		if 128 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 191 {
+		if 128 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 191 {
 			goto st64
 		}
 		goto tr44
-tr86:
+	tr86:
 //line rfc5424/machine.go.rl:32
+		m.pb = m.p
 
-	m.pb = m.p
-
-	goto st67
+		goto st67
 	st67:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof67
 		}
 	st_case_67:
 //line rfc5424/machine.go:3131
-		if 128 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 159 {
+		if 128 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 159 {
 			goto st64
 		}
 		goto tr44
-tr87:
+	tr87:
 //line rfc5424/machine.go.rl:32
+		m.pb = m.p
 
-	m.pb = m.p
-
-	goto st68
+		goto st68
 	st68:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof68
 		}
 	st_case_68:
 //line rfc5424/machine.go:3147
-		if 144 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 191 {
+		if 144 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 191 {
 			goto st66
 		}
 		goto tr44
-tr88:
+	tr88:
 //line rfc5424/machine.go.rl:32
+		m.pb = m.p
 
-	m.pb = m.p
-
-	goto st69
+		goto st69
 	st69:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof69
 		}
 	st_case_69:
 //line rfc5424/machine.go:3163
-		if 128 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 191 {
+		if 128 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 191 {
 			goto st66
 		}
 		goto tr44
-tr89:
+	tr89:
 //line rfc5424/machine.go.rl:32
+		m.pb = m.p
 
-	m.pb = m.p
-
-	goto st70
+		goto st70
 	st70:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof70
 		}
 	st_case_70:
 //line rfc5424/machine.go:3179
-		if 128 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 143 {
+		if 128 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 143 {
 			goto st66
 		}
 		goto tr44
 	st71:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof71
 		}
 	st_case_71:
-		switch ( m.data)[( m.p)] {
+		switch (m.data)[(m.p)] {
 		case 32:
 			goto tr41
 		case 33:
@@ -3194,20 +3163,20 @@ tr89:
 			goto tr43
 		}
 		switch {
-		case ( m.data)[( m.p)] > 60:
-			if 62 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		case (m.data)[(m.p)] > 60:
+			if 62 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 				goto st72
 			}
-		case ( m.data)[( m.p)] >= 35:
+		case (m.data)[(m.p)] >= 35:
 			goto st72
 		}
 		goto tr40
 	st72:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof72
 		}
 	st_case_72:
-		switch ( m.data)[( m.p)] {
+		switch (m.data)[(m.p)] {
 		case 32:
 			goto tr41
 		case 33:
@@ -3216,20 +3185,20 @@ tr89:
 			goto tr43
 		}
 		switch {
-		case ( m.data)[( m.p)] > 60:
-			if 62 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		case (m.data)[(m.p)] > 60:
+			if 62 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 				goto st73
 			}
-		case ( m.data)[( m.p)] >= 35:
+		case (m.data)[(m.p)] >= 35:
 			goto st73
 		}
 		goto tr40
 	st73:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof73
 		}
 	st_case_73:
-		switch ( m.data)[( m.p)] {
+		switch (m.data)[(m.p)] {
 		case 32:
 			goto tr41
 		case 33:
@@ -3238,20 +3207,20 @@ tr89:
 			goto tr43
 		}
 		switch {
-		case ( m.data)[( m.p)] > 60:
-			if 62 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		case (m.data)[(m.p)] > 60:
+			if 62 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 				goto st74
 			}
-		case ( m.data)[( m.p)] >= 35:
+		case (m.data)[(m.p)] >= 35:
 			goto st74
 		}
 		goto tr40
 	st74:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof74
 		}
 	st_case_74:
-		switch ( m.data)[( m.p)] {
+		switch (m.data)[(m.p)] {
 		case 32:
 			goto tr41
 		case 33:
@@ -3260,20 +3229,20 @@ tr89:
 			goto tr43
 		}
 		switch {
-		case ( m.data)[( m.p)] > 60:
-			if 62 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		case (m.data)[(m.p)] > 60:
+			if 62 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 				goto st75
 			}
-		case ( m.data)[( m.p)] >= 35:
+		case (m.data)[(m.p)] >= 35:
 			goto st75
 		}
 		goto tr40
 	st75:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof75
 		}
 	st_case_75:
-		switch ( m.data)[( m.p)] {
+		switch (m.data)[(m.p)] {
 		case 32:
 			goto tr41
 		case 33:
@@ -3282,20 +3251,20 @@ tr89:
 			goto tr43
 		}
 		switch {
-		case ( m.data)[( m.p)] > 60:
-			if 62 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		case (m.data)[(m.p)] > 60:
+			if 62 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 				goto st76
 			}
-		case ( m.data)[( m.p)] >= 35:
+		case (m.data)[(m.p)] >= 35:
 			goto st76
 		}
 		goto tr40
 	st76:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof76
 		}
 	st_case_76:
-		switch ( m.data)[( m.p)] {
+		switch (m.data)[(m.p)] {
 		case 32:
 			goto tr41
 		case 33:
@@ -3304,20 +3273,20 @@ tr89:
 			goto tr43
 		}
 		switch {
-		case ( m.data)[( m.p)] > 60:
-			if 62 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		case (m.data)[(m.p)] > 60:
+			if 62 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 				goto st77
 			}
-		case ( m.data)[( m.p)] >= 35:
+		case (m.data)[(m.p)] >= 35:
 			goto st77
 		}
 		goto tr40
 	st77:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof77
 		}
 	st_case_77:
-		switch ( m.data)[( m.p)] {
+		switch (m.data)[(m.p)] {
 		case 32:
 			goto tr41
 		case 33:
@@ -3326,20 +3295,20 @@ tr89:
 			goto tr43
 		}
 		switch {
-		case ( m.data)[( m.p)] > 60:
-			if 62 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		case (m.data)[(m.p)] > 60:
+			if 62 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 				goto st78
 			}
-		case ( m.data)[( m.p)] >= 35:
+		case (m.data)[(m.p)] >= 35:
 			goto st78
 		}
 		goto tr40
 	st78:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof78
 		}
 	st_case_78:
-		switch ( m.data)[( m.p)] {
+		switch (m.data)[(m.p)] {
 		case 32:
 			goto tr41
 		case 33:
@@ -3348,20 +3317,20 @@ tr89:
 			goto tr43
 		}
 		switch {
-		case ( m.data)[( m.p)] > 60:
-			if 62 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		case (m.data)[(m.p)] > 60:
+			if 62 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 				goto st79
 			}
-		case ( m.data)[( m.p)] >= 35:
+		case (m.data)[(m.p)] >= 35:
 			goto st79
 		}
 		goto tr40
 	st79:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof79
 		}
 	st_case_79:
-		switch ( m.data)[( m.p)] {
+		switch (m.data)[(m.p)] {
 		case 32:
 			goto tr41
 		case 33:
@@ -3370,20 +3339,20 @@ tr89:
 			goto tr43
 		}
 		switch {
-		case ( m.data)[( m.p)] > 60:
-			if 62 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		case (m.data)[(m.p)] > 60:
+			if 62 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 				goto st80
 			}
-		case ( m.data)[( m.p)] >= 35:
+		case (m.data)[(m.p)] >= 35:
 			goto st80
 		}
 		goto tr40
 	st80:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof80
 		}
 	st_case_80:
-		switch ( m.data)[( m.p)] {
+		switch (m.data)[(m.p)] {
 		case 32:
 			goto tr41
 		case 33:
@@ -3392,20 +3361,20 @@ tr89:
 			goto tr43
 		}
 		switch {
-		case ( m.data)[( m.p)] > 60:
-			if 62 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		case (m.data)[(m.p)] > 60:
+			if 62 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 				goto st81
 			}
-		case ( m.data)[( m.p)] >= 35:
+		case (m.data)[(m.p)] >= 35:
 			goto st81
 		}
 		goto tr40
 	st81:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof81
 		}
 	st_case_81:
-		switch ( m.data)[( m.p)] {
+		switch (m.data)[(m.p)] {
 		case 32:
 			goto tr41
 		case 33:
@@ -3414,20 +3383,20 @@ tr89:
 			goto tr43
 		}
 		switch {
-		case ( m.data)[( m.p)] > 60:
-			if 62 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		case (m.data)[(m.p)] > 60:
+			if 62 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 				goto st82
 			}
-		case ( m.data)[( m.p)] >= 35:
+		case (m.data)[(m.p)] >= 35:
 			goto st82
 		}
 		goto tr40
 	st82:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof82
 		}
 	st_case_82:
-		switch ( m.data)[( m.p)] {
+		switch (m.data)[(m.p)] {
 		case 32:
 			goto tr41
 		case 33:
@@ -3436,20 +3405,20 @@ tr89:
 			goto tr43
 		}
 		switch {
-		case ( m.data)[( m.p)] > 60:
-			if 62 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		case (m.data)[(m.p)] > 60:
+			if 62 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 				goto st83
 			}
-		case ( m.data)[( m.p)] >= 35:
+		case (m.data)[(m.p)] >= 35:
 			goto st83
 		}
 		goto tr40
 	st83:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof83
 		}
 	st_case_83:
-		switch ( m.data)[( m.p)] {
+		switch (m.data)[(m.p)] {
 		case 32:
 			goto tr41
 		case 33:
@@ -3458,20 +3427,20 @@ tr89:
 			goto tr43
 		}
 		switch {
-		case ( m.data)[( m.p)] > 60:
-			if 62 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		case (m.data)[(m.p)] > 60:
+			if 62 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 				goto st84
 			}
-		case ( m.data)[( m.p)] >= 35:
+		case (m.data)[(m.p)] >= 35:
 			goto st84
 		}
 		goto tr40
 	st84:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof84
 		}
 	st_case_84:
-		switch ( m.data)[( m.p)] {
+		switch (m.data)[(m.p)] {
 		case 32:
 			goto tr41
 		case 33:
@@ -3480,20 +3449,20 @@ tr89:
 			goto tr43
 		}
 		switch {
-		case ( m.data)[( m.p)] > 60:
-			if 62 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		case (m.data)[(m.p)] > 60:
+			if 62 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 				goto st85
 			}
-		case ( m.data)[( m.p)] >= 35:
+		case (m.data)[(m.p)] >= 35:
 			goto st85
 		}
 		goto tr40
 	st85:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof85
 		}
 	st_case_85:
-		switch ( m.data)[( m.p)] {
+		switch (m.data)[(m.p)] {
 		case 32:
 			goto tr41
 		case 33:
@@ -3502,20 +3471,20 @@ tr89:
 			goto tr43
 		}
 		switch {
-		case ( m.data)[( m.p)] > 60:
-			if 62 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		case (m.data)[(m.p)] > 60:
+			if 62 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 				goto st86
 			}
-		case ( m.data)[( m.p)] >= 35:
+		case (m.data)[(m.p)] >= 35:
 			goto st86
 		}
 		goto tr40
 	st86:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof86
 		}
 	st_case_86:
-		switch ( m.data)[( m.p)] {
+		switch (m.data)[(m.p)] {
 		case 32:
 			goto tr41
 		case 33:
@@ -3524,20 +3493,20 @@ tr89:
 			goto tr43
 		}
 		switch {
-		case ( m.data)[( m.p)] > 60:
-			if 62 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		case (m.data)[(m.p)] > 60:
+			if 62 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 				goto st87
 			}
-		case ( m.data)[( m.p)] >= 35:
+		case (m.data)[(m.p)] >= 35:
 			goto st87
 		}
 		goto tr40
 	st87:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof87
 		}
 	st_case_87:
-		switch ( m.data)[( m.p)] {
+		switch (m.data)[(m.p)] {
 		case 32:
 			goto tr41
 		case 33:
@@ -3546,20 +3515,20 @@ tr89:
 			goto tr43
 		}
 		switch {
-		case ( m.data)[( m.p)] > 60:
-			if 62 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		case (m.data)[(m.p)] > 60:
+			if 62 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 				goto st88
 			}
-		case ( m.data)[( m.p)] >= 35:
+		case (m.data)[(m.p)] >= 35:
 			goto st88
 		}
 		goto tr40
 	st88:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof88
 		}
 	st_case_88:
-		switch ( m.data)[( m.p)] {
+		switch (m.data)[(m.p)] {
 		case 32:
 			goto tr41
 		case 33:
@@ -3568,20 +3537,20 @@ tr89:
 			goto tr43
 		}
 		switch {
-		case ( m.data)[( m.p)] > 60:
-			if 62 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		case (m.data)[(m.p)] > 60:
+			if 62 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 				goto st89
 			}
-		case ( m.data)[( m.p)] >= 35:
+		case (m.data)[(m.p)] >= 35:
 			goto st89
 		}
 		goto tr40
 	st89:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof89
 		}
 	st_case_89:
-		switch ( m.data)[( m.p)] {
+		switch (m.data)[(m.p)] {
 		case 32:
 			goto tr41
 		case 33:
@@ -3590,20 +3559,20 @@ tr89:
 			goto tr43
 		}
 		switch {
-		case ( m.data)[( m.p)] > 60:
-			if 62 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		case (m.data)[(m.p)] > 60:
+			if 62 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 				goto st90
 			}
-		case ( m.data)[( m.p)] >= 35:
+		case (m.data)[(m.p)] >= 35:
 			goto st90
 		}
 		goto tr40
 	st90:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof90
 		}
 	st_case_90:
-		switch ( m.data)[( m.p)] {
+		switch (m.data)[(m.p)] {
 		case 32:
 			goto tr41
 		case 33:
@@ -3612,20 +3581,20 @@ tr89:
 			goto tr43
 		}
 		switch {
-		case ( m.data)[( m.p)] > 60:
-			if 62 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		case (m.data)[(m.p)] > 60:
+			if 62 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 				goto st91
 			}
-		case ( m.data)[( m.p)] >= 35:
+		case (m.data)[(m.p)] >= 35:
 			goto st91
 		}
 		goto tr40
 	st91:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof91
 		}
 	st_case_91:
-		switch ( m.data)[( m.p)] {
+		switch (m.data)[(m.p)] {
 		case 32:
 			goto tr41
 		case 33:
@@ -3634,20 +3603,20 @@ tr89:
 			goto tr43
 		}
 		switch {
-		case ( m.data)[( m.p)] > 60:
-			if 62 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		case (m.data)[(m.p)] > 60:
+			if 62 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 				goto st92
 			}
-		case ( m.data)[( m.p)] >= 35:
+		case (m.data)[(m.p)] >= 35:
 			goto st92
 		}
 		goto tr40
 	st92:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof92
 		}
 	st_case_92:
-		switch ( m.data)[( m.p)] {
+		switch (m.data)[(m.p)] {
 		case 32:
 			goto tr41
 		case 33:
@@ -3656,20 +3625,20 @@ tr89:
 			goto tr43
 		}
 		switch {
-		case ( m.data)[( m.p)] > 60:
-			if 62 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		case (m.data)[(m.p)] > 60:
+			if 62 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 				goto st93
 			}
-		case ( m.data)[( m.p)] >= 35:
+		case (m.data)[(m.p)] >= 35:
 			goto st93
 		}
 		goto tr40
 	st93:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof93
 		}
 	st_case_93:
-		switch ( m.data)[( m.p)] {
+		switch (m.data)[(m.p)] {
 		case 32:
 			goto tr41
 		case 33:
@@ -3678,20 +3647,20 @@ tr89:
 			goto tr43
 		}
 		switch {
-		case ( m.data)[( m.p)] > 60:
-			if 62 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		case (m.data)[(m.p)] > 60:
+			if 62 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 				goto st94
 			}
-		case ( m.data)[( m.p)] >= 35:
+		case (m.data)[(m.p)] >= 35:
 			goto st94
 		}
 		goto tr40
 	st94:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof94
 		}
 	st_case_94:
-		switch ( m.data)[( m.p)] {
+		switch (m.data)[(m.p)] {
 		case 32:
 			goto tr41
 		case 33:
@@ -3700,20 +3669,20 @@ tr89:
 			goto tr43
 		}
 		switch {
-		case ( m.data)[( m.p)] > 60:
-			if 62 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		case (m.data)[(m.p)] > 60:
+			if 62 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 				goto st95
 			}
-		case ( m.data)[( m.p)] >= 35:
+		case (m.data)[(m.p)] >= 35:
 			goto st95
 		}
 		goto tr40
 	st95:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof95
 		}
 	st_case_95:
-		switch ( m.data)[( m.p)] {
+		switch (m.data)[(m.p)] {
 		case 32:
 			goto tr41
 		case 33:
@@ -3722,20 +3691,20 @@ tr89:
 			goto tr43
 		}
 		switch {
-		case ( m.data)[( m.p)] > 60:
-			if 62 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		case (m.data)[(m.p)] > 60:
+			if 62 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 				goto st96
 			}
-		case ( m.data)[( m.p)] >= 35:
+		case (m.data)[(m.p)] >= 35:
 			goto st96
 		}
 		goto tr40
 	st96:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof96
 		}
 	st_case_96:
-		switch ( m.data)[( m.p)] {
+		switch (m.data)[(m.p)] {
 		case 32:
 			goto tr41
 		case 33:
@@ -3744,20 +3713,20 @@ tr89:
 			goto tr43
 		}
 		switch {
-		case ( m.data)[( m.p)] > 60:
-			if 62 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		case (m.data)[(m.p)] > 60:
+			if 62 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 				goto st97
 			}
-		case ( m.data)[( m.p)] >= 35:
+		case (m.data)[(m.p)] >= 35:
 			goto st97
 		}
 		goto tr40
 	st97:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof97
 		}
 	st_case_97:
-		switch ( m.data)[( m.p)] {
+		switch (m.data)[(m.p)] {
 		case 32:
 			goto tr41
 		case 33:
@@ -3766,20 +3735,20 @@ tr89:
 			goto tr43
 		}
 		switch {
-		case ( m.data)[( m.p)] > 60:
-			if 62 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		case (m.data)[(m.p)] > 60:
+			if 62 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 				goto st98
 			}
-		case ( m.data)[( m.p)] >= 35:
+		case (m.data)[(m.p)] >= 35:
 			goto st98
 		}
 		goto tr40
 	st98:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof98
 		}
 	st_case_98:
-		switch ( m.data)[( m.p)] {
+		switch (m.data)[(m.p)] {
 		case 32:
 			goto tr41
 		case 33:
@@ -3788,20 +3757,20 @@ tr89:
 			goto tr43
 		}
 		switch {
-		case ( m.data)[( m.p)] > 60:
-			if 62 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		case (m.data)[(m.p)] > 60:
+			if 62 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 				goto st99
 			}
-		case ( m.data)[( m.p)] >= 35:
+		case (m.data)[(m.p)] >= 35:
 			goto st99
 		}
 		goto tr40
 	st99:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof99
 		}
 	st_case_99:
-		switch ( m.data)[( m.p)] {
+		switch (m.data)[(m.p)] {
 		case 32:
 			goto tr41
 		case 33:
@@ -3810,20 +3779,20 @@ tr89:
 			goto tr43
 		}
 		switch {
-		case ( m.data)[( m.p)] > 60:
-			if 62 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		case (m.data)[(m.p)] > 60:
+			if 62 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 				goto st100
 			}
-		case ( m.data)[( m.p)] >= 35:
+		case (m.data)[(m.p)] >= 35:
 			goto st100
 		}
 		goto tr40
 	st100:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof100
 		}
 	st_case_100:
-		switch ( m.data)[( m.p)] {
+		switch (m.data)[(m.p)] {
 		case 32:
 			goto tr41
 		case 33:
@@ -3832,20 +3801,20 @@ tr89:
 			goto tr43
 		}
 		switch {
-		case ( m.data)[( m.p)] > 60:
-			if 62 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		case (m.data)[(m.p)] > 60:
+			if 62 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 				goto st101
 			}
-		case ( m.data)[( m.p)] >= 35:
+		case (m.data)[(m.p)] >= 35:
 			goto st101
 		}
 		goto tr40
 	st101:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof101
 		}
 	st_case_101:
-		switch ( m.data)[( m.p)] {
+		switch (m.data)[(m.p)] {
 		case 32:
 			goto tr41
 		case 93:
@@ -3853,5550 +3822,5549 @@ tr89:
 		}
 		goto tr40
 	st102:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof102
 		}
 	st_case_102:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr29
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st103
 		}
 		goto tr27
 	st103:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof103
 		}
 	st_case_103:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr29
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st104
 		}
 		goto tr27
 	st104:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof104
 		}
 	st_case_104:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr29
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st105
 		}
 		goto tr27
 	st105:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof105
 		}
 	st_case_105:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr29
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st106
 		}
 		goto tr27
 	st106:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof106
 		}
 	st_case_106:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr29
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st107
 		}
 		goto tr27
 	st107:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof107
 		}
 	st_case_107:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr29
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st108
 		}
 		goto tr27
 	st108:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof108
 		}
 	st_case_108:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr29
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st109
 		}
 		goto tr27
 	st109:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof109
 		}
 	st_case_109:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr29
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st110
 		}
 		goto tr27
 	st110:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof110
 		}
 	st_case_110:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr29
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st111
 		}
 		goto tr27
 	st111:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof111
 		}
 	st_case_111:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr29
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st112
 		}
 		goto tr27
 	st112:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof112
 		}
 	st_case_112:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr29
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st113
 		}
 		goto tr27
 	st113:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof113
 		}
 	st_case_113:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr29
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st114
 		}
 		goto tr27
 	st114:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof114
 		}
 	st_case_114:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr29
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st115
 		}
 		goto tr27
 	st115:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof115
 		}
 	st_case_115:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr29
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st116
 		}
 		goto tr27
 	st116:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof116
 		}
 	st_case_116:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr29
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st117
 		}
 		goto tr27
 	st117:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof117
 		}
 	st_case_117:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr29
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st118
 		}
 		goto tr27
 	st118:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof118
 		}
 	st_case_118:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr29
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st119
 		}
 		goto tr27
 	st119:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof119
 		}
 	st_case_119:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr29
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st120
 		}
 		goto tr27
 	st120:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof120
 		}
 	st_case_120:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr29
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st121
 		}
 		goto tr27
 	st121:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof121
 		}
 	st_case_121:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr29
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st122
 		}
 		goto tr27
 	st122:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof122
 		}
 	st_case_122:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr29
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st123
 		}
 		goto tr27
 	st123:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof123
 		}
 	st_case_123:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr29
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st124
 		}
 		goto tr27
 	st124:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof124
 		}
 	st_case_124:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr29
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st125
 		}
 		goto tr27
 	st125:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof125
 		}
 	st_case_125:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr29
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st126
 		}
 		goto tr27
 	st126:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof126
 		}
 	st_case_126:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr29
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st127
 		}
 		goto tr27
 	st127:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof127
 		}
 	st_case_127:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr29
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st128
 		}
 		goto tr27
 	st128:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof128
 		}
 	st_case_128:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr29
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st129
 		}
 		goto tr27
 	st129:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof129
 		}
 	st_case_129:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr29
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st130
 		}
 		goto tr27
 	st130:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof130
 		}
 	st_case_130:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr29
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st131
 		}
 		goto tr27
 	st131:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof131
 		}
 	st_case_131:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr29
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st132
 		}
 		goto tr27
 	st132:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof132
 		}
 	st_case_132:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr29
 		}
 		goto tr27
 	st133:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof133
 		}
 	st_case_133:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr25
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st134
 		}
 		goto tr23
 	st134:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof134
 		}
 	st_case_134:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr25
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st135
 		}
 		goto tr23
 	st135:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof135
 		}
 	st_case_135:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr25
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st136
 		}
 		goto tr23
 	st136:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof136
 		}
 	st_case_136:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr25
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st137
 		}
 		goto tr23
 	st137:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof137
 		}
 	st_case_137:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr25
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st138
 		}
 		goto tr23
 	st138:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof138
 		}
 	st_case_138:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr25
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st139
 		}
 		goto tr23
 	st139:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof139
 		}
 	st_case_139:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr25
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st140
 		}
 		goto tr23
 	st140:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof140
 		}
 	st_case_140:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr25
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st141
 		}
 		goto tr23
 	st141:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof141
 		}
 	st_case_141:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr25
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st142
 		}
 		goto tr23
 	st142:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof142
 		}
 	st_case_142:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr25
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st143
 		}
 		goto tr23
 	st143:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof143
 		}
 	st_case_143:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr25
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st144
 		}
 		goto tr23
 	st144:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof144
 		}
 	st_case_144:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr25
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st145
 		}
 		goto tr23
 	st145:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof145
 		}
 	st_case_145:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr25
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st146
 		}
 		goto tr23
 	st146:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof146
 		}
 	st_case_146:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr25
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st147
 		}
 		goto tr23
 	st147:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof147
 		}
 	st_case_147:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr25
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st148
 		}
 		goto tr23
 	st148:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof148
 		}
 	st_case_148:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr25
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st149
 		}
 		goto tr23
 	st149:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof149
 		}
 	st_case_149:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr25
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st150
 		}
 		goto tr23
 	st150:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof150
 		}
 	st_case_150:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr25
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st151
 		}
 		goto tr23
 	st151:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof151
 		}
 	st_case_151:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr25
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st152
 		}
 		goto tr23
 	st152:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof152
 		}
 	st_case_152:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr25
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st153
 		}
 		goto tr23
 	st153:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof153
 		}
 	st_case_153:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr25
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st154
 		}
 		goto tr23
 	st154:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof154
 		}
 	st_case_154:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr25
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st155
 		}
 		goto tr23
 	st155:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof155
 		}
 	st_case_155:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr25
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st156
 		}
 		goto tr23
 	st156:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof156
 		}
 	st_case_156:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr25
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st157
 		}
 		goto tr23
 	st157:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof157
 		}
 	st_case_157:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr25
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st158
 		}
 		goto tr23
 	st158:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof158
 		}
 	st_case_158:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr25
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st159
 		}
 		goto tr23
 	st159:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof159
 		}
 	st_case_159:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr25
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st160
 		}
 		goto tr23
 	st160:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof160
 		}
 	st_case_160:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr25
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st161
 		}
 		goto tr23
 	st161:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof161
 		}
 	st_case_161:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr25
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st162
 		}
 		goto tr23
 	st162:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof162
 		}
 	st_case_162:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr25
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st163
 		}
 		goto tr23
 	st163:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof163
 		}
 	st_case_163:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr25
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st164
 		}
 		goto tr23
 	st164:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof164
 		}
 	st_case_164:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr25
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st165
 		}
 		goto tr23
 	st165:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof165
 		}
 	st_case_165:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr25
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st166
 		}
 		goto tr23
 	st166:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof166
 		}
 	st_case_166:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr25
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st167
 		}
 		goto tr23
 	st167:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof167
 		}
 	st_case_167:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr25
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st168
 		}
 		goto tr23
 	st168:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof168
 		}
 	st_case_168:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr25
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st169
 		}
 		goto tr23
 	st169:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof169
 		}
 	st_case_169:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr25
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st170
 		}
 		goto tr23
 	st170:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof170
 		}
 	st_case_170:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr25
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st171
 		}
 		goto tr23
 	st171:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof171
 		}
 	st_case_171:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr25
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st172
 		}
 		goto tr23
 	st172:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof172
 		}
 	st_case_172:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr25
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st173
 		}
 		goto tr23
 	st173:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof173
 		}
 	st_case_173:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr25
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st174
 		}
 		goto tr23
 	st174:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof174
 		}
 	st_case_174:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr25
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st175
 		}
 		goto tr23
 	st175:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof175
 		}
 	st_case_175:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr25
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st176
 		}
 		goto tr23
 	st176:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof176
 		}
 	st_case_176:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr25
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st177
 		}
 		goto tr23
 	st177:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof177
 		}
 	st_case_177:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr25
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st178
 		}
 		goto tr23
 	st178:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof178
 		}
 	st_case_178:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr25
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st179
 		}
 		goto tr23
 	st179:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof179
 		}
 	st_case_179:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr25
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st180
 		}
 		goto tr23
 	st180:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof180
 		}
 	st_case_180:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr25
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st181
 		}
 		goto tr23
 	st181:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof181
 		}
 	st_case_181:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr25
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st182
 		}
 		goto tr23
 	st182:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof182
 		}
 	st_case_182:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr25
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st183
 		}
 		goto tr23
 	st183:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof183
 		}
 	st_case_183:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr25
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st184
 		}
 		goto tr23
 	st184:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof184
 		}
 	st_case_184:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr25
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st185
 		}
 		goto tr23
 	st185:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof185
 		}
 	st_case_185:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr25
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st186
 		}
 		goto tr23
 	st186:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof186
 		}
 	st_case_186:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr25
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st187
 		}
 		goto tr23
 	st187:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof187
 		}
 	st_case_187:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr25
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st188
 		}
 		goto tr23
 	st188:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof188
 		}
 	st_case_188:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr25
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st189
 		}
 		goto tr23
 	st189:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof189
 		}
 	st_case_189:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr25
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st190
 		}
 		goto tr23
 	st190:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof190
 		}
 	st_case_190:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr25
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st191
 		}
 		goto tr23
 	st191:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof191
 		}
 	st_case_191:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr25
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st192
 		}
 		goto tr23
 	st192:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof192
 		}
 	st_case_192:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr25
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st193
 		}
 		goto tr23
 	st193:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof193
 		}
 	st_case_193:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr25
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st194
 		}
 		goto tr23
 	st194:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof194
 		}
 	st_case_194:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr25
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st195
 		}
 		goto tr23
 	st195:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof195
 		}
 	st_case_195:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr25
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st196
 		}
 		goto tr23
 	st196:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof196
 		}
 	st_case_196:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr25
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st197
 		}
 		goto tr23
 	st197:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof197
 		}
 	st_case_197:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr25
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st198
 		}
 		goto tr23
 	st198:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof198
 		}
 	st_case_198:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr25
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st199
 		}
 		goto tr23
 	st199:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof199
 		}
 	st_case_199:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr25
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st200
 		}
 		goto tr23
 	st200:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof200
 		}
 	st_case_200:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr25
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st201
 		}
 		goto tr23
 	st201:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof201
 		}
 	st_case_201:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr25
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st202
 		}
 		goto tr23
 	st202:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof202
 		}
 	st_case_202:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr25
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st203
 		}
 		goto tr23
 	st203:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof203
 		}
 	st_case_203:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr25
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st204
 		}
 		goto tr23
 	st204:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof204
 		}
 	st_case_204:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr25
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st205
 		}
 		goto tr23
 	st205:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof205
 		}
 	st_case_205:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr25
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st206
 		}
 		goto tr23
 	st206:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof206
 		}
 	st_case_206:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr25
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st207
 		}
 		goto tr23
 	st207:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof207
 		}
 	st_case_207:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr25
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st208
 		}
 		goto tr23
 	st208:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof208
 		}
 	st_case_208:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr25
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st209
 		}
 		goto tr23
 	st209:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof209
 		}
 	st_case_209:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr25
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st210
 		}
 		goto tr23
 	st210:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof210
 		}
 	st_case_210:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr25
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st211
 		}
 		goto tr23
 	st211:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof211
 		}
 	st_case_211:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr25
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st212
 		}
 		goto tr23
 	st212:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof212
 		}
 	st_case_212:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr25
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st213
 		}
 		goto tr23
 	st213:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof213
 		}
 	st_case_213:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr25
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st214
 		}
 		goto tr23
 	st214:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof214
 		}
 	st_case_214:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr25
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st215
 		}
 		goto tr23
 	st215:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof215
 		}
 	st_case_215:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr25
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st216
 		}
 		goto tr23
 	st216:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof216
 		}
 	st_case_216:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr25
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st217
 		}
 		goto tr23
 	st217:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof217
 		}
 	st_case_217:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr25
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st218
 		}
 		goto tr23
 	st218:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof218
 		}
 	st_case_218:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr25
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st219
 		}
 		goto tr23
 	st219:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof219
 		}
 	st_case_219:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr25
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st220
 		}
 		goto tr23
 	st220:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof220
 		}
 	st_case_220:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr25
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st221
 		}
 		goto tr23
 	st221:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof221
 		}
 	st_case_221:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr25
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st222
 		}
 		goto tr23
 	st222:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof222
 		}
 	st_case_222:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr25
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st223
 		}
 		goto tr23
 	st223:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof223
 		}
 	st_case_223:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr25
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st224
 		}
 		goto tr23
 	st224:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof224
 		}
 	st_case_224:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr25
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st225
 		}
 		goto tr23
 	st225:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof225
 		}
 	st_case_225:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr25
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st226
 		}
 		goto tr23
 	st226:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof226
 		}
 	st_case_226:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr25
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st227
 		}
 		goto tr23
 	st227:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof227
 		}
 	st_case_227:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr25
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st228
 		}
 		goto tr23
 	st228:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof228
 		}
 	st_case_228:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr25
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st229
 		}
 		goto tr23
 	st229:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof229
 		}
 	st_case_229:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr25
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st230
 		}
 		goto tr23
 	st230:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof230
 		}
 	st_case_230:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr25
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st231
 		}
 		goto tr23
 	st231:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof231
 		}
 	st_case_231:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr25
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st232
 		}
 		goto tr23
 	st232:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof232
 		}
 	st_case_232:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr25
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st233
 		}
 		goto tr23
 	st233:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof233
 		}
 	st_case_233:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr25
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st234
 		}
 		goto tr23
 	st234:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof234
 		}
 	st_case_234:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr25
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st235
 		}
 		goto tr23
 	st235:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof235
 		}
 	st_case_235:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr25
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st236
 		}
 		goto tr23
 	st236:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof236
 		}
 	st_case_236:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr25
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st237
 		}
 		goto tr23
 	st237:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof237
 		}
 	st_case_237:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr25
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st238
 		}
 		goto tr23
 	st238:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof238
 		}
 	st_case_238:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr25
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st239
 		}
 		goto tr23
 	st239:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof239
 		}
 	st_case_239:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr25
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st240
 		}
 		goto tr23
 	st240:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof240
 		}
 	st_case_240:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr25
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st241
 		}
 		goto tr23
 	st241:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof241
 		}
 	st_case_241:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr25
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st242
 		}
 		goto tr23
 	st242:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof242
 		}
 	st_case_242:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr25
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st243
 		}
 		goto tr23
 	st243:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof243
 		}
 	st_case_243:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr25
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st244
 		}
 		goto tr23
 	st244:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof244
 		}
 	st_case_244:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr25
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st245
 		}
 		goto tr23
 	st245:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof245
 		}
 	st_case_245:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr25
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st246
 		}
 		goto tr23
 	st246:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof246
 		}
 	st_case_246:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr25
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st247
 		}
 		goto tr23
 	st247:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof247
 		}
 	st_case_247:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr25
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st248
 		}
 		goto tr23
 	st248:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof248
 		}
 	st_case_248:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr25
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st249
 		}
 		goto tr23
 	st249:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof249
 		}
 	st_case_249:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr25
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st250
 		}
 		goto tr23
 	st250:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof250
 		}
 	st_case_250:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr25
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st251
 		}
 		goto tr23
 	st251:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof251
 		}
 	st_case_251:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr25
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st252
 		}
 		goto tr23
 	st252:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof252
 		}
 	st_case_252:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr25
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st253
 		}
 		goto tr23
 	st253:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof253
 		}
 	st_case_253:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr25
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st254
 		}
 		goto tr23
 	st254:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof254
 		}
 	st_case_254:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr25
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st255
 		}
 		goto tr23
 	st255:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof255
 		}
 	st_case_255:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr25
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st256
 		}
 		goto tr23
 	st256:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof256
 		}
 	st_case_256:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr25
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st257
 		}
 		goto tr23
 	st257:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof257
 		}
 	st_case_257:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr25
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st258
 		}
 		goto tr23
 	st258:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof258
 		}
 	st_case_258:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr25
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st259
 		}
 		goto tr23
 	st259:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof259
 		}
 	st_case_259:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr25
 		}
 		goto tr23
 	st260:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof260
 		}
 	st_case_260:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr21
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st261
 		}
 		goto tr19
 	st261:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof261
 		}
 	st_case_261:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr21
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st262
 		}
 		goto tr19
 	st262:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof262
 		}
 	st_case_262:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr21
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st263
 		}
 		goto tr19
 	st263:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof263
 		}
 	st_case_263:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr21
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st264
 		}
 		goto tr19
 	st264:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof264
 		}
 	st_case_264:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr21
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st265
 		}
 		goto tr19
 	st265:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof265
 		}
 	st_case_265:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr21
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st266
 		}
 		goto tr19
 	st266:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof266
 		}
 	st_case_266:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr21
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st267
 		}
 		goto tr19
 	st267:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof267
 		}
 	st_case_267:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr21
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st268
 		}
 		goto tr19
 	st268:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof268
 		}
 	st_case_268:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr21
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st269
 		}
 		goto tr19
 	st269:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof269
 		}
 	st_case_269:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr21
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st270
 		}
 		goto tr19
 	st270:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof270
 		}
 	st_case_270:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr21
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st271
 		}
 		goto tr19
 	st271:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof271
 		}
 	st_case_271:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr21
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st272
 		}
 		goto tr19
 	st272:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof272
 		}
 	st_case_272:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr21
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st273
 		}
 		goto tr19
 	st273:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof273
 		}
 	st_case_273:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr21
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st274
 		}
 		goto tr19
 	st274:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof274
 		}
 	st_case_274:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr21
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st275
 		}
 		goto tr19
 	st275:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof275
 		}
 	st_case_275:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr21
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st276
 		}
 		goto tr19
 	st276:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof276
 		}
 	st_case_276:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr21
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st277
 		}
 		goto tr19
 	st277:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof277
 		}
 	st_case_277:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr21
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st278
 		}
 		goto tr19
 	st278:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof278
 		}
 	st_case_278:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr21
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st279
 		}
 		goto tr19
 	st279:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof279
 		}
 	st_case_279:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr21
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st280
 		}
 		goto tr19
 	st280:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof280
 		}
 	st_case_280:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr21
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st281
 		}
 		goto tr19
 	st281:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof281
 		}
 	st_case_281:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr21
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st282
 		}
 		goto tr19
 	st282:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof282
 		}
 	st_case_282:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr21
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st283
 		}
 		goto tr19
 	st283:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof283
 		}
 	st_case_283:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr21
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st284
 		}
 		goto tr19
 	st284:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof284
 		}
 	st_case_284:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr21
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st285
 		}
 		goto tr19
 	st285:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof285
 		}
 	st_case_285:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr21
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st286
 		}
 		goto tr19
 	st286:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof286
 		}
 	st_case_286:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr21
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st287
 		}
 		goto tr19
 	st287:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof287
 		}
 	st_case_287:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr21
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st288
 		}
 		goto tr19
 	st288:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof288
 		}
 	st_case_288:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr21
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st289
 		}
 		goto tr19
 	st289:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof289
 		}
 	st_case_289:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr21
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st290
 		}
 		goto tr19
 	st290:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof290
 		}
 	st_case_290:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr21
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st291
 		}
 		goto tr19
 	st291:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof291
 		}
 	st_case_291:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr21
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st292
 		}
 		goto tr19
 	st292:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof292
 		}
 	st_case_292:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr21
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st293
 		}
 		goto tr19
 	st293:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof293
 		}
 	st_case_293:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr21
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st294
 		}
 		goto tr19
 	st294:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof294
 		}
 	st_case_294:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr21
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st295
 		}
 		goto tr19
 	st295:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof295
 		}
 	st_case_295:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr21
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st296
 		}
 		goto tr19
 	st296:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof296
 		}
 	st_case_296:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr21
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st297
 		}
 		goto tr19
 	st297:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof297
 		}
 	st_case_297:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr21
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st298
 		}
 		goto tr19
 	st298:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof298
 		}
 	st_case_298:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr21
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st299
 		}
 		goto tr19
 	st299:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof299
 		}
 	st_case_299:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr21
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st300
 		}
 		goto tr19
 	st300:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof300
 		}
 	st_case_300:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr21
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st301
 		}
 		goto tr19
 	st301:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof301
 		}
 	st_case_301:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr21
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st302
 		}
 		goto tr19
 	st302:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof302
 		}
 	st_case_302:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr21
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st303
 		}
 		goto tr19
 	st303:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof303
 		}
 	st_case_303:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr21
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st304
 		}
 		goto tr19
 	st304:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof304
 		}
 	st_case_304:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr21
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st305
 		}
 		goto tr19
 	st305:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof305
 		}
 	st_case_305:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr21
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st306
 		}
 		goto tr19
 	st306:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof306
 		}
 	st_case_306:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr21
 		}
 		goto tr19
 	st307:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof307
 		}
 	st_case_307:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st308
 		}
 		goto tr15
 	st308:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof308
 		}
 	st_case_308:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st309
 		}
 		goto tr15
 	st309:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof309
 		}
 	st_case_309:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st310
 		}
 		goto tr15
 	st310:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof310
 		}
 	st_case_310:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st311
 		}
 		goto tr15
 	st311:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof311
 		}
 	st_case_311:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st312
 		}
 		goto tr15
 	st312:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof312
 		}
 	st_case_312:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st313
 		}
 		goto tr15
 	st313:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof313
 		}
 	st_case_313:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st314
 		}
 		goto tr15
 	st314:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof314
 		}
 	st_case_314:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st315
 		}
 		goto tr15
 	st315:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof315
 		}
 	st_case_315:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st316
 		}
 		goto tr15
 	st316:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof316
 		}
 	st_case_316:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st317
 		}
 		goto tr15
 	st317:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof317
 		}
 	st_case_317:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st318
 		}
 		goto tr15
 	st318:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof318
 		}
 	st_case_318:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st319
 		}
 		goto tr15
 	st319:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof319
 		}
 	st_case_319:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st320
 		}
 		goto tr15
 	st320:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof320
 		}
 	st_case_320:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st321
 		}
 		goto tr15
 	st321:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof321
 		}
 	st_case_321:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st322
 		}
 		goto tr15
 	st322:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof322
 		}
 	st_case_322:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st323
 		}
 		goto tr15
 	st323:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof323
 		}
 	st_case_323:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st324
 		}
 		goto tr15
 	st324:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof324
 		}
 	st_case_324:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st325
 		}
 		goto tr15
 	st325:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof325
 		}
 	st_case_325:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st326
 		}
 		goto tr15
 	st326:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof326
 		}
 	st_case_326:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st327
 		}
 		goto tr15
 	st327:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof327
 		}
 	st_case_327:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st328
 		}
 		goto tr15
 	st328:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof328
 		}
 	st_case_328:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st329
 		}
 		goto tr15
 	st329:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof329
 		}
 	st_case_329:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st330
 		}
 		goto tr15
 	st330:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof330
 		}
 	st_case_330:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st331
 		}
 		goto tr15
 	st331:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof331
 		}
 	st_case_331:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st332
 		}
 		goto tr15
 	st332:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof332
 		}
 	st_case_332:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st333
 		}
 		goto tr15
 	st333:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof333
 		}
 	st_case_333:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st334
 		}
 		goto tr15
 	st334:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof334
 		}
 	st_case_334:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st335
 		}
 		goto tr15
 	st335:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof335
 		}
 	st_case_335:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st336
 		}
 		goto tr15
 	st336:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof336
 		}
 	st_case_336:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st337
 		}
 		goto tr15
 	st337:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof337
 		}
 	st_case_337:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st338
 		}
 		goto tr15
 	st338:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof338
 		}
 	st_case_338:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st339
 		}
 		goto tr15
 	st339:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof339
 		}
 	st_case_339:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st340
 		}
 		goto tr15
 	st340:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof340
 		}
 	st_case_340:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st341
 		}
 		goto tr15
 	st341:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof341
 		}
 	st_case_341:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st342
 		}
 		goto tr15
 	st342:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof342
 		}
 	st_case_342:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st343
 		}
 		goto tr15
 	st343:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof343
 		}
 	st_case_343:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st344
 		}
 		goto tr15
 	st344:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof344
 		}
 	st_case_344:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st345
 		}
 		goto tr15
 	st345:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof345
 		}
 	st_case_345:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st346
 		}
 		goto tr15
 	st346:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof346
 		}
 	st_case_346:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st347
 		}
 		goto tr15
 	st347:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof347
 		}
 	st_case_347:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st348
 		}
 		goto tr15
 	st348:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof348
 		}
 	st_case_348:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st349
 		}
 		goto tr15
 	st349:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof349
 		}
 	st_case_349:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st350
 		}
 		goto tr15
 	st350:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof350
 		}
 	st_case_350:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st351
 		}
 		goto tr15
 	st351:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof351
 		}
 	st_case_351:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st352
 		}
 		goto tr15
 	st352:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof352
 		}
 	st_case_352:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st353
 		}
 		goto tr15
 	st353:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof353
 		}
 	st_case_353:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st354
 		}
 		goto tr15
 	st354:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof354
 		}
 	st_case_354:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st355
 		}
 		goto tr15
 	st355:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof355
 		}
 	st_case_355:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st356
 		}
 		goto tr15
 	st356:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof356
 		}
 	st_case_356:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st357
 		}
 		goto tr15
 	st357:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof357
 		}
 	st_case_357:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st358
 		}
 		goto tr15
 	st358:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof358
 		}
 	st_case_358:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st359
 		}
 		goto tr15
 	st359:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof359
 		}
 	st_case_359:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st360
 		}
 		goto tr15
 	st360:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof360
 		}
 	st_case_360:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st361
 		}
 		goto tr15
 	st361:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof361
 		}
 	st_case_361:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st362
 		}
 		goto tr15
 	st362:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof362
 		}
 	st_case_362:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st363
 		}
 		goto tr15
 	st363:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof363
 		}
 	st_case_363:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st364
 		}
 		goto tr15
 	st364:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof364
 		}
 	st_case_364:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st365
 		}
 		goto tr15
 	st365:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof365
 		}
 	st_case_365:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st366
 		}
 		goto tr15
 	st366:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof366
 		}
 	st_case_366:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st367
 		}
 		goto tr15
 	st367:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof367
 		}
 	st_case_367:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st368
 		}
 		goto tr15
 	st368:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof368
 		}
 	st_case_368:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st369
 		}
 		goto tr15
 	st369:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof369
 		}
 	st_case_369:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st370
 		}
 		goto tr15
 	st370:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof370
 		}
 	st_case_370:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st371
 		}
 		goto tr15
 	st371:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof371
 		}
 	st_case_371:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st372
 		}
 		goto tr15
 	st372:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof372
 		}
 	st_case_372:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st373
 		}
 		goto tr15
 	st373:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof373
 		}
 	st_case_373:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st374
 		}
 		goto tr15
 	st374:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof374
 		}
 	st_case_374:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st375
 		}
 		goto tr15
 	st375:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof375
 		}
 	st_case_375:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st376
 		}
 		goto tr15
 	st376:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof376
 		}
 	st_case_376:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st377
 		}
 		goto tr15
 	st377:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof377
 		}
 	st_case_377:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st378
 		}
 		goto tr15
 	st378:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof378
 		}
 	st_case_378:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st379
 		}
 		goto tr15
 	st379:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof379
 		}
 	st_case_379:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st380
 		}
 		goto tr15
 	st380:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof380
 		}
 	st_case_380:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st381
 		}
 		goto tr15
 	st381:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof381
 		}
 	st_case_381:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st382
 		}
 		goto tr15
 	st382:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof382
 		}
 	st_case_382:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st383
 		}
 		goto tr15
 	st383:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof383
 		}
 	st_case_383:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st384
 		}
 		goto tr15
 	st384:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof384
 		}
 	st_case_384:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st385
 		}
 		goto tr15
 	st385:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof385
 		}
 	st_case_385:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st386
 		}
 		goto tr15
 	st386:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof386
 		}
 	st_case_386:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st387
 		}
 		goto tr15
 	st387:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof387
 		}
 	st_case_387:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st388
 		}
 		goto tr15
 	st388:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof388
 		}
 	st_case_388:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st389
 		}
 		goto tr15
 	st389:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof389
 		}
 	st_case_389:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st390
 		}
 		goto tr15
 	st390:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof390
 		}
 	st_case_390:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st391
 		}
 		goto tr15
 	st391:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof391
 		}
 	st_case_391:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st392
 		}
 		goto tr15
 	st392:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof392
 		}
 	st_case_392:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st393
 		}
 		goto tr15
 	st393:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof393
 		}
 	st_case_393:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st394
 		}
 		goto tr15
 	st394:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof394
 		}
 	st_case_394:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st395
 		}
 		goto tr15
 	st395:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof395
 		}
 	st_case_395:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st396
 		}
 		goto tr15
 	st396:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof396
 		}
 	st_case_396:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st397
 		}
 		goto tr15
 	st397:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof397
 		}
 	st_case_397:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st398
 		}
 		goto tr15
 	st398:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof398
 		}
 	st_case_398:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st399
 		}
 		goto tr15
 	st399:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof399
 		}
 	st_case_399:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st400
 		}
 		goto tr15
 	st400:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof400
 		}
 	st_case_400:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st401
 		}
 		goto tr15
 	st401:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof401
 		}
 	st_case_401:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st402
 		}
 		goto tr15
 	st402:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof402
 		}
 	st_case_402:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st403
 		}
 		goto tr15
 	st403:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof403
 		}
 	st_case_403:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st404
 		}
 		goto tr15
 	st404:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof404
 		}
 	st_case_404:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st405
 		}
 		goto tr15
 	st405:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof405
 		}
 	st_case_405:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st406
 		}
 		goto tr15
 	st406:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof406
 		}
 	st_case_406:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st407
 		}
 		goto tr15
 	st407:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof407
 		}
 	st_case_407:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st408
 		}
 		goto tr15
 	st408:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof408
 		}
 	st_case_408:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st409
 		}
 		goto tr15
 	st409:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof409
 		}
 	st_case_409:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st410
 		}
 		goto tr15
 	st410:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof410
 		}
 	st_case_410:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st411
 		}
 		goto tr15
 	st411:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof411
 		}
 	st_case_411:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st412
 		}
 		goto tr15
 	st412:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof412
 		}
 	st_case_412:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st413
 		}
 		goto tr15
 	st413:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof413
 		}
 	st_case_413:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st414
 		}
 		goto tr15
 	st414:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof414
 		}
 	st_case_414:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st415
 		}
 		goto tr15
 	st415:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof415
 		}
 	st_case_415:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st416
 		}
 		goto tr15
 	st416:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof416
 		}
 	st_case_416:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st417
 		}
 		goto tr15
 	st417:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof417
 		}
 	st_case_417:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st418
 		}
 		goto tr15
 	st418:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof418
 		}
 	st_case_418:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st419
 		}
 		goto tr15
 	st419:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof419
 		}
 	st_case_419:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st420
 		}
 		goto tr15
 	st420:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof420
 		}
 	st_case_420:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st421
 		}
 		goto tr15
 	st421:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof421
 		}
 	st_case_421:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st422
 		}
 		goto tr15
 	st422:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof422
 		}
 	st_case_422:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st423
 		}
 		goto tr15
 	st423:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof423
 		}
 	st_case_423:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st424
 		}
 		goto tr15
 	st424:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof424
 		}
 	st_case_424:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st425
 		}
 		goto tr15
 	st425:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof425
 		}
 	st_case_425:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st426
 		}
 		goto tr15
 	st426:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof426
 		}
 	st_case_426:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st427
 		}
 		goto tr15
 	st427:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof427
 		}
 	st_case_427:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st428
 		}
 		goto tr15
 	st428:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof428
 		}
 	st_case_428:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st429
 		}
 		goto tr15
 	st429:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof429
 		}
 	st_case_429:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st430
 		}
 		goto tr15
 	st430:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof430
 		}
 	st_case_430:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st431
 		}
 		goto tr15
 	st431:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof431
 		}
 	st_case_431:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st432
 		}
 		goto tr15
 	st432:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof432
 		}
 	st_case_432:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st433
 		}
 		goto tr15
 	st433:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof433
 		}
 	st_case_433:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st434
 		}
 		goto tr15
 	st434:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof434
 		}
 	st_case_434:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st435
 		}
 		goto tr15
 	st435:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof435
 		}
 	st_case_435:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st436
 		}
 		goto tr15
 	st436:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof436
 		}
 	st_case_436:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st437
 		}
 		goto tr15
 	st437:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof437
 		}
 	st_case_437:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st438
 		}
 		goto tr15
 	st438:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof438
 		}
 	st_case_438:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st439
 		}
 		goto tr15
 	st439:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof439
 		}
 	st_case_439:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st440
 		}
 		goto tr15
 	st440:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof440
 		}
 	st_case_440:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st441
 		}
 		goto tr15
 	st441:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof441
 		}
 	st_case_441:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st442
 		}
 		goto tr15
 	st442:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof442
 		}
 	st_case_442:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st443
 		}
 		goto tr15
 	st443:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof443
 		}
 	st_case_443:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st444
 		}
 		goto tr15
 	st444:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof444
 		}
 	st_case_444:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st445
 		}
 		goto tr15
 	st445:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof445
 		}
 	st_case_445:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st446
 		}
 		goto tr15
 	st446:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof446
 		}
 	st_case_446:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st447
 		}
 		goto tr15
 	st447:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof447
 		}
 	st_case_447:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st448
 		}
 		goto tr15
 	st448:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof448
 		}
 	st_case_448:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st449
 		}
 		goto tr15
 	st449:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof449
 		}
 	st_case_449:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st450
 		}
 		goto tr15
 	st450:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof450
 		}
 	st_case_450:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st451
 		}
 		goto tr15
 	st451:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof451
 		}
 	st_case_451:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st452
 		}
 		goto tr15
 	st452:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof452
 		}
 	st_case_452:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st453
 		}
 		goto tr15
 	st453:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof453
 		}
 	st_case_453:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st454
 		}
 		goto tr15
 	st454:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof454
 		}
 	st_case_454:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st455
 		}
 		goto tr15
 	st455:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof455
 		}
 	st_case_455:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st456
 		}
 		goto tr15
 	st456:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof456
 		}
 	st_case_456:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st457
 		}
 		goto tr15
 	st457:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof457
 		}
 	st_case_457:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st458
 		}
 		goto tr15
 	st458:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof458
 		}
 	st_case_458:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st459
 		}
 		goto tr15
 	st459:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof459
 		}
 	st_case_459:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st460
 		}
 		goto tr15
 	st460:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof460
 		}
 	st_case_460:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st461
 		}
 		goto tr15
 	st461:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof461
 		}
 	st_case_461:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st462
 		}
 		goto tr15
 	st462:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof462
 		}
 	st_case_462:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st463
 		}
 		goto tr15
 	st463:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof463
 		}
 	st_case_463:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st464
 		}
 		goto tr15
 	st464:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof464
 		}
 	st_case_464:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st465
 		}
 		goto tr15
 	st465:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof465
 		}
 	st_case_465:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st466
 		}
 		goto tr15
 	st466:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof466
 		}
 	st_case_466:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st467
 		}
 		goto tr15
 	st467:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof467
 		}
 	st_case_467:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st468
 		}
 		goto tr15
 	st468:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof468
 		}
 	st_case_468:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st469
 		}
 		goto tr15
 	st469:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof469
 		}
 	st_case_469:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st470
 		}
 		goto tr15
 	st470:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof470
 		}
 	st_case_470:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st471
 		}
 		goto tr15
 	st471:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof471
 		}
 	st_case_471:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st472
 		}
 		goto tr15
 	st472:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof472
 		}
 	st_case_472:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st473
 		}
 		goto tr15
 	st473:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof473
 		}
 	st_case_473:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st474
 		}
 		goto tr15
 	st474:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof474
 		}
 	st_case_474:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st475
 		}
 		goto tr15
 	st475:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof475
 		}
 	st_case_475:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st476
 		}
 		goto tr15
 	st476:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof476
 		}
 	st_case_476:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st477
 		}
 		goto tr15
 	st477:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof477
 		}
 	st_case_477:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st478
 		}
 		goto tr15
 	st478:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof478
 		}
 	st_case_478:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st479
 		}
 		goto tr15
 	st479:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof479
 		}
 	st_case_479:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st480
 		}
 		goto tr15
 	st480:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof480
 		}
 	st_case_480:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st481
 		}
 		goto tr15
 	st481:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof481
 		}
 	st_case_481:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st482
 		}
 		goto tr15
 	st482:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof482
 		}
 	st_case_482:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st483
 		}
 		goto tr15
 	st483:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof483
 		}
 	st_case_483:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st484
 		}
 		goto tr15
 	st484:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof484
 		}
 	st_case_484:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st485
 		}
 		goto tr15
 	st485:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof485
 		}
 	st_case_485:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st486
 		}
 		goto tr15
 	st486:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof486
 		}
 	st_case_486:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st487
 		}
 		goto tr15
 	st487:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof487
 		}
 	st_case_487:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st488
 		}
 		goto tr15
 	st488:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof488
 		}
 	st_case_488:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st489
 		}
 		goto tr15
 	st489:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof489
 		}
 	st_case_489:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st490
 		}
 		goto tr15
 	st490:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof490
 		}
 	st_case_490:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st491
 		}
 		goto tr15
 	st491:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof491
 		}
 	st_case_491:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st492
 		}
 		goto tr15
 	st492:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof492
 		}
 	st_case_492:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st493
 		}
 		goto tr15
 	st493:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof493
 		}
 	st_case_493:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st494
 		}
 		goto tr15
 	st494:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof494
 		}
 	st_case_494:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st495
 		}
 		goto tr15
 	st495:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof495
 		}
 	st_case_495:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st496
 		}
 		goto tr15
 	st496:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof496
 		}
 	st_case_496:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st497
 		}
 		goto tr15
 	st497:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof497
 		}
 	st_case_497:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st498
 		}
 		goto tr15
 	st498:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof498
 		}
 	st_case_498:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st499
 		}
 		goto tr15
 	st499:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof499
 		}
 	st_case_499:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st500
 		}
 		goto tr15
 	st500:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof500
 		}
 	st_case_500:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st501
 		}
 		goto tr15
 	st501:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof501
 		}
 	st_case_501:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st502
 		}
 		goto tr15
 	st502:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof502
 		}
 	st_case_502:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st503
 		}
 		goto tr15
 	st503:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof503
 		}
 	st_case_503:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st504
 		}
 		goto tr15
 	st504:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof504
 		}
 	st_case_504:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st505
 		}
 		goto tr15
 	st505:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof505
 		}
 	st_case_505:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st506
 		}
 		goto tr15
 	st506:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof506
 		}
 	st_case_506:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st507
 		}
 		goto tr15
 	st507:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof507
 		}
 	st_case_507:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st508
 		}
 		goto tr15
 	st508:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof508
 		}
 	st_case_508:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st509
 		}
 		goto tr15
 	st509:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof509
 		}
 	st_case_509:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st510
 		}
 		goto tr15
 	st510:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof510
 		}
 	st_case_510:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st511
 		}
 		goto tr15
 	st511:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof511
 		}
 	st_case_511:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st512
 		}
 		goto tr15
 	st512:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof512
 		}
 	st_case_512:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st513
 		}
 		goto tr15
 	st513:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof513
 		}
 	st_case_513:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st514
 		}
 		goto tr15
 	st514:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof514
 		}
 	st_case_514:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st515
 		}
 		goto tr15
 	st515:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof515
 		}
 	st_case_515:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st516
 		}
 		goto tr15
 	st516:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof516
 		}
 	st_case_516:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st517
 		}
 		goto tr15
 	st517:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof517
 		}
 	st_case_517:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st518
 		}
 		goto tr15
 	st518:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof518
 		}
 	st_case_518:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st519
 		}
 		goto tr15
 	st519:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof519
 		}
 	st_case_519:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st520
 		}
 		goto tr15
 	st520:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof520
 		}
 	st_case_520:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st521
 		}
 		goto tr15
 	st521:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof521
 		}
 	st_case_521:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st522
 		}
 		goto tr15
 	st522:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof522
 		}
 	st_case_522:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st523
 		}
 		goto tr15
 	st523:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof523
 		}
 	st_case_523:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st524
 		}
 		goto tr15
 	st524:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof524
 		}
 	st_case_524:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st525
 		}
 		goto tr15
 	st525:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof525
 		}
 	st_case_525:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st526
 		}
 		goto tr15
 	st526:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof526
 		}
 	st_case_526:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st527
 		}
 		goto tr15
 	st527:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof527
 		}
 	st_case_527:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st528
 		}
 		goto tr15
 	st528:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof528
 		}
 	st_case_528:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st529
 		}
 		goto tr15
 	st529:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof529
 		}
 	st_case_529:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st530
 		}
 		goto tr15
 	st530:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof530
 		}
 	st_case_530:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st531
 		}
 		goto tr15
 	st531:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof531
 		}
 	st_case_531:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st532
 		}
 		goto tr15
 	st532:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof532
 		}
 	st_case_532:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st533
 		}
 		goto tr15
 	st533:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof533
 		}
 	st_case_533:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st534
 		}
 		goto tr15
 	st534:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof534
 		}
 	st_case_534:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st535
 		}
 		goto tr15
 	st535:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof535
 		}
 	st_case_535:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st536
 		}
 		goto tr15
 	st536:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof536
 		}
 	st_case_536:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st537
 		}
 		goto tr15
 	st537:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof537
 		}
 	st_case_537:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st538
 		}
 		goto tr15
 	st538:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof538
 		}
 	st_case_538:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st539
 		}
 		goto tr15
 	st539:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof539
 		}
 	st_case_539:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st540
 		}
 		goto tr15
 	st540:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof540
 		}
 	st_case_540:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st541
 		}
 		goto tr15
 	st541:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof541
 		}
 	st_case_541:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st542
 		}
 		goto tr15
 	st542:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof542
 		}
 	st_case_542:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st543
 		}
 		goto tr15
 	st543:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof543
 		}
 	st_case_543:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st544
 		}
 		goto tr15
 	st544:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof544
 		}
 	st_case_544:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st545
 		}
 		goto tr15
 	st545:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof545
 		}
 	st_case_545:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st546
 		}
 		goto tr15
 	st546:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof546
 		}
 	st_case_546:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st547
 		}
 		goto tr15
 	st547:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof547
 		}
 	st_case_547:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st548
 		}
 		goto tr15
 	st548:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof548
 		}
 	st_case_548:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st549
 		}
 		goto tr15
 	st549:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof549
 		}
 	st_case_549:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st550
 		}
 		goto tr15
 	st550:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof550
 		}
 	st_case_550:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st551
 		}
 		goto tr15
 	st551:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof551
 		}
 	st_case_551:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st552
 		}
 		goto tr15
 	st552:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof552
 		}
 	st_case_552:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st553
 		}
 		goto tr15
 	st553:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof553
 		}
 	st_case_553:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st554
 		}
 		goto tr15
 	st554:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof554
 		}
 	st_case_554:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st555
 		}
 		goto tr15
 	st555:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof555
 		}
 	st_case_555:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st556
 		}
 		goto tr15
 	st556:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof556
 		}
 	st_case_556:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st557
 		}
 		goto tr15
 	st557:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof557
 		}
 	st_case_557:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st558
 		}
 		goto tr15
 	st558:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof558
 		}
 	st_case_558:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st559
 		}
 		goto tr15
 	st559:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof559
 		}
 	st_case_559:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
-		if 33 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 126 {
+		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto st560
 		}
 		goto tr15
 	st560:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof560
 		}
 	st_case_560:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr17
 		}
 		goto tr15
-tr13:
+	tr13:
 //line rfc5424/machine.go.rl:32
+		m.pb = m.p
 
-	m.pb = m.p
-
-	goto st561
+		goto st561
 	st561:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof561
 		}
 	st_case_561:
 //line rfc5424/machine.go:9363
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+		if 48 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 57 {
 			goto st562
 		}
 		goto tr587
 	st562:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof562
 		}
 	st_case_562:
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+		if 48 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 57 {
 			goto st563
 		}
 		goto tr587
 	st563:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof563
 		}
 	st_case_563:
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+		if 48 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 57 {
 			goto st564
 		}
 		goto tr587
 	st564:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof564
 		}
 	st_case_564:
-		if ( m.data)[( m.p)] == 45 {
+		if (m.data)[(m.p)] == 45 {
 			goto st565
 		}
 		goto tr587
 	st565:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof565
 		}
 	st_case_565:
-		switch ( m.data)[( m.p)] {
+		switch (m.data)[(m.p)] {
 		case 48:
 			goto st566
 		case 49:
@@ -9404,137 +9372,137 @@ tr13:
 		}
 		goto tr587
 	st566:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof566
 		}
 	st_case_566:
-		if 49 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+		if 49 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 57 {
 			goto st567
 		}
 		goto tr587
 	st567:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof567
 		}
 	st_case_567:
-		if ( m.data)[( m.p)] == 45 {
+		if (m.data)[(m.p)] == 45 {
 			goto st568
 		}
 		goto tr587
 	st568:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof568
 		}
 	st_case_568:
-		switch ( m.data)[( m.p)] {
+		switch (m.data)[(m.p)] {
 		case 48:
 			goto st569
 		case 51:
 			goto st596
 		}
-		if 49 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 50 {
+		if 49 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 50 {
 			goto st595
 		}
 		goto tr587
 	st569:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof569
 		}
 	st_case_569:
-		if 49 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+		if 49 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 57 {
 			goto st570
 		}
 		goto tr587
 	st570:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof570
 		}
 	st_case_570:
-		if ( m.data)[( m.p)] == 84 {
+		if (m.data)[(m.p)] == 84 {
 			goto st571
 		}
 		goto tr587
 	st571:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof571
 		}
 	st_case_571:
-		if ( m.data)[( m.p)] == 50 {
+		if (m.data)[(m.p)] == 50 {
 			goto st594
 		}
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 49 {
+		if 48 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 49 {
 			goto st572
 		}
 		goto tr587
 	st572:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof572
 		}
 	st_case_572:
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+		if 48 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 57 {
 			goto st573
 		}
 		goto tr587
 	st573:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof573
 		}
 	st_case_573:
-		if ( m.data)[( m.p)] == 58 {
+		if (m.data)[(m.p)] == 58 {
 			goto st574
 		}
 		goto tr587
 	st574:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof574
 		}
 	st_case_574:
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 53 {
+		if 48 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 53 {
 			goto st575
 		}
 		goto tr587
 	st575:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof575
 		}
 	st_case_575:
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+		if 48 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 57 {
 			goto st576
 		}
 		goto tr587
 	st576:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof576
 		}
 	st_case_576:
-		if ( m.data)[( m.p)] == 58 {
+		if (m.data)[(m.p)] == 58 {
 			goto st577
 		}
 		goto tr587
 	st577:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof577
 		}
 	st_case_577:
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 53 {
+		if 48 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 53 {
 			goto st578
 		}
 		goto tr587
 	st578:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof578
 		}
 	st_case_578:
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+		if 48 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 57 {
 			goto st579
 		}
 		goto tr587
 	st579:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof579
 		}
 	st_case_579:
-		switch ( m.data)[( m.p)] {
+		switch (m.data)[(m.p)] {
 		case 43:
 			goto st580
 		case 45:
@@ -9546,86 +9514,86 @@ tr13:
 		}
 		goto tr587
 	st580:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof580
 		}
 	st_case_580:
-		if ( m.data)[( m.p)] == 50 {
+		if (m.data)[(m.p)] == 50 {
 			goto st586
 		}
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 49 {
+		if 48 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 49 {
 			goto st581
 		}
 		goto tr587
 	st581:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof581
 		}
 	st_case_581:
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+		if 48 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 57 {
 			goto st582
 		}
 		goto tr587
 	st582:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof582
 		}
 	st_case_582:
-		if ( m.data)[( m.p)] == 58 {
+		if (m.data)[(m.p)] == 58 {
 			goto st583
 		}
 		goto tr587
 	st583:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof583
 		}
 	st_case_583:
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 53 {
+		if 48 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 53 {
 			goto st584
 		}
 		goto tr587
 	st584:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof584
 		}
 	st_case_584:
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+		if 48 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 57 {
 			goto st585
 		}
 		goto tr587
 	st585:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof585
 		}
 	st_case_585:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr619
 		}
 		goto tr618
 	st586:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof586
 		}
 	st_case_586:
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 51 {
+		if 48 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 51 {
 			goto st582
 		}
 		goto tr587
 	st587:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof587
 		}
 	st_case_587:
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+		if 48 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 57 {
 			goto st588
 		}
 		goto tr587
 	st588:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof588
 		}
 	st_case_588:
-		switch ( m.data)[( m.p)] {
+		switch (m.data)[(m.p)] {
 		case 43:
 			goto st580
 		case 45:
@@ -9633,16 +9601,16 @@ tr13:
 		case 90:
 			goto st585
 		}
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+		if 48 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 57 {
 			goto st589
 		}
 		goto tr587
 	st589:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof589
 		}
 	st_case_589:
-		switch ( m.data)[( m.p)] {
+		switch (m.data)[(m.p)] {
 		case 43:
 			goto st580
 		case 45:
@@ -9650,16 +9618,16 @@ tr13:
 		case 90:
 			goto st585
 		}
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+		if 48 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 57 {
 			goto st590
 		}
 		goto tr587
 	st590:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof590
 		}
 	st_case_590:
-		switch ( m.data)[( m.p)] {
+		switch (m.data)[(m.p)] {
 		case 43:
 			goto st580
 		case 45:
@@ -9667,16 +9635,16 @@ tr13:
 		case 90:
 			goto st585
 		}
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+		if 48 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 57 {
 			goto st591
 		}
 		goto tr587
 	st591:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof591
 		}
 	st_case_591:
-		switch ( m.data)[( m.p)] {
+		switch (m.data)[(m.p)] {
 		case 43:
 			goto st580
 		case 45:
@@ -9684,16 +9652,16 @@ tr13:
 		case 90:
 			goto st585
 		}
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+		if 48 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 57 {
 			goto st592
 		}
 		goto tr587
 	st592:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof592
 		}
 	st_case_592:
-		switch ( m.data)[( m.p)] {
+		switch (m.data)[(m.p)] {
 		case 43:
 			goto st580
 		case 45:
@@ -9701,16 +9669,16 @@ tr13:
 		case 90:
 			goto st585
 		}
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+		if 48 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 57 {
 			goto st593
 		}
 		goto tr587
 	st593:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof593
 		}
 	st_case_593:
-		switch ( m.data)[( m.p)] {
+		switch (m.data)[(m.p)] {
 		case 43:
 			goto st580
 		case 45:
@@ -9720,134 +9688,129 @@ tr13:
 		}
 		goto tr587
 	st594:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof594
 		}
 	st_case_594:
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 51 {
+		if 48 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 51 {
 			goto st573
 		}
 		goto tr587
 	st595:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof595
 		}
 	st_case_595:
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+		if 48 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 57 {
 			goto st570
 		}
 		goto tr587
 	st596:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof596
 		}
 	st_case_596:
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 49 {
+		if 48 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 49 {
 			goto st570
 		}
 		goto tr587
 	st597:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof597
 		}
 	st_case_597:
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 50 {
+		if 48 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 50 {
 			goto st567
 		}
 		goto tr587
 	st598:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof598
 		}
 	st_case_598:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr9
 		}
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+		if 48 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 57 {
 			goto st599
 		}
 		goto tr7
 	st599:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof599
 		}
 	st_case_599:
-		if ( m.data)[( m.p)] == 32 {
+		if (m.data)[(m.p)] == 32 {
 			goto tr9
 		}
 		goto tr7
-tr4:
+	tr4:
 //line rfc5424/machine.go.rl:32
+		m.pb = m.p
 
-	m.pb = m.p
-
-	goto st600
+		goto st600
 	st600:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof600
 		}
 	st_case_600:
 //line rfc5424/machine.go.rl:40
-
-	m.output.SetPriority(uint8(unsafeUTF8DecimalCodePointsToInt(m.text())))
+		output.SetPriority(uint8(unsafeUTF8DecimalCodePointsToInt(m.text())))
 
 //line rfc5424/machine.go:9795
-		switch ( m.data)[( m.p)] {
+		switch (m.data)[(m.p)] {
 		case 57:
 			goto st602
 		case 62:
 			goto st4
 		}
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 56 {
+		if 48 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 56 {
 			goto st601
 		}
 		goto tr2
-tr5:
+	tr5:
 //line rfc5424/machine.go.rl:32
+		m.pb = m.p
 
-	m.pb = m.p
-
-	goto st601
+		goto st601
 	st601:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof601
 		}
 	st_case_601:
 //line rfc5424/machine.go.rl:40
-
-	m.output.SetPriority(uint8(unsafeUTF8DecimalCodePointsToInt(m.text())))
+		output.SetPriority(uint8(unsafeUTF8DecimalCodePointsToInt(m.text())))
 
 //line rfc5424/machine.go:9821
-		if ( m.data)[( m.p)] == 62 {
+		if (m.data)[(m.p)] == 62 {
 			goto st4
 		}
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+		if 48 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 57 {
 			goto st3
 		}
 		goto tr2
 	st602:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof602
 		}
 	st_case_602:
 //line rfc5424/machine.go.rl:40
-
-	m.output.SetPriority(uint8(unsafeUTF8DecimalCodePointsToInt(m.text())))
+		output.SetPriority(uint8(unsafeUTF8DecimalCodePointsToInt(m.text())))
 
 //line rfc5424/machine.go:9838
-		if ( m.data)[( m.p)] == 62 {
+		if (m.data)[(m.p)] == 62 {
 			goto st4
 		}
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 49 {
+		if 48 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 49 {
 			goto st3
 		}
 		goto tr2
 	st607:
-		if ( m.p)++; ( m.p) == ( m.pe) {
+		if (m.p)++; (m.p) == (m.pe) {
 			goto _test_eof607
 		}
 	st_case_607:
-		switch ( m.data)[( m.p)] {
+		switch (m.data)[(m.p)] {
 		case 10:
 			goto st0
 		case 13:
@@ -9855,865 +9818,2100 @@ tr5:
 		}
 		goto st607
 	st_out:
-	_test_eof2:  m.cs = 2; goto _test_eof
-	_test_eof3:  m.cs = 3; goto _test_eof
-	_test_eof4:  m.cs = 4; goto _test_eof
-	_test_eof5:  m.cs = 5; goto _test_eof
-	_test_eof6:  m.cs = 6; goto _test_eof
-	_test_eof7:  m.cs = 7; goto _test_eof
-	_test_eof8:  m.cs = 8; goto _test_eof
-	_test_eof9:  m.cs = 9; goto _test_eof
-	_test_eof10:  m.cs = 10; goto _test_eof
-	_test_eof11:  m.cs = 11; goto _test_eof
-	_test_eof12:  m.cs = 12; goto _test_eof
-	_test_eof13:  m.cs = 13; goto _test_eof
-	_test_eof14:  m.cs = 14; goto _test_eof
-	_test_eof15:  m.cs = 15; goto _test_eof
-	_test_eof16:  m.cs = 16; goto _test_eof
-	_test_eof603:  m.cs = 603; goto _test_eof
-	_test_eof604:  m.cs = 604; goto _test_eof
-	_test_eof605:  m.cs = 605; goto _test_eof
-	_test_eof17:  m.cs = 17; goto _test_eof
-	_test_eof18:  m.cs = 18; goto _test_eof
-	_test_eof19:  m.cs = 19; goto _test_eof
-	_test_eof20:  m.cs = 20; goto _test_eof
-	_test_eof21:  m.cs = 21; goto _test_eof
-	_test_eof22:  m.cs = 22; goto _test_eof
-	_test_eof23:  m.cs = 23; goto _test_eof
-	_test_eof24:  m.cs = 24; goto _test_eof
-	_test_eof25:  m.cs = 25; goto _test_eof
-	_test_eof26:  m.cs = 26; goto _test_eof
-	_test_eof27:  m.cs = 27; goto _test_eof
-	_test_eof28:  m.cs = 28; goto _test_eof
-	_test_eof29:  m.cs = 29; goto _test_eof
-	_test_eof30:  m.cs = 30; goto _test_eof
-	_test_eof31:  m.cs = 31; goto _test_eof
-	_test_eof32:  m.cs = 32; goto _test_eof
-	_test_eof33:  m.cs = 33; goto _test_eof
-	_test_eof34:  m.cs = 34; goto _test_eof
-	_test_eof35:  m.cs = 35; goto _test_eof
-	_test_eof36:  m.cs = 36; goto _test_eof
-	_test_eof37:  m.cs = 37; goto _test_eof
-	_test_eof38:  m.cs = 38; goto _test_eof
-	_test_eof39:  m.cs = 39; goto _test_eof
-	_test_eof40:  m.cs = 40; goto _test_eof
-	_test_eof41:  m.cs = 41; goto _test_eof
-	_test_eof42:  m.cs = 42; goto _test_eof
-	_test_eof43:  m.cs = 43; goto _test_eof
-	_test_eof44:  m.cs = 44; goto _test_eof
-	_test_eof45:  m.cs = 45; goto _test_eof
-	_test_eof46:  m.cs = 46; goto _test_eof
-	_test_eof47:  m.cs = 47; goto _test_eof
-	_test_eof48:  m.cs = 48; goto _test_eof
-	_test_eof49:  m.cs = 49; goto _test_eof
-	_test_eof50:  m.cs = 50; goto _test_eof
-	_test_eof51:  m.cs = 51; goto _test_eof
-	_test_eof52:  m.cs = 52; goto _test_eof
-	_test_eof53:  m.cs = 53; goto _test_eof
-	_test_eof54:  m.cs = 54; goto _test_eof
-	_test_eof55:  m.cs = 55; goto _test_eof
-	_test_eof56:  m.cs = 56; goto _test_eof
-	_test_eof57:  m.cs = 57; goto _test_eof
-	_test_eof58:  m.cs = 58; goto _test_eof
-	_test_eof59:  m.cs = 59; goto _test_eof
-	_test_eof60:  m.cs = 60; goto _test_eof
-	_test_eof61:  m.cs = 61; goto _test_eof
-	_test_eof62:  m.cs = 62; goto _test_eof
-	_test_eof606:  m.cs = 606; goto _test_eof
-	_test_eof63:  m.cs = 63; goto _test_eof
-	_test_eof64:  m.cs = 64; goto _test_eof
-	_test_eof65:  m.cs = 65; goto _test_eof
-	_test_eof66:  m.cs = 66; goto _test_eof
-	_test_eof67:  m.cs = 67; goto _test_eof
-	_test_eof68:  m.cs = 68; goto _test_eof
-	_test_eof69:  m.cs = 69; goto _test_eof
-	_test_eof70:  m.cs = 70; goto _test_eof
-	_test_eof71:  m.cs = 71; goto _test_eof
-	_test_eof72:  m.cs = 72; goto _test_eof
-	_test_eof73:  m.cs = 73; goto _test_eof
-	_test_eof74:  m.cs = 74; goto _test_eof
-	_test_eof75:  m.cs = 75; goto _test_eof
-	_test_eof76:  m.cs = 76; goto _test_eof
-	_test_eof77:  m.cs = 77; goto _test_eof
-	_test_eof78:  m.cs = 78; goto _test_eof
-	_test_eof79:  m.cs = 79; goto _test_eof
-	_test_eof80:  m.cs = 80; goto _test_eof
-	_test_eof81:  m.cs = 81; goto _test_eof
-	_test_eof82:  m.cs = 82; goto _test_eof
-	_test_eof83:  m.cs = 83; goto _test_eof
-	_test_eof84:  m.cs = 84; goto _test_eof
-	_test_eof85:  m.cs = 85; goto _test_eof
-	_test_eof86:  m.cs = 86; goto _test_eof
-	_test_eof87:  m.cs = 87; goto _test_eof
-	_test_eof88:  m.cs = 88; goto _test_eof
-	_test_eof89:  m.cs = 89; goto _test_eof
-	_test_eof90:  m.cs = 90; goto _test_eof
-	_test_eof91:  m.cs = 91; goto _test_eof
-	_test_eof92:  m.cs = 92; goto _test_eof
-	_test_eof93:  m.cs = 93; goto _test_eof
-	_test_eof94:  m.cs = 94; goto _test_eof
-	_test_eof95:  m.cs = 95; goto _test_eof
-	_test_eof96:  m.cs = 96; goto _test_eof
-	_test_eof97:  m.cs = 97; goto _test_eof
-	_test_eof98:  m.cs = 98; goto _test_eof
-	_test_eof99:  m.cs = 99; goto _test_eof
-	_test_eof100:  m.cs = 100; goto _test_eof
-	_test_eof101:  m.cs = 101; goto _test_eof
-	_test_eof102:  m.cs = 102; goto _test_eof
-	_test_eof103:  m.cs = 103; goto _test_eof
-	_test_eof104:  m.cs = 104; goto _test_eof
-	_test_eof105:  m.cs = 105; goto _test_eof
-	_test_eof106:  m.cs = 106; goto _test_eof
-	_test_eof107:  m.cs = 107; goto _test_eof
-	_test_eof108:  m.cs = 108; goto _test_eof
-	_test_eof109:  m.cs = 109; goto _test_eof
-	_test_eof110:  m.cs = 110; goto _test_eof
-	_test_eof111:  m.cs = 111; goto _test_eof
-	_test_eof112:  m.cs = 112; goto _test_eof
-	_test_eof113:  m.cs = 113; goto _test_eof
-	_test_eof114:  m.cs = 114; goto _test_eof
-	_test_eof115:  m.cs = 115; goto _test_eof
-	_test_eof116:  m.cs = 116; goto _test_eof
-	_test_eof117:  m.cs = 117; goto _test_eof
-	_test_eof118:  m.cs = 118; goto _test_eof
-	_test_eof119:  m.cs = 119; goto _test_eof
-	_test_eof120:  m.cs = 120; goto _test_eof
-	_test_eof121:  m.cs = 121; goto _test_eof
-	_test_eof122:  m.cs = 122; goto _test_eof
-	_test_eof123:  m.cs = 123; goto _test_eof
-	_test_eof124:  m.cs = 124; goto _test_eof
-	_test_eof125:  m.cs = 125; goto _test_eof
-	_test_eof126:  m.cs = 126; goto _test_eof
-	_test_eof127:  m.cs = 127; goto _test_eof
-	_test_eof128:  m.cs = 128; goto _test_eof
-	_test_eof129:  m.cs = 129; goto _test_eof
-	_test_eof130:  m.cs = 130; goto _test_eof
-	_test_eof131:  m.cs = 131; goto _test_eof
-	_test_eof132:  m.cs = 132; goto _test_eof
-	_test_eof133:  m.cs = 133; goto _test_eof
-	_test_eof134:  m.cs = 134; goto _test_eof
-	_test_eof135:  m.cs = 135; goto _test_eof
-	_test_eof136:  m.cs = 136; goto _test_eof
-	_test_eof137:  m.cs = 137; goto _test_eof
-	_test_eof138:  m.cs = 138; goto _test_eof
-	_test_eof139:  m.cs = 139; goto _test_eof
-	_test_eof140:  m.cs = 140; goto _test_eof
-	_test_eof141:  m.cs = 141; goto _test_eof
-	_test_eof142:  m.cs = 142; goto _test_eof
-	_test_eof143:  m.cs = 143; goto _test_eof
-	_test_eof144:  m.cs = 144; goto _test_eof
-	_test_eof145:  m.cs = 145; goto _test_eof
-	_test_eof146:  m.cs = 146; goto _test_eof
-	_test_eof147:  m.cs = 147; goto _test_eof
-	_test_eof148:  m.cs = 148; goto _test_eof
-	_test_eof149:  m.cs = 149; goto _test_eof
-	_test_eof150:  m.cs = 150; goto _test_eof
-	_test_eof151:  m.cs = 151; goto _test_eof
-	_test_eof152:  m.cs = 152; goto _test_eof
-	_test_eof153:  m.cs = 153; goto _test_eof
-	_test_eof154:  m.cs = 154; goto _test_eof
-	_test_eof155:  m.cs = 155; goto _test_eof
-	_test_eof156:  m.cs = 156; goto _test_eof
-	_test_eof157:  m.cs = 157; goto _test_eof
-	_test_eof158:  m.cs = 158; goto _test_eof
-	_test_eof159:  m.cs = 159; goto _test_eof
-	_test_eof160:  m.cs = 160; goto _test_eof
-	_test_eof161:  m.cs = 161; goto _test_eof
-	_test_eof162:  m.cs = 162; goto _test_eof
-	_test_eof163:  m.cs = 163; goto _test_eof
-	_test_eof164:  m.cs = 164; goto _test_eof
-	_test_eof165:  m.cs = 165; goto _test_eof
-	_test_eof166:  m.cs = 166; goto _test_eof
-	_test_eof167:  m.cs = 167; goto _test_eof
-	_test_eof168:  m.cs = 168; goto _test_eof
-	_test_eof169:  m.cs = 169; goto _test_eof
-	_test_eof170:  m.cs = 170; goto _test_eof
-	_test_eof171:  m.cs = 171; goto _test_eof
-	_test_eof172:  m.cs = 172; goto _test_eof
-	_test_eof173:  m.cs = 173; goto _test_eof
-	_test_eof174:  m.cs = 174; goto _test_eof
-	_test_eof175:  m.cs = 175; goto _test_eof
-	_test_eof176:  m.cs = 176; goto _test_eof
-	_test_eof177:  m.cs = 177; goto _test_eof
-	_test_eof178:  m.cs = 178; goto _test_eof
-	_test_eof179:  m.cs = 179; goto _test_eof
-	_test_eof180:  m.cs = 180; goto _test_eof
-	_test_eof181:  m.cs = 181; goto _test_eof
-	_test_eof182:  m.cs = 182; goto _test_eof
-	_test_eof183:  m.cs = 183; goto _test_eof
-	_test_eof184:  m.cs = 184; goto _test_eof
-	_test_eof185:  m.cs = 185; goto _test_eof
-	_test_eof186:  m.cs = 186; goto _test_eof
-	_test_eof187:  m.cs = 187; goto _test_eof
-	_test_eof188:  m.cs = 188; goto _test_eof
-	_test_eof189:  m.cs = 189; goto _test_eof
-	_test_eof190:  m.cs = 190; goto _test_eof
-	_test_eof191:  m.cs = 191; goto _test_eof
-	_test_eof192:  m.cs = 192; goto _test_eof
-	_test_eof193:  m.cs = 193; goto _test_eof
-	_test_eof194:  m.cs = 194; goto _test_eof
-	_test_eof195:  m.cs = 195; goto _test_eof
-	_test_eof196:  m.cs = 196; goto _test_eof
-	_test_eof197:  m.cs = 197; goto _test_eof
-	_test_eof198:  m.cs = 198; goto _test_eof
-	_test_eof199:  m.cs = 199; goto _test_eof
-	_test_eof200:  m.cs = 200; goto _test_eof
-	_test_eof201:  m.cs = 201; goto _test_eof
-	_test_eof202:  m.cs = 202; goto _test_eof
-	_test_eof203:  m.cs = 203; goto _test_eof
-	_test_eof204:  m.cs = 204; goto _test_eof
-	_test_eof205:  m.cs = 205; goto _test_eof
-	_test_eof206:  m.cs = 206; goto _test_eof
-	_test_eof207:  m.cs = 207; goto _test_eof
-	_test_eof208:  m.cs = 208; goto _test_eof
-	_test_eof209:  m.cs = 209; goto _test_eof
-	_test_eof210:  m.cs = 210; goto _test_eof
-	_test_eof211:  m.cs = 211; goto _test_eof
-	_test_eof212:  m.cs = 212; goto _test_eof
-	_test_eof213:  m.cs = 213; goto _test_eof
-	_test_eof214:  m.cs = 214; goto _test_eof
-	_test_eof215:  m.cs = 215; goto _test_eof
-	_test_eof216:  m.cs = 216; goto _test_eof
-	_test_eof217:  m.cs = 217; goto _test_eof
-	_test_eof218:  m.cs = 218; goto _test_eof
-	_test_eof219:  m.cs = 219; goto _test_eof
-	_test_eof220:  m.cs = 220; goto _test_eof
-	_test_eof221:  m.cs = 221; goto _test_eof
-	_test_eof222:  m.cs = 222; goto _test_eof
-	_test_eof223:  m.cs = 223; goto _test_eof
-	_test_eof224:  m.cs = 224; goto _test_eof
-	_test_eof225:  m.cs = 225; goto _test_eof
-	_test_eof226:  m.cs = 226; goto _test_eof
-	_test_eof227:  m.cs = 227; goto _test_eof
-	_test_eof228:  m.cs = 228; goto _test_eof
-	_test_eof229:  m.cs = 229; goto _test_eof
-	_test_eof230:  m.cs = 230; goto _test_eof
-	_test_eof231:  m.cs = 231; goto _test_eof
-	_test_eof232:  m.cs = 232; goto _test_eof
-	_test_eof233:  m.cs = 233; goto _test_eof
-	_test_eof234:  m.cs = 234; goto _test_eof
-	_test_eof235:  m.cs = 235; goto _test_eof
-	_test_eof236:  m.cs = 236; goto _test_eof
-	_test_eof237:  m.cs = 237; goto _test_eof
-	_test_eof238:  m.cs = 238; goto _test_eof
-	_test_eof239:  m.cs = 239; goto _test_eof
-	_test_eof240:  m.cs = 240; goto _test_eof
-	_test_eof241:  m.cs = 241; goto _test_eof
-	_test_eof242:  m.cs = 242; goto _test_eof
-	_test_eof243:  m.cs = 243; goto _test_eof
-	_test_eof244:  m.cs = 244; goto _test_eof
-	_test_eof245:  m.cs = 245; goto _test_eof
-	_test_eof246:  m.cs = 246; goto _test_eof
-	_test_eof247:  m.cs = 247; goto _test_eof
-	_test_eof248:  m.cs = 248; goto _test_eof
-	_test_eof249:  m.cs = 249; goto _test_eof
-	_test_eof250:  m.cs = 250; goto _test_eof
-	_test_eof251:  m.cs = 251; goto _test_eof
-	_test_eof252:  m.cs = 252; goto _test_eof
-	_test_eof253:  m.cs = 253; goto _test_eof
-	_test_eof254:  m.cs = 254; goto _test_eof
-	_test_eof255:  m.cs = 255; goto _test_eof
-	_test_eof256:  m.cs = 256; goto _test_eof
-	_test_eof257:  m.cs = 257; goto _test_eof
-	_test_eof258:  m.cs = 258; goto _test_eof
-	_test_eof259:  m.cs = 259; goto _test_eof
-	_test_eof260:  m.cs = 260; goto _test_eof
-	_test_eof261:  m.cs = 261; goto _test_eof
-	_test_eof262:  m.cs = 262; goto _test_eof
-	_test_eof263:  m.cs = 263; goto _test_eof
-	_test_eof264:  m.cs = 264; goto _test_eof
-	_test_eof265:  m.cs = 265; goto _test_eof
-	_test_eof266:  m.cs = 266; goto _test_eof
-	_test_eof267:  m.cs = 267; goto _test_eof
-	_test_eof268:  m.cs = 268; goto _test_eof
-	_test_eof269:  m.cs = 269; goto _test_eof
-	_test_eof270:  m.cs = 270; goto _test_eof
-	_test_eof271:  m.cs = 271; goto _test_eof
-	_test_eof272:  m.cs = 272; goto _test_eof
-	_test_eof273:  m.cs = 273; goto _test_eof
-	_test_eof274:  m.cs = 274; goto _test_eof
-	_test_eof275:  m.cs = 275; goto _test_eof
-	_test_eof276:  m.cs = 276; goto _test_eof
-	_test_eof277:  m.cs = 277; goto _test_eof
-	_test_eof278:  m.cs = 278; goto _test_eof
-	_test_eof279:  m.cs = 279; goto _test_eof
-	_test_eof280:  m.cs = 280; goto _test_eof
-	_test_eof281:  m.cs = 281; goto _test_eof
-	_test_eof282:  m.cs = 282; goto _test_eof
-	_test_eof283:  m.cs = 283; goto _test_eof
-	_test_eof284:  m.cs = 284; goto _test_eof
-	_test_eof285:  m.cs = 285; goto _test_eof
-	_test_eof286:  m.cs = 286; goto _test_eof
-	_test_eof287:  m.cs = 287; goto _test_eof
-	_test_eof288:  m.cs = 288; goto _test_eof
-	_test_eof289:  m.cs = 289; goto _test_eof
-	_test_eof290:  m.cs = 290; goto _test_eof
-	_test_eof291:  m.cs = 291; goto _test_eof
-	_test_eof292:  m.cs = 292; goto _test_eof
-	_test_eof293:  m.cs = 293; goto _test_eof
-	_test_eof294:  m.cs = 294; goto _test_eof
-	_test_eof295:  m.cs = 295; goto _test_eof
-	_test_eof296:  m.cs = 296; goto _test_eof
-	_test_eof297:  m.cs = 297; goto _test_eof
-	_test_eof298:  m.cs = 298; goto _test_eof
-	_test_eof299:  m.cs = 299; goto _test_eof
-	_test_eof300:  m.cs = 300; goto _test_eof
-	_test_eof301:  m.cs = 301; goto _test_eof
-	_test_eof302:  m.cs = 302; goto _test_eof
-	_test_eof303:  m.cs = 303; goto _test_eof
-	_test_eof304:  m.cs = 304; goto _test_eof
-	_test_eof305:  m.cs = 305; goto _test_eof
-	_test_eof306:  m.cs = 306; goto _test_eof
-	_test_eof307:  m.cs = 307; goto _test_eof
-	_test_eof308:  m.cs = 308; goto _test_eof
-	_test_eof309:  m.cs = 309; goto _test_eof
-	_test_eof310:  m.cs = 310; goto _test_eof
-	_test_eof311:  m.cs = 311; goto _test_eof
-	_test_eof312:  m.cs = 312; goto _test_eof
-	_test_eof313:  m.cs = 313; goto _test_eof
-	_test_eof314:  m.cs = 314; goto _test_eof
-	_test_eof315:  m.cs = 315; goto _test_eof
-	_test_eof316:  m.cs = 316; goto _test_eof
-	_test_eof317:  m.cs = 317; goto _test_eof
-	_test_eof318:  m.cs = 318; goto _test_eof
-	_test_eof319:  m.cs = 319; goto _test_eof
-	_test_eof320:  m.cs = 320; goto _test_eof
-	_test_eof321:  m.cs = 321; goto _test_eof
-	_test_eof322:  m.cs = 322; goto _test_eof
-	_test_eof323:  m.cs = 323; goto _test_eof
-	_test_eof324:  m.cs = 324; goto _test_eof
-	_test_eof325:  m.cs = 325; goto _test_eof
-	_test_eof326:  m.cs = 326; goto _test_eof
-	_test_eof327:  m.cs = 327; goto _test_eof
-	_test_eof328:  m.cs = 328; goto _test_eof
-	_test_eof329:  m.cs = 329; goto _test_eof
-	_test_eof330:  m.cs = 330; goto _test_eof
-	_test_eof331:  m.cs = 331; goto _test_eof
-	_test_eof332:  m.cs = 332; goto _test_eof
-	_test_eof333:  m.cs = 333; goto _test_eof
-	_test_eof334:  m.cs = 334; goto _test_eof
-	_test_eof335:  m.cs = 335; goto _test_eof
-	_test_eof336:  m.cs = 336; goto _test_eof
-	_test_eof337:  m.cs = 337; goto _test_eof
-	_test_eof338:  m.cs = 338; goto _test_eof
-	_test_eof339:  m.cs = 339; goto _test_eof
-	_test_eof340:  m.cs = 340; goto _test_eof
-	_test_eof341:  m.cs = 341; goto _test_eof
-	_test_eof342:  m.cs = 342; goto _test_eof
-	_test_eof343:  m.cs = 343; goto _test_eof
-	_test_eof344:  m.cs = 344; goto _test_eof
-	_test_eof345:  m.cs = 345; goto _test_eof
-	_test_eof346:  m.cs = 346; goto _test_eof
-	_test_eof347:  m.cs = 347; goto _test_eof
-	_test_eof348:  m.cs = 348; goto _test_eof
-	_test_eof349:  m.cs = 349; goto _test_eof
-	_test_eof350:  m.cs = 350; goto _test_eof
-	_test_eof351:  m.cs = 351; goto _test_eof
-	_test_eof352:  m.cs = 352; goto _test_eof
-	_test_eof353:  m.cs = 353; goto _test_eof
-	_test_eof354:  m.cs = 354; goto _test_eof
-	_test_eof355:  m.cs = 355; goto _test_eof
-	_test_eof356:  m.cs = 356; goto _test_eof
-	_test_eof357:  m.cs = 357; goto _test_eof
-	_test_eof358:  m.cs = 358; goto _test_eof
-	_test_eof359:  m.cs = 359; goto _test_eof
-	_test_eof360:  m.cs = 360; goto _test_eof
-	_test_eof361:  m.cs = 361; goto _test_eof
-	_test_eof362:  m.cs = 362; goto _test_eof
-	_test_eof363:  m.cs = 363; goto _test_eof
-	_test_eof364:  m.cs = 364; goto _test_eof
-	_test_eof365:  m.cs = 365; goto _test_eof
-	_test_eof366:  m.cs = 366; goto _test_eof
-	_test_eof367:  m.cs = 367; goto _test_eof
-	_test_eof368:  m.cs = 368; goto _test_eof
-	_test_eof369:  m.cs = 369; goto _test_eof
-	_test_eof370:  m.cs = 370; goto _test_eof
-	_test_eof371:  m.cs = 371; goto _test_eof
-	_test_eof372:  m.cs = 372; goto _test_eof
-	_test_eof373:  m.cs = 373; goto _test_eof
-	_test_eof374:  m.cs = 374; goto _test_eof
-	_test_eof375:  m.cs = 375; goto _test_eof
-	_test_eof376:  m.cs = 376; goto _test_eof
-	_test_eof377:  m.cs = 377; goto _test_eof
-	_test_eof378:  m.cs = 378; goto _test_eof
-	_test_eof379:  m.cs = 379; goto _test_eof
-	_test_eof380:  m.cs = 380; goto _test_eof
-	_test_eof381:  m.cs = 381; goto _test_eof
-	_test_eof382:  m.cs = 382; goto _test_eof
-	_test_eof383:  m.cs = 383; goto _test_eof
-	_test_eof384:  m.cs = 384; goto _test_eof
-	_test_eof385:  m.cs = 385; goto _test_eof
-	_test_eof386:  m.cs = 386; goto _test_eof
-	_test_eof387:  m.cs = 387; goto _test_eof
-	_test_eof388:  m.cs = 388; goto _test_eof
-	_test_eof389:  m.cs = 389; goto _test_eof
-	_test_eof390:  m.cs = 390; goto _test_eof
-	_test_eof391:  m.cs = 391; goto _test_eof
-	_test_eof392:  m.cs = 392; goto _test_eof
-	_test_eof393:  m.cs = 393; goto _test_eof
-	_test_eof394:  m.cs = 394; goto _test_eof
-	_test_eof395:  m.cs = 395; goto _test_eof
-	_test_eof396:  m.cs = 396; goto _test_eof
-	_test_eof397:  m.cs = 397; goto _test_eof
-	_test_eof398:  m.cs = 398; goto _test_eof
-	_test_eof399:  m.cs = 399; goto _test_eof
-	_test_eof400:  m.cs = 400; goto _test_eof
-	_test_eof401:  m.cs = 401; goto _test_eof
-	_test_eof402:  m.cs = 402; goto _test_eof
-	_test_eof403:  m.cs = 403; goto _test_eof
-	_test_eof404:  m.cs = 404; goto _test_eof
-	_test_eof405:  m.cs = 405; goto _test_eof
-	_test_eof406:  m.cs = 406; goto _test_eof
-	_test_eof407:  m.cs = 407; goto _test_eof
-	_test_eof408:  m.cs = 408; goto _test_eof
-	_test_eof409:  m.cs = 409; goto _test_eof
-	_test_eof410:  m.cs = 410; goto _test_eof
-	_test_eof411:  m.cs = 411; goto _test_eof
-	_test_eof412:  m.cs = 412; goto _test_eof
-	_test_eof413:  m.cs = 413; goto _test_eof
-	_test_eof414:  m.cs = 414; goto _test_eof
-	_test_eof415:  m.cs = 415; goto _test_eof
-	_test_eof416:  m.cs = 416; goto _test_eof
-	_test_eof417:  m.cs = 417; goto _test_eof
-	_test_eof418:  m.cs = 418; goto _test_eof
-	_test_eof419:  m.cs = 419; goto _test_eof
-	_test_eof420:  m.cs = 420; goto _test_eof
-	_test_eof421:  m.cs = 421; goto _test_eof
-	_test_eof422:  m.cs = 422; goto _test_eof
-	_test_eof423:  m.cs = 423; goto _test_eof
-	_test_eof424:  m.cs = 424; goto _test_eof
-	_test_eof425:  m.cs = 425; goto _test_eof
-	_test_eof426:  m.cs = 426; goto _test_eof
-	_test_eof427:  m.cs = 427; goto _test_eof
-	_test_eof428:  m.cs = 428; goto _test_eof
-	_test_eof429:  m.cs = 429; goto _test_eof
-	_test_eof430:  m.cs = 430; goto _test_eof
-	_test_eof431:  m.cs = 431; goto _test_eof
-	_test_eof432:  m.cs = 432; goto _test_eof
-	_test_eof433:  m.cs = 433; goto _test_eof
-	_test_eof434:  m.cs = 434; goto _test_eof
-	_test_eof435:  m.cs = 435; goto _test_eof
-	_test_eof436:  m.cs = 436; goto _test_eof
-	_test_eof437:  m.cs = 437; goto _test_eof
-	_test_eof438:  m.cs = 438; goto _test_eof
-	_test_eof439:  m.cs = 439; goto _test_eof
-	_test_eof440:  m.cs = 440; goto _test_eof
-	_test_eof441:  m.cs = 441; goto _test_eof
-	_test_eof442:  m.cs = 442; goto _test_eof
-	_test_eof443:  m.cs = 443; goto _test_eof
-	_test_eof444:  m.cs = 444; goto _test_eof
-	_test_eof445:  m.cs = 445; goto _test_eof
-	_test_eof446:  m.cs = 446; goto _test_eof
-	_test_eof447:  m.cs = 447; goto _test_eof
-	_test_eof448:  m.cs = 448; goto _test_eof
-	_test_eof449:  m.cs = 449; goto _test_eof
-	_test_eof450:  m.cs = 450; goto _test_eof
-	_test_eof451:  m.cs = 451; goto _test_eof
-	_test_eof452:  m.cs = 452; goto _test_eof
-	_test_eof453:  m.cs = 453; goto _test_eof
-	_test_eof454:  m.cs = 454; goto _test_eof
-	_test_eof455:  m.cs = 455; goto _test_eof
-	_test_eof456:  m.cs = 456; goto _test_eof
-	_test_eof457:  m.cs = 457; goto _test_eof
-	_test_eof458:  m.cs = 458; goto _test_eof
-	_test_eof459:  m.cs = 459; goto _test_eof
-	_test_eof460:  m.cs = 460; goto _test_eof
-	_test_eof461:  m.cs = 461; goto _test_eof
-	_test_eof462:  m.cs = 462; goto _test_eof
-	_test_eof463:  m.cs = 463; goto _test_eof
-	_test_eof464:  m.cs = 464; goto _test_eof
-	_test_eof465:  m.cs = 465; goto _test_eof
-	_test_eof466:  m.cs = 466; goto _test_eof
-	_test_eof467:  m.cs = 467; goto _test_eof
-	_test_eof468:  m.cs = 468; goto _test_eof
-	_test_eof469:  m.cs = 469; goto _test_eof
-	_test_eof470:  m.cs = 470; goto _test_eof
-	_test_eof471:  m.cs = 471; goto _test_eof
-	_test_eof472:  m.cs = 472; goto _test_eof
-	_test_eof473:  m.cs = 473; goto _test_eof
-	_test_eof474:  m.cs = 474; goto _test_eof
-	_test_eof475:  m.cs = 475; goto _test_eof
-	_test_eof476:  m.cs = 476; goto _test_eof
-	_test_eof477:  m.cs = 477; goto _test_eof
-	_test_eof478:  m.cs = 478; goto _test_eof
-	_test_eof479:  m.cs = 479; goto _test_eof
-	_test_eof480:  m.cs = 480; goto _test_eof
-	_test_eof481:  m.cs = 481; goto _test_eof
-	_test_eof482:  m.cs = 482; goto _test_eof
-	_test_eof483:  m.cs = 483; goto _test_eof
-	_test_eof484:  m.cs = 484; goto _test_eof
-	_test_eof485:  m.cs = 485; goto _test_eof
-	_test_eof486:  m.cs = 486; goto _test_eof
-	_test_eof487:  m.cs = 487; goto _test_eof
-	_test_eof488:  m.cs = 488; goto _test_eof
-	_test_eof489:  m.cs = 489; goto _test_eof
-	_test_eof490:  m.cs = 490; goto _test_eof
-	_test_eof491:  m.cs = 491; goto _test_eof
-	_test_eof492:  m.cs = 492; goto _test_eof
-	_test_eof493:  m.cs = 493; goto _test_eof
-	_test_eof494:  m.cs = 494; goto _test_eof
-	_test_eof495:  m.cs = 495; goto _test_eof
-	_test_eof496:  m.cs = 496; goto _test_eof
-	_test_eof497:  m.cs = 497; goto _test_eof
-	_test_eof498:  m.cs = 498; goto _test_eof
-	_test_eof499:  m.cs = 499; goto _test_eof
-	_test_eof500:  m.cs = 500; goto _test_eof
-	_test_eof501:  m.cs = 501; goto _test_eof
-	_test_eof502:  m.cs = 502; goto _test_eof
-	_test_eof503:  m.cs = 503; goto _test_eof
-	_test_eof504:  m.cs = 504; goto _test_eof
-	_test_eof505:  m.cs = 505; goto _test_eof
-	_test_eof506:  m.cs = 506; goto _test_eof
-	_test_eof507:  m.cs = 507; goto _test_eof
-	_test_eof508:  m.cs = 508; goto _test_eof
-	_test_eof509:  m.cs = 509; goto _test_eof
-	_test_eof510:  m.cs = 510; goto _test_eof
-	_test_eof511:  m.cs = 511; goto _test_eof
-	_test_eof512:  m.cs = 512; goto _test_eof
-	_test_eof513:  m.cs = 513; goto _test_eof
-	_test_eof514:  m.cs = 514; goto _test_eof
-	_test_eof515:  m.cs = 515; goto _test_eof
-	_test_eof516:  m.cs = 516; goto _test_eof
-	_test_eof517:  m.cs = 517; goto _test_eof
-	_test_eof518:  m.cs = 518; goto _test_eof
-	_test_eof519:  m.cs = 519; goto _test_eof
-	_test_eof520:  m.cs = 520; goto _test_eof
-	_test_eof521:  m.cs = 521; goto _test_eof
-	_test_eof522:  m.cs = 522; goto _test_eof
-	_test_eof523:  m.cs = 523; goto _test_eof
-	_test_eof524:  m.cs = 524; goto _test_eof
-	_test_eof525:  m.cs = 525; goto _test_eof
-	_test_eof526:  m.cs = 526; goto _test_eof
-	_test_eof527:  m.cs = 527; goto _test_eof
-	_test_eof528:  m.cs = 528; goto _test_eof
-	_test_eof529:  m.cs = 529; goto _test_eof
-	_test_eof530:  m.cs = 530; goto _test_eof
-	_test_eof531:  m.cs = 531; goto _test_eof
-	_test_eof532:  m.cs = 532; goto _test_eof
-	_test_eof533:  m.cs = 533; goto _test_eof
-	_test_eof534:  m.cs = 534; goto _test_eof
-	_test_eof535:  m.cs = 535; goto _test_eof
-	_test_eof536:  m.cs = 536; goto _test_eof
-	_test_eof537:  m.cs = 537; goto _test_eof
-	_test_eof538:  m.cs = 538; goto _test_eof
-	_test_eof539:  m.cs = 539; goto _test_eof
-	_test_eof540:  m.cs = 540; goto _test_eof
-	_test_eof541:  m.cs = 541; goto _test_eof
-	_test_eof542:  m.cs = 542; goto _test_eof
-	_test_eof543:  m.cs = 543; goto _test_eof
-	_test_eof544:  m.cs = 544; goto _test_eof
-	_test_eof545:  m.cs = 545; goto _test_eof
-	_test_eof546:  m.cs = 546; goto _test_eof
-	_test_eof547:  m.cs = 547; goto _test_eof
-	_test_eof548:  m.cs = 548; goto _test_eof
-	_test_eof549:  m.cs = 549; goto _test_eof
-	_test_eof550:  m.cs = 550; goto _test_eof
-	_test_eof551:  m.cs = 551; goto _test_eof
-	_test_eof552:  m.cs = 552; goto _test_eof
-	_test_eof553:  m.cs = 553; goto _test_eof
-	_test_eof554:  m.cs = 554; goto _test_eof
-	_test_eof555:  m.cs = 555; goto _test_eof
-	_test_eof556:  m.cs = 556; goto _test_eof
-	_test_eof557:  m.cs = 557; goto _test_eof
-	_test_eof558:  m.cs = 558; goto _test_eof
-	_test_eof559:  m.cs = 559; goto _test_eof
-	_test_eof560:  m.cs = 560; goto _test_eof
-	_test_eof561:  m.cs = 561; goto _test_eof
-	_test_eof562:  m.cs = 562; goto _test_eof
-	_test_eof563:  m.cs = 563; goto _test_eof
-	_test_eof564:  m.cs = 564; goto _test_eof
-	_test_eof565:  m.cs = 565; goto _test_eof
-	_test_eof566:  m.cs = 566; goto _test_eof
-	_test_eof567:  m.cs = 567; goto _test_eof
-	_test_eof568:  m.cs = 568; goto _test_eof
-	_test_eof569:  m.cs = 569; goto _test_eof
-	_test_eof570:  m.cs = 570; goto _test_eof
-	_test_eof571:  m.cs = 571; goto _test_eof
-	_test_eof572:  m.cs = 572; goto _test_eof
-	_test_eof573:  m.cs = 573; goto _test_eof
-	_test_eof574:  m.cs = 574; goto _test_eof
-	_test_eof575:  m.cs = 575; goto _test_eof
-	_test_eof576:  m.cs = 576; goto _test_eof
-	_test_eof577:  m.cs = 577; goto _test_eof
-	_test_eof578:  m.cs = 578; goto _test_eof
-	_test_eof579:  m.cs = 579; goto _test_eof
-	_test_eof580:  m.cs = 580; goto _test_eof
-	_test_eof581:  m.cs = 581; goto _test_eof
-	_test_eof582:  m.cs = 582; goto _test_eof
-	_test_eof583:  m.cs = 583; goto _test_eof
-	_test_eof584:  m.cs = 584; goto _test_eof
-	_test_eof585:  m.cs = 585; goto _test_eof
-	_test_eof586:  m.cs = 586; goto _test_eof
-	_test_eof587:  m.cs = 587; goto _test_eof
-	_test_eof588:  m.cs = 588; goto _test_eof
-	_test_eof589:  m.cs = 589; goto _test_eof
-	_test_eof590:  m.cs = 590; goto _test_eof
-	_test_eof591:  m.cs = 591; goto _test_eof
-	_test_eof592:  m.cs = 592; goto _test_eof
-	_test_eof593:  m.cs = 593; goto _test_eof
-	_test_eof594:  m.cs = 594; goto _test_eof
-	_test_eof595:  m.cs = 595; goto _test_eof
-	_test_eof596:  m.cs = 596; goto _test_eof
-	_test_eof597:  m.cs = 597; goto _test_eof
-	_test_eof598:  m.cs = 598; goto _test_eof
-	_test_eof599:  m.cs = 599; goto _test_eof
-	_test_eof600:  m.cs = 600; goto _test_eof
-	_test_eof601:  m.cs = 601; goto _test_eof
-	_test_eof602:  m.cs = 602; goto _test_eof
-	_test_eof607:  m.cs = 607; goto _test_eof
+	_test_eof2:
+		m.cs = 2
+		goto _test_eof
+	_test_eof3:
+		m.cs = 3
+		goto _test_eof
+	_test_eof4:
+		m.cs = 4
+		goto _test_eof
+	_test_eof5:
+		m.cs = 5
+		goto _test_eof
+	_test_eof6:
+		m.cs = 6
+		goto _test_eof
+	_test_eof7:
+		m.cs = 7
+		goto _test_eof
+	_test_eof8:
+		m.cs = 8
+		goto _test_eof
+	_test_eof9:
+		m.cs = 9
+		goto _test_eof
+	_test_eof10:
+		m.cs = 10
+		goto _test_eof
+	_test_eof11:
+		m.cs = 11
+		goto _test_eof
+	_test_eof12:
+		m.cs = 12
+		goto _test_eof
+	_test_eof13:
+		m.cs = 13
+		goto _test_eof
+	_test_eof14:
+		m.cs = 14
+		goto _test_eof
+	_test_eof15:
+		m.cs = 15
+		goto _test_eof
+	_test_eof16:
+		m.cs = 16
+		goto _test_eof
+	_test_eof603:
+		m.cs = 603
+		goto _test_eof
+	_test_eof604:
+		m.cs = 604
+		goto _test_eof
+	_test_eof605:
+		m.cs = 605
+		goto _test_eof
+	_test_eof17:
+		m.cs = 17
+		goto _test_eof
+	_test_eof18:
+		m.cs = 18
+		goto _test_eof
+	_test_eof19:
+		m.cs = 19
+		goto _test_eof
+	_test_eof20:
+		m.cs = 20
+		goto _test_eof
+	_test_eof21:
+		m.cs = 21
+		goto _test_eof
+	_test_eof22:
+		m.cs = 22
+		goto _test_eof
+	_test_eof23:
+		m.cs = 23
+		goto _test_eof
+	_test_eof24:
+		m.cs = 24
+		goto _test_eof
+	_test_eof25:
+		m.cs = 25
+		goto _test_eof
+	_test_eof26:
+		m.cs = 26
+		goto _test_eof
+	_test_eof27:
+		m.cs = 27
+		goto _test_eof
+	_test_eof28:
+		m.cs = 28
+		goto _test_eof
+	_test_eof29:
+		m.cs = 29
+		goto _test_eof
+	_test_eof30:
+		m.cs = 30
+		goto _test_eof
+	_test_eof31:
+		m.cs = 31
+		goto _test_eof
+	_test_eof32:
+		m.cs = 32
+		goto _test_eof
+	_test_eof33:
+		m.cs = 33
+		goto _test_eof
+	_test_eof34:
+		m.cs = 34
+		goto _test_eof
+	_test_eof35:
+		m.cs = 35
+		goto _test_eof
+	_test_eof36:
+		m.cs = 36
+		goto _test_eof
+	_test_eof37:
+		m.cs = 37
+		goto _test_eof
+	_test_eof38:
+		m.cs = 38
+		goto _test_eof
+	_test_eof39:
+		m.cs = 39
+		goto _test_eof
+	_test_eof40:
+		m.cs = 40
+		goto _test_eof
+	_test_eof41:
+		m.cs = 41
+		goto _test_eof
+	_test_eof42:
+		m.cs = 42
+		goto _test_eof
+	_test_eof43:
+		m.cs = 43
+		goto _test_eof
+	_test_eof44:
+		m.cs = 44
+		goto _test_eof
+	_test_eof45:
+		m.cs = 45
+		goto _test_eof
+	_test_eof46:
+		m.cs = 46
+		goto _test_eof
+	_test_eof47:
+		m.cs = 47
+		goto _test_eof
+	_test_eof48:
+		m.cs = 48
+		goto _test_eof
+	_test_eof49:
+		m.cs = 49
+		goto _test_eof
+	_test_eof50:
+		m.cs = 50
+		goto _test_eof
+	_test_eof51:
+		m.cs = 51
+		goto _test_eof
+	_test_eof52:
+		m.cs = 52
+		goto _test_eof
+	_test_eof53:
+		m.cs = 53
+		goto _test_eof
+	_test_eof54:
+		m.cs = 54
+		goto _test_eof
+	_test_eof55:
+		m.cs = 55
+		goto _test_eof
+	_test_eof56:
+		m.cs = 56
+		goto _test_eof
+	_test_eof57:
+		m.cs = 57
+		goto _test_eof
+	_test_eof58:
+		m.cs = 58
+		goto _test_eof
+	_test_eof59:
+		m.cs = 59
+		goto _test_eof
+	_test_eof60:
+		m.cs = 60
+		goto _test_eof
+	_test_eof61:
+		m.cs = 61
+		goto _test_eof
+	_test_eof62:
+		m.cs = 62
+		goto _test_eof
+	_test_eof606:
+		m.cs = 606
+		goto _test_eof
+	_test_eof63:
+		m.cs = 63
+		goto _test_eof
+	_test_eof64:
+		m.cs = 64
+		goto _test_eof
+	_test_eof65:
+		m.cs = 65
+		goto _test_eof
+	_test_eof66:
+		m.cs = 66
+		goto _test_eof
+	_test_eof67:
+		m.cs = 67
+		goto _test_eof
+	_test_eof68:
+		m.cs = 68
+		goto _test_eof
+	_test_eof69:
+		m.cs = 69
+		goto _test_eof
+	_test_eof70:
+		m.cs = 70
+		goto _test_eof
+	_test_eof71:
+		m.cs = 71
+		goto _test_eof
+	_test_eof72:
+		m.cs = 72
+		goto _test_eof
+	_test_eof73:
+		m.cs = 73
+		goto _test_eof
+	_test_eof74:
+		m.cs = 74
+		goto _test_eof
+	_test_eof75:
+		m.cs = 75
+		goto _test_eof
+	_test_eof76:
+		m.cs = 76
+		goto _test_eof
+	_test_eof77:
+		m.cs = 77
+		goto _test_eof
+	_test_eof78:
+		m.cs = 78
+		goto _test_eof
+	_test_eof79:
+		m.cs = 79
+		goto _test_eof
+	_test_eof80:
+		m.cs = 80
+		goto _test_eof
+	_test_eof81:
+		m.cs = 81
+		goto _test_eof
+	_test_eof82:
+		m.cs = 82
+		goto _test_eof
+	_test_eof83:
+		m.cs = 83
+		goto _test_eof
+	_test_eof84:
+		m.cs = 84
+		goto _test_eof
+	_test_eof85:
+		m.cs = 85
+		goto _test_eof
+	_test_eof86:
+		m.cs = 86
+		goto _test_eof
+	_test_eof87:
+		m.cs = 87
+		goto _test_eof
+	_test_eof88:
+		m.cs = 88
+		goto _test_eof
+	_test_eof89:
+		m.cs = 89
+		goto _test_eof
+	_test_eof90:
+		m.cs = 90
+		goto _test_eof
+	_test_eof91:
+		m.cs = 91
+		goto _test_eof
+	_test_eof92:
+		m.cs = 92
+		goto _test_eof
+	_test_eof93:
+		m.cs = 93
+		goto _test_eof
+	_test_eof94:
+		m.cs = 94
+		goto _test_eof
+	_test_eof95:
+		m.cs = 95
+		goto _test_eof
+	_test_eof96:
+		m.cs = 96
+		goto _test_eof
+	_test_eof97:
+		m.cs = 97
+		goto _test_eof
+	_test_eof98:
+		m.cs = 98
+		goto _test_eof
+	_test_eof99:
+		m.cs = 99
+		goto _test_eof
+	_test_eof100:
+		m.cs = 100
+		goto _test_eof
+	_test_eof101:
+		m.cs = 101
+		goto _test_eof
+	_test_eof102:
+		m.cs = 102
+		goto _test_eof
+	_test_eof103:
+		m.cs = 103
+		goto _test_eof
+	_test_eof104:
+		m.cs = 104
+		goto _test_eof
+	_test_eof105:
+		m.cs = 105
+		goto _test_eof
+	_test_eof106:
+		m.cs = 106
+		goto _test_eof
+	_test_eof107:
+		m.cs = 107
+		goto _test_eof
+	_test_eof108:
+		m.cs = 108
+		goto _test_eof
+	_test_eof109:
+		m.cs = 109
+		goto _test_eof
+	_test_eof110:
+		m.cs = 110
+		goto _test_eof
+	_test_eof111:
+		m.cs = 111
+		goto _test_eof
+	_test_eof112:
+		m.cs = 112
+		goto _test_eof
+	_test_eof113:
+		m.cs = 113
+		goto _test_eof
+	_test_eof114:
+		m.cs = 114
+		goto _test_eof
+	_test_eof115:
+		m.cs = 115
+		goto _test_eof
+	_test_eof116:
+		m.cs = 116
+		goto _test_eof
+	_test_eof117:
+		m.cs = 117
+		goto _test_eof
+	_test_eof118:
+		m.cs = 118
+		goto _test_eof
+	_test_eof119:
+		m.cs = 119
+		goto _test_eof
+	_test_eof120:
+		m.cs = 120
+		goto _test_eof
+	_test_eof121:
+		m.cs = 121
+		goto _test_eof
+	_test_eof122:
+		m.cs = 122
+		goto _test_eof
+	_test_eof123:
+		m.cs = 123
+		goto _test_eof
+	_test_eof124:
+		m.cs = 124
+		goto _test_eof
+	_test_eof125:
+		m.cs = 125
+		goto _test_eof
+	_test_eof126:
+		m.cs = 126
+		goto _test_eof
+	_test_eof127:
+		m.cs = 127
+		goto _test_eof
+	_test_eof128:
+		m.cs = 128
+		goto _test_eof
+	_test_eof129:
+		m.cs = 129
+		goto _test_eof
+	_test_eof130:
+		m.cs = 130
+		goto _test_eof
+	_test_eof131:
+		m.cs = 131
+		goto _test_eof
+	_test_eof132:
+		m.cs = 132
+		goto _test_eof
+	_test_eof133:
+		m.cs = 133
+		goto _test_eof
+	_test_eof134:
+		m.cs = 134
+		goto _test_eof
+	_test_eof135:
+		m.cs = 135
+		goto _test_eof
+	_test_eof136:
+		m.cs = 136
+		goto _test_eof
+	_test_eof137:
+		m.cs = 137
+		goto _test_eof
+	_test_eof138:
+		m.cs = 138
+		goto _test_eof
+	_test_eof139:
+		m.cs = 139
+		goto _test_eof
+	_test_eof140:
+		m.cs = 140
+		goto _test_eof
+	_test_eof141:
+		m.cs = 141
+		goto _test_eof
+	_test_eof142:
+		m.cs = 142
+		goto _test_eof
+	_test_eof143:
+		m.cs = 143
+		goto _test_eof
+	_test_eof144:
+		m.cs = 144
+		goto _test_eof
+	_test_eof145:
+		m.cs = 145
+		goto _test_eof
+	_test_eof146:
+		m.cs = 146
+		goto _test_eof
+	_test_eof147:
+		m.cs = 147
+		goto _test_eof
+	_test_eof148:
+		m.cs = 148
+		goto _test_eof
+	_test_eof149:
+		m.cs = 149
+		goto _test_eof
+	_test_eof150:
+		m.cs = 150
+		goto _test_eof
+	_test_eof151:
+		m.cs = 151
+		goto _test_eof
+	_test_eof152:
+		m.cs = 152
+		goto _test_eof
+	_test_eof153:
+		m.cs = 153
+		goto _test_eof
+	_test_eof154:
+		m.cs = 154
+		goto _test_eof
+	_test_eof155:
+		m.cs = 155
+		goto _test_eof
+	_test_eof156:
+		m.cs = 156
+		goto _test_eof
+	_test_eof157:
+		m.cs = 157
+		goto _test_eof
+	_test_eof158:
+		m.cs = 158
+		goto _test_eof
+	_test_eof159:
+		m.cs = 159
+		goto _test_eof
+	_test_eof160:
+		m.cs = 160
+		goto _test_eof
+	_test_eof161:
+		m.cs = 161
+		goto _test_eof
+	_test_eof162:
+		m.cs = 162
+		goto _test_eof
+	_test_eof163:
+		m.cs = 163
+		goto _test_eof
+	_test_eof164:
+		m.cs = 164
+		goto _test_eof
+	_test_eof165:
+		m.cs = 165
+		goto _test_eof
+	_test_eof166:
+		m.cs = 166
+		goto _test_eof
+	_test_eof167:
+		m.cs = 167
+		goto _test_eof
+	_test_eof168:
+		m.cs = 168
+		goto _test_eof
+	_test_eof169:
+		m.cs = 169
+		goto _test_eof
+	_test_eof170:
+		m.cs = 170
+		goto _test_eof
+	_test_eof171:
+		m.cs = 171
+		goto _test_eof
+	_test_eof172:
+		m.cs = 172
+		goto _test_eof
+	_test_eof173:
+		m.cs = 173
+		goto _test_eof
+	_test_eof174:
+		m.cs = 174
+		goto _test_eof
+	_test_eof175:
+		m.cs = 175
+		goto _test_eof
+	_test_eof176:
+		m.cs = 176
+		goto _test_eof
+	_test_eof177:
+		m.cs = 177
+		goto _test_eof
+	_test_eof178:
+		m.cs = 178
+		goto _test_eof
+	_test_eof179:
+		m.cs = 179
+		goto _test_eof
+	_test_eof180:
+		m.cs = 180
+		goto _test_eof
+	_test_eof181:
+		m.cs = 181
+		goto _test_eof
+	_test_eof182:
+		m.cs = 182
+		goto _test_eof
+	_test_eof183:
+		m.cs = 183
+		goto _test_eof
+	_test_eof184:
+		m.cs = 184
+		goto _test_eof
+	_test_eof185:
+		m.cs = 185
+		goto _test_eof
+	_test_eof186:
+		m.cs = 186
+		goto _test_eof
+	_test_eof187:
+		m.cs = 187
+		goto _test_eof
+	_test_eof188:
+		m.cs = 188
+		goto _test_eof
+	_test_eof189:
+		m.cs = 189
+		goto _test_eof
+	_test_eof190:
+		m.cs = 190
+		goto _test_eof
+	_test_eof191:
+		m.cs = 191
+		goto _test_eof
+	_test_eof192:
+		m.cs = 192
+		goto _test_eof
+	_test_eof193:
+		m.cs = 193
+		goto _test_eof
+	_test_eof194:
+		m.cs = 194
+		goto _test_eof
+	_test_eof195:
+		m.cs = 195
+		goto _test_eof
+	_test_eof196:
+		m.cs = 196
+		goto _test_eof
+	_test_eof197:
+		m.cs = 197
+		goto _test_eof
+	_test_eof198:
+		m.cs = 198
+		goto _test_eof
+	_test_eof199:
+		m.cs = 199
+		goto _test_eof
+	_test_eof200:
+		m.cs = 200
+		goto _test_eof
+	_test_eof201:
+		m.cs = 201
+		goto _test_eof
+	_test_eof202:
+		m.cs = 202
+		goto _test_eof
+	_test_eof203:
+		m.cs = 203
+		goto _test_eof
+	_test_eof204:
+		m.cs = 204
+		goto _test_eof
+	_test_eof205:
+		m.cs = 205
+		goto _test_eof
+	_test_eof206:
+		m.cs = 206
+		goto _test_eof
+	_test_eof207:
+		m.cs = 207
+		goto _test_eof
+	_test_eof208:
+		m.cs = 208
+		goto _test_eof
+	_test_eof209:
+		m.cs = 209
+		goto _test_eof
+	_test_eof210:
+		m.cs = 210
+		goto _test_eof
+	_test_eof211:
+		m.cs = 211
+		goto _test_eof
+	_test_eof212:
+		m.cs = 212
+		goto _test_eof
+	_test_eof213:
+		m.cs = 213
+		goto _test_eof
+	_test_eof214:
+		m.cs = 214
+		goto _test_eof
+	_test_eof215:
+		m.cs = 215
+		goto _test_eof
+	_test_eof216:
+		m.cs = 216
+		goto _test_eof
+	_test_eof217:
+		m.cs = 217
+		goto _test_eof
+	_test_eof218:
+		m.cs = 218
+		goto _test_eof
+	_test_eof219:
+		m.cs = 219
+		goto _test_eof
+	_test_eof220:
+		m.cs = 220
+		goto _test_eof
+	_test_eof221:
+		m.cs = 221
+		goto _test_eof
+	_test_eof222:
+		m.cs = 222
+		goto _test_eof
+	_test_eof223:
+		m.cs = 223
+		goto _test_eof
+	_test_eof224:
+		m.cs = 224
+		goto _test_eof
+	_test_eof225:
+		m.cs = 225
+		goto _test_eof
+	_test_eof226:
+		m.cs = 226
+		goto _test_eof
+	_test_eof227:
+		m.cs = 227
+		goto _test_eof
+	_test_eof228:
+		m.cs = 228
+		goto _test_eof
+	_test_eof229:
+		m.cs = 229
+		goto _test_eof
+	_test_eof230:
+		m.cs = 230
+		goto _test_eof
+	_test_eof231:
+		m.cs = 231
+		goto _test_eof
+	_test_eof232:
+		m.cs = 232
+		goto _test_eof
+	_test_eof233:
+		m.cs = 233
+		goto _test_eof
+	_test_eof234:
+		m.cs = 234
+		goto _test_eof
+	_test_eof235:
+		m.cs = 235
+		goto _test_eof
+	_test_eof236:
+		m.cs = 236
+		goto _test_eof
+	_test_eof237:
+		m.cs = 237
+		goto _test_eof
+	_test_eof238:
+		m.cs = 238
+		goto _test_eof
+	_test_eof239:
+		m.cs = 239
+		goto _test_eof
+	_test_eof240:
+		m.cs = 240
+		goto _test_eof
+	_test_eof241:
+		m.cs = 241
+		goto _test_eof
+	_test_eof242:
+		m.cs = 242
+		goto _test_eof
+	_test_eof243:
+		m.cs = 243
+		goto _test_eof
+	_test_eof244:
+		m.cs = 244
+		goto _test_eof
+	_test_eof245:
+		m.cs = 245
+		goto _test_eof
+	_test_eof246:
+		m.cs = 246
+		goto _test_eof
+	_test_eof247:
+		m.cs = 247
+		goto _test_eof
+	_test_eof248:
+		m.cs = 248
+		goto _test_eof
+	_test_eof249:
+		m.cs = 249
+		goto _test_eof
+	_test_eof250:
+		m.cs = 250
+		goto _test_eof
+	_test_eof251:
+		m.cs = 251
+		goto _test_eof
+	_test_eof252:
+		m.cs = 252
+		goto _test_eof
+	_test_eof253:
+		m.cs = 253
+		goto _test_eof
+	_test_eof254:
+		m.cs = 254
+		goto _test_eof
+	_test_eof255:
+		m.cs = 255
+		goto _test_eof
+	_test_eof256:
+		m.cs = 256
+		goto _test_eof
+	_test_eof257:
+		m.cs = 257
+		goto _test_eof
+	_test_eof258:
+		m.cs = 258
+		goto _test_eof
+	_test_eof259:
+		m.cs = 259
+		goto _test_eof
+	_test_eof260:
+		m.cs = 260
+		goto _test_eof
+	_test_eof261:
+		m.cs = 261
+		goto _test_eof
+	_test_eof262:
+		m.cs = 262
+		goto _test_eof
+	_test_eof263:
+		m.cs = 263
+		goto _test_eof
+	_test_eof264:
+		m.cs = 264
+		goto _test_eof
+	_test_eof265:
+		m.cs = 265
+		goto _test_eof
+	_test_eof266:
+		m.cs = 266
+		goto _test_eof
+	_test_eof267:
+		m.cs = 267
+		goto _test_eof
+	_test_eof268:
+		m.cs = 268
+		goto _test_eof
+	_test_eof269:
+		m.cs = 269
+		goto _test_eof
+	_test_eof270:
+		m.cs = 270
+		goto _test_eof
+	_test_eof271:
+		m.cs = 271
+		goto _test_eof
+	_test_eof272:
+		m.cs = 272
+		goto _test_eof
+	_test_eof273:
+		m.cs = 273
+		goto _test_eof
+	_test_eof274:
+		m.cs = 274
+		goto _test_eof
+	_test_eof275:
+		m.cs = 275
+		goto _test_eof
+	_test_eof276:
+		m.cs = 276
+		goto _test_eof
+	_test_eof277:
+		m.cs = 277
+		goto _test_eof
+	_test_eof278:
+		m.cs = 278
+		goto _test_eof
+	_test_eof279:
+		m.cs = 279
+		goto _test_eof
+	_test_eof280:
+		m.cs = 280
+		goto _test_eof
+	_test_eof281:
+		m.cs = 281
+		goto _test_eof
+	_test_eof282:
+		m.cs = 282
+		goto _test_eof
+	_test_eof283:
+		m.cs = 283
+		goto _test_eof
+	_test_eof284:
+		m.cs = 284
+		goto _test_eof
+	_test_eof285:
+		m.cs = 285
+		goto _test_eof
+	_test_eof286:
+		m.cs = 286
+		goto _test_eof
+	_test_eof287:
+		m.cs = 287
+		goto _test_eof
+	_test_eof288:
+		m.cs = 288
+		goto _test_eof
+	_test_eof289:
+		m.cs = 289
+		goto _test_eof
+	_test_eof290:
+		m.cs = 290
+		goto _test_eof
+	_test_eof291:
+		m.cs = 291
+		goto _test_eof
+	_test_eof292:
+		m.cs = 292
+		goto _test_eof
+	_test_eof293:
+		m.cs = 293
+		goto _test_eof
+	_test_eof294:
+		m.cs = 294
+		goto _test_eof
+	_test_eof295:
+		m.cs = 295
+		goto _test_eof
+	_test_eof296:
+		m.cs = 296
+		goto _test_eof
+	_test_eof297:
+		m.cs = 297
+		goto _test_eof
+	_test_eof298:
+		m.cs = 298
+		goto _test_eof
+	_test_eof299:
+		m.cs = 299
+		goto _test_eof
+	_test_eof300:
+		m.cs = 300
+		goto _test_eof
+	_test_eof301:
+		m.cs = 301
+		goto _test_eof
+	_test_eof302:
+		m.cs = 302
+		goto _test_eof
+	_test_eof303:
+		m.cs = 303
+		goto _test_eof
+	_test_eof304:
+		m.cs = 304
+		goto _test_eof
+	_test_eof305:
+		m.cs = 305
+		goto _test_eof
+	_test_eof306:
+		m.cs = 306
+		goto _test_eof
+	_test_eof307:
+		m.cs = 307
+		goto _test_eof
+	_test_eof308:
+		m.cs = 308
+		goto _test_eof
+	_test_eof309:
+		m.cs = 309
+		goto _test_eof
+	_test_eof310:
+		m.cs = 310
+		goto _test_eof
+	_test_eof311:
+		m.cs = 311
+		goto _test_eof
+	_test_eof312:
+		m.cs = 312
+		goto _test_eof
+	_test_eof313:
+		m.cs = 313
+		goto _test_eof
+	_test_eof314:
+		m.cs = 314
+		goto _test_eof
+	_test_eof315:
+		m.cs = 315
+		goto _test_eof
+	_test_eof316:
+		m.cs = 316
+		goto _test_eof
+	_test_eof317:
+		m.cs = 317
+		goto _test_eof
+	_test_eof318:
+		m.cs = 318
+		goto _test_eof
+	_test_eof319:
+		m.cs = 319
+		goto _test_eof
+	_test_eof320:
+		m.cs = 320
+		goto _test_eof
+	_test_eof321:
+		m.cs = 321
+		goto _test_eof
+	_test_eof322:
+		m.cs = 322
+		goto _test_eof
+	_test_eof323:
+		m.cs = 323
+		goto _test_eof
+	_test_eof324:
+		m.cs = 324
+		goto _test_eof
+	_test_eof325:
+		m.cs = 325
+		goto _test_eof
+	_test_eof326:
+		m.cs = 326
+		goto _test_eof
+	_test_eof327:
+		m.cs = 327
+		goto _test_eof
+	_test_eof328:
+		m.cs = 328
+		goto _test_eof
+	_test_eof329:
+		m.cs = 329
+		goto _test_eof
+	_test_eof330:
+		m.cs = 330
+		goto _test_eof
+	_test_eof331:
+		m.cs = 331
+		goto _test_eof
+	_test_eof332:
+		m.cs = 332
+		goto _test_eof
+	_test_eof333:
+		m.cs = 333
+		goto _test_eof
+	_test_eof334:
+		m.cs = 334
+		goto _test_eof
+	_test_eof335:
+		m.cs = 335
+		goto _test_eof
+	_test_eof336:
+		m.cs = 336
+		goto _test_eof
+	_test_eof337:
+		m.cs = 337
+		goto _test_eof
+	_test_eof338:
+		m.cs = 338
+		goto _test_eof
+	_test_eof339:
+		m.cs = 339
+		goto _test_eof
+	_test_eof340:
+		m.cs = 340
+		goto _test_eof
+	_test_eof341:
+		m.cs = 341
+		goto _test_eof
+	_test_eof342:
+		m.cs = 342
+		goto _test_eof
+	_test_eof343:
+		m.cs = 343
+		goto _test_eof
+	_test_eof344:
+		m.cs = 344
+		goto _test_eof
+	_test_eof345:
+		m.cs = 345
+		goto _test_eof
+	_test_eof346:
+		m.cs = 346
+		goto _test_eof
+	_test_eof347:
+		m.cs = 347
+		goto _test_eof
+	_test_eof348:
+		m.cs = 348
+		goto _test_eof
+	_test_eof349:
+		m.cs = 349
+		goto _test_eof
+	_test_eof350:
+		m.cs = 350
+		goto _test_eof
+	_test_eof351:
+		m.cs = 351
+		goto _test_eof
+	_test_eof352:
+		m.cs = 352
+		goto _test_eof
+	_test_eof353:
+		m.cs = 353
+		goto _test_eof
+	_test_eof354:
+		m.cs = 354
+		goto _test_eof
+	_test_eof355:
+		m.cs = 355
+		goto _test_eof
+	_test_eof356:
+		m.cs = 356
+		goto _test_eof
+	_test_eof357:
+		m.cs = 357
+		goto _test_eof
+	_test_eof358:
+		m.cs = 358
+		goto _test_eof
+	_test_eof359:
+		m.cs = 359
+		goto _test_eof
+	_test_eof360:
+		m.cs = 360
+		goto _test_eof
+	_test_eof361:
+		m.cs = 361
+		goto _test_eof
+	_test_eof362:
+		m.cs = 362
+		goto _test_eof
+	_test_eof363:
+		m.cs = 363
+		goto _test_eof
+	_test_eof364:
+		m.cs = 364
+		goto _test_eof
+	_test_eof365:
+		m.cs = 365
+		goto _test_eof
+	_test_eof366:
+		m.cs = 366
+		goto _test_eof
+	_test_eof367:
+		m.cs = 367
+		goto _test_eof
+	_test_eof368:
+		m.cs = 368
+		goto _test_eof
+	_test_eof369:
+		m.cs = 369
+		goto _test_eof
+	_test_eof370:
+		m.cs = 370
+		goto _test_eof
+	_test_eof371:
+		m.cs = 371
+		goto _test_eof
+	_test_eof372:
+		m.cs = 372
+		goto _test_eof
+	_test_eof373:
+		m.cs = 373
+		goto _test_eof
+	_test_eof374:
+		m.cs = 374
+		goto _test_eof
+	_test_eof375:
+		m.cs = 375
+		goto _test_eof
+	_test_eof376:
+		m.cs = 376
+		goto _test_eof
+	_test_eof377:
+		m.cs = 377
+		goto _test_eof
+	_test_eof378:
+		m.cs = 378
+		goto _test_eof
+	_test_eof379:
+		m.cs = 379
+		goto _test_eof
+	_test_eof380:
+		m.cs = 380
+		goto _test_eof
+	_test_eof381:
+		m.cs = 381
+		goto _test_eof
+	_test_eof382:
+		m.cs = 382
+		goto _test_eof
+	_test_eof383:
+		m.cs = 383
+		goto _test_eof
+	_test_eof384:
+		m.cs = 384
+		goto _test_eof
+	_test_eof385:
+		m.cs = 385
+		goto _test_eof
+	_test_eof386:
+		m.cs = 386
+		goto _test_eof
+	_test_eof387:
+		m.cs = 387
+		goto _test_eof
+	_test_eof388:
+		m.cs = 388
+		goto _test_eof
+	_test_eof389:
+		m.cs = 389
+		goto _test_eof
+	_test_eof390:
+		m.cs = 390
+		goto _test_eof
+	_test_eof391:
+		m.cs = 391
+		goto _test_eof
+	_test_eof392:
+		m.cs = 392
+		goto _test_eof
+	_test_eof393:
+		m.cs = 393
+		goto _test_eof
+	_test_eof394:
+		m.cs = 394
+		goto _test_eof
+	_test_eof395:
+		m.cs = 395
+		goto _test_eof
+	_test_eof396:
+		m.cs = 396
+		goto _test_eof
+	_test_eof397:
+		m.cs = 397
+		goto _test_eof
+	_test_eof398:
+		m.cs = 398
+		goto _test_eof
+	_test_eof399:
+		m.cs = 399
+		goto _test_eof
+	_test_eof400:
+		m.cs = 400
+		goto _test_eof
+	_test_eof401:
+		m.cs = 401
+		goto _test_eof
+	_test_eof402:
+		m.cs = 402
+		goto _test_eof
+	_test_eof403:
+		m.cs = 403
+		goto _test_eof
+	_test_eof404:
+		m.cs = 404
+		goto _test_eof
+	_test_eof405:
+		m.cs = 405
+		goto _test_eof
+	_test_eof406:
+		m.cs = 406
+		goto _test_eof
+	_test_eof407:
+		m.cs = 407
+		goto _test_eof
+	_test_eof408:
+		m.cs = 408
+		goto _test_eof
+	_test_eof409:
+		m.cs = 409
+		goto _test_eof
+	_test_eof410:
+		m.cs = 410
+		goto _test_eof
+	_test_eof411:
+		m.cs = 411
+		goto _test_eof
+	_test_eof412:
+		m.cs = 412
+		goto _test_eof
+	_test_eof413:
+		m.cs = 413
+		goto _test_eof
+	_test_eof414:
+		m.cs = 414
+		goto _test_eof
+	_test_eof415:
+		m.cs = 415
+		goto _test_eof
+	_test_eof416:
+		m.cs = 416
+		goto _test_eof
+	_test_eof417:
+		m.cs = 417
+		goto _test_eof
+	_test_eof418:
+		m.cs = 418
+		goto _test_eof
+	_test_eof419:
+		m.cs = 419
+		goto _test_eof
+	_test_eof420:
+		m.cs = 420
+		goto _test_eof
+	_test_eof421:
+		m.cs = 421
+		goto _test_eof
+	_test_eof422:
+		m.cs = 422
+		goto _test_eof
+	_test_eof423:
+		m.cs = 423
+		goto _test_eof
+	_test_eof424:
+		m.cs = 424
+		goto _test_eof
+	_test_eof425:
+		m.cs = 425
+		goto _test_eof
+	_test_eof426:
+		m.cs = 426
+		goto _test_eof
+	_test_eof427:
+		m.cs = 427
+		goto _test_eof
+	_test_eof428:
+		m.cs = 428
+		goto _test_eof
+	_test_eof429:
+		m.cs = 429
+		goto _test_eof
+	_test_eof430:
+		m.cs = 430
+		goto _test_eof
+	_test_eof431:
+		m.cs = 431
+		goto _test_eof
+	_test_eof432:
+		m.cs = 432
+		goto _test_eof
+	_test_eof433:
+		m.cs = 433
+		goto _test_eof
+	_test_eof434:
+		m.cs = 434
+		goto _test_eof
+	_test_eof435:
+		m.cs = 435
+		goto _test_eof
+	_test_eof436:
+		m.cs = 436
+		goto _test_eof
+	_test_eof437:
+		m.cs = 437
+		goto _test_eof
+	_test_eof438:
+		m.cs = 438
+		goto _test_eof
+	_test_eof439:
+		m.cs = 439
+		goto _test_eof
+	_test_eof440:
+		m.cs = 440
+		goto _test_eof
+	_test_eof441:
+		m.cs = 441
+		goto _test_eof
+	_test_eof442:
+		m.cs = 442
+		goto _test_eof
+	_test_eof443:
+		m.cs = 443
+		goto _test_eof
+	_test_eof444:
+		m.cs = 444
+		goto _test_eof
+	_test_eof445:
+		m.cs = 445
+		goto _test_eof
+	_test_eof446:
+		m.cs = 446
+		goto _test_eof
+	_test_eof447:
+		m.cs = 447
+		goto _test_eof
+	_test_eof448:
+		m.cs = 448
+		goto _test_eof
+	_test_eof449:
+		m.cs = 449
+		goto _test_eof
+	_test_eof450:
+		m.cs = 450
+		goto _test_eof
+	_test_eof451:
+		m.cs = 451
+		goto _test_eof
+	_test_eof452:
+		m.cs = 452
+		goto _test_eof
+	_test_eof453:
+		m.cs = 453
+		goto _test_eof
+	_test_eof454:
+		m.cs = 454
+		goto _test_eof
+	_test_eof455:
+		m.cs = 455
+		goto _test_eof
+	_test_eof456:
+		m.cs = 456
+		goto _test_eof
+	_test_eof457:
+		m.cs = 457
+		goto _test_eof
+	_test_eof458:
+		m.cs = 458
+		goto _test_eof
+	_test_eof459:
+		m.cs = 459
+		goto _test_eof
+	_test_eof460:
+		m.cs = 460
+		goto _test_eof
+	_test_eof461:
+		m.cs = 461
+		goto _test_eof
+	_test_eof462:
+		m.cs = 462
+		goto _test_eof
+	_test_eof463:
+		m.cs = 463
+		goto _test_eof
+	_test_eof464:
+		m.cs = 464
+		goto _test_eof
+	_test_eof465:
+		m.cs = 465
+		goto _test_eof
+	_test_eof466:
+		m.cs = 466
+		goto _test_eof
+	_test_eof467:
+		m.cs = 467
+		goto _test_eof
+	_test_eof468:
+		m.cs = 468
+		goto _test_eof
+	_test_eof469:
+		m.cs = 469
+		goto _test_eof
+	_test_eof470:
+		m.cs = 470
+		goto _test_eof
+	_test_eof471:
+		m.cs = 471
+		goto _test_eof
+	_test_eof472:
+		m.cs = 472
+		goto _test_eof
+	_test_eof473:
+		m.cs = 473
+		goto _test_eof
+	_test_eof474:
+		m.cs = 474
+		goto _test_eof
+	_test_eof475:
+		m.cs = 475
+		goto _test_eof
+	_test_eof476:
+		m.cs = 476
+		goto _test_eof
+	_test_eof477:
+		m.cs = 477
+		goto _test_eof
+	_test_eof478:
+		m.cs = 478
+		goto _test_eof
+	_test_eof479:
+		m.cs = 479
+		goto _test_eof
+	_test_eof480:
+		m.cs = 480
+		goto _test_eof
+	_test_eof481:
+		m.cs = 481
+		goto _test_eof
+	_test_eof482:
+		m.cs = 482
+		goto _test_eof
+	_test_eof483:
+		m.cs = 483
+		goto _test_eof
+	_test_eof484:
+		m.cs = 484
+		goto _test_eof
+	_test_eof485:
+		m.cs = 485
+		goto _test_eof
+	_test_eof486:
+		m.cs = 486
+		goto _test_eof
+	_test_eof487:
+		m.cs = 487
+		goto _test_eof
+	_test_eof488:
+		m.cs = 488
+		goto _test_eof
+	_test_eof489:
+		m.cs = 489
+		goto _test_eof
+	_test_eof490:
+		m.cs = 490
+		goto _test_eof
+	_test_eof491:
+		m.cs = 491
+		goto _test_eof
+	_test_eof492:
+		m.cs = 492
+		goto _test_eof
+	_test_eof493:
+		m.cs = 493
+		goto _test_eof
+	_test_eof494:
+		m.cs = 494
+		goto _test_eof
+	_test_eof495:
+		m.cs = 495
+		goto _test_eof
+	_test_eof496:
+		m.cs = 496
+		goto _test_eof
+	_test_eof497:
+		m.cs = 497
+		goto _test_eof
+	_test_eof498:
+		m.cs = 498
+		goto _test_eof
+	_test_eof499:
+		m.cs = 499
+		goto _test_eof
+	_test_eof500:
+		m.cs = 500
+		goto _test_eof
+	_test_eof501:
+		m.cs = 501
+		goto _test_eof
+	_test_eof502:
+		m.cs = 502
+		goto _test_eof
+	_test_eof503:
+		m.cs = 503
+		goto _test_eof
+	_test_eof504:
+		m.cs = 504
+		goto _test_eof
+	_test_eof505:
+		m.cs = 505
+		goto _test_eof
+	_test_eof506:
+		m.cs = 506
+		goto _test_eof
+	_test_eof507:
+		m.cs = 507
+		goto _test_eof
+	_test_eof508:
+		m.cs = 508
+		goto _test_eof
+	_test_eof509:
+		m.cs = 509
+		goto _test_eof
+	_test_eof510:
+		m.cs = 510
+		goto _test_eof
+	_test_eof511:
+		m.cs = 511
+		goto _test_eof
+	_test_eof512:
+		m.cs = 512
+		goto _test_eof
+	_test_eof513:
+		m.cs = 513
+		goto _test_eof
+	_test_eof514:
+		m.cs = 514
+		goto _test_eof
+	_test_eof515:
+		m.cs = 515
+		goto _test_eof
+	_test_eof516:
+		m.cs = 516
+		goto _test_eof
+	_test_eof517:
+		m.cs = 517
+		goto _test_eof
+	_test_eof518:
+		m.cs = 518
+		goto _test_eof
+	_test_eof519:
+		m.cs = 519
+		goto _test_eof
+	_test_eof520:
+		m.cs = 520
+		goto _test_eof
+	_test_eof521:
+		m.cs = 521
+		goto _test_eof
+	_test_eof522:
+		m.cs = 522
+		goto _test_eof
+	_test_eof523:
+		m.cs = 523
+		goto _test_eof
+	_test_eof524:
+		m.cs = 524
+		goto _test_eof
+	_test_eof525:
+		m.cs = 525
+		goto _test_eof
+	_test_eof526:
+		m.cs = 526
+		goto _test_eof
+	_test_eof527:
+		m.cs = 527
+		goto _test_eof
+	_test_eof528:
+		m.cs = 528
+		goto _test_eof
+	_test_eof529:
+		m.cs = 529
+		goto _test_eof
+	_test_eof530:
+		m.cs = 530
+		goto _test_eof
+	_test_eof531:
+		m.cs = 531
+		goto _test_eof
+	_test_eof532:
+		m.cs = 532
+		goto _test_eof
+	_test_eof533:
+		m.cs = 533
+		goto _test_eof
+	_test_eof534:
+		m.cs = 534
+		goto _test_eof
+	_test_eof535:
+		m.cs = 535
+		goto _test_eof
+	_test_eof536:
+		m.cs = 536
+		goto _test_eof
+	_test_eof537:
+		m.cs = 537
+		goto _test_eof
+	_test_eof538:
+		m.cs = 538
+		goto _test_eof
+	_test_eof539:
+		m.cs = 539
+		goto _test_eof
+	_test_eof540:
+		m.cs = 540
+		goto _test_eof
+	_test_eof541:
+		m.cs = 541
+		goto _test_eof
+	_test_eof542:
+		m.cs = 542
+		goto _test_eof
+	_test_eof543:
+		m.cs = 543
+		goto _test_eof
+	_test_eof544:
+		m.cs = 544
+		goto _test_eof
+	_test_eof545:
+		m.cs = 545
+		goto _test_eof
+	_test_eof546:
+		m.cs = 546
+		goto _test_eof
+	_test_eof547:
+		m.cs = 547
+		goto _test_eof
+	_test_eof548:
+		m.cs = 548
+		goto _test_eof
+	_test_eof549:
+		m.cs = 549
+		goto _test_eof
+	_test_eof550:
+		m.cs = 550
+		goto _test_eof
+	_test_eof551:
+		m.cs = 551
+		goto _test_eof
+	_test_eof552:
+		m.cs = 552
+		goto _test_eof
+	_test_eof553:
+		m.cs = 553
+		goto _test_eof
+	_test_eof554:
+		m.cs = 554
+		goto _test_eof
+	_test_eof555:
+		m.cs = 555
+		goto _test_eof
+	_test_eof556:
+		m.cs = 556
+		goto _test_eof
+	_test_eof557:
+		m.cs = 557
+		goto _test_eof
+	_test_eof558:
+		m.cs = 558
+		goto _test_eof
+	_test_eof559:
+		m.cs = 559
+		goto _test_eof
+	_test_eof560:
+		m.cs = 560
+		goto _test_eof
+	_test_eof561:
+		m.cs = 561
+		goto _test_eof
+	_test_eof562:
+		m.cs = 562
+		goto _test_eof
+	_test_eof563:
+		m.cs = 563
+		goto _test_eof
+	_test_eof564:
+		m.cs = 564
+		goto _test_eof
+	_test_eof565:
+		m.cs = 565
+		goto _test_eof
+	_test_eof566:
+		m.cs = 566
+		goto _test_eof
+	_test_eof567:
+		m.cs = 567
+		goto _test_eof
+	_test_eof568:
+		m.cs = 568
+		goto _test_eof
+	_test_eof569:
+		m.cs = 569
+		goto _test_eof
+	_test_eof570:
+		m.cs = 570
+		goto _test_eof
+	_test_eof571:
+		m.cs = 571
+		goto _test_eof
+	_test_eof572:
+		m.cs = 572
+		goto _test_eof
+	_test_eof573:
+		m.cs = 573
+		goto _test_eof
+	_test_eof574:
+		m.cs = 574
+		goto _test_eof
+	_test_eof575:
+		m.cs = 575
+		goto _test_eof
+	_test_eof576:
+		m.cs = 576
+		goto _test_eof
+	_test_eof577:
+		m.cs = 577
+		goto _test_eof
+	_test_eof578:
+		m.cs = 578
+		goto _test_eof
+	_test_eof579:
+		m.cs = 579
+		goto _test_eof
+	_test_eof580:
+		m.cs = 580
+		goto _test_eof
+	_test_eof581:
+		m.cs = 581
+		goto _test_eof
+	_test_eof582:
+		m.cs = 582
+		goto _test_eof
+	_test_eof583:
+		m.cs = 583
+		goto _test_eof
+	_test_eof584:
+		m.cs = 584
+		goto _test_eof
+	_test_eof585:
+		m.cs = 585
+		goto _test_eof
+	_test_eof586:
+		m.cs = 586
+		goto _test_eof
+	_test_eof587:
+		m.cs = 587
+		goto _test_eof
+	_test_eof588:
+		m.cs = 588
+		goto _test_eof
+	_test_eof589:
+		m.cs = 589
+		goto _test_eof
+	_test_eof590:
+		m.cs = 590
+		goto _test_eof
+	_test_eof591:
+		m.cs = 591
+		goto _test_eof
+	_test_eof592:
+		m.cs = 592
+		goto _test_eof
+	_test_eof593:
+		m.cs = 593
+		goto _test_eof
+	_test_eof594:
+		m.cs = 594
+		goto _test_eof
+	_test_eof595:
+		m.cs = 595
+		goto _test_eof
+	_test_eof596:
+		m.cs = 596
+		goto _test_eof
+	_test_eof597:
+		m.cs = 597
+		goto _test_eof
+	_test_eof598:
+		m.cs = 598
+		goto _test_eof
+	_test_eof599:
+		m.cs = 599
+		goto _test_eof
+	_test_eof600:
+		m.cs = 600
+		goto _test_eof
+	_test_eof601:
+		m.cs = 601
+		goto _test_eof
+	_test_eof602:
+		m.cs = 602
+		goto _test_eof
+	_test_eof607:
+		m.cs = 607
+		goto _test_eof
 
-	_test_eof: {}
-	if ( m.p) == ( m.eof) {
-		switch  m.cs {
-		case 585:
+	_test_eof:
+		{
+		}
+		if (m.p) == (m.eof) {
+			switch m.cs {
+			case 585:
 //line rfc5424/machine.go.rl:48
+				if t, e := time.Parse(time.RFC3339Nano, string(m.text())); e != nil {
+					m.err = fmt.Errorf("%s [col %d]", e, m.p)
+					(m.p)--
 
-	if t, e := time.Parse(time.RFC3339Nano, string(m.text())); e != nil {
-        m.err = fmt.Errorf("%s [col %d]", e, m.p)
-		( m.p)--
+					{
+						goto st607
+					}
+				} else {
+					output.Timestamp = t
+				}
 
-    	{goto st607 }
-    } else {
-        m.output.Timestamp = &t
-    }
-
-		case 605:
+			case 605:
 //line rfc5424/machine.go.rl:136
+				if msg := string(m.text()); msg != "" {
+					output.Message = msg
+				}
 
-	if msg := string(m.text()); msg != "" {
-		m.output.Message = &msg
-	}
-
-		case 1:
+			case 1:
 //line rfc5424/machine.go.rl:148
+				m.err = fmt.Errorf(errPri, m.p)
+				(m.p)--
 
-	m.err = fmt.Errorf(errPri, m.p)
-	( m.p)--
+				{
+					goto st607
+				}
 
-    {goto st607 }
-
-		case 4, 5, 598, 599:
+			case 4, 5, 598, 599:
 //line rfc5424/machine.go.rl:154
+				m.err = fmt.Errorf(errVersion, m.p)
+				(m.p)--
 
-	m.err = fmt.Errorf(errVersion, m.p)
-	( m.p)--
+				{
+					goto st607
+				}
 
-    {goto st607 }
-
-		case 561, 562, 563, 564, 565, 566, 567, 568, 569, 570, 571, 572, 573, 574, 575, 576, 577, 578, 579, 580, 581, 582, 583, 584, 586, 587, 588, 589, 590, 591, 592, 593, 594, 595, 596, 597:
+			case 561, 562, 563, 564, 565, 566, 567, 568, 569, 570, 571, 572, 573, 574, 575, 576, 577, 578, 579, 580, 581, 582, 583, 584, 586, 587, 588, 589, 590, 591, 592, 593, 594, 595, 596, 597:
 //line rfc5424/machine.go.rl:160
+				m.err = fmt.Errorf(errTimestamp, m.p)
+				(m.p)--
 
-	m.err = fmt.Errorf(errTimestamp, m.p)
-	( m.p)--
+				{
+					goto st607
+				}
 
-    {goto st607 }
-
-		case 8, 9, 307, 308, 309, 310, 311, 312, 313, 314, 315, 316, 317, 318, 319, 320, 321, 322, 323, 324, 325, 326, 327, 328, 329, 330, 331, 332, 333, 334, 335, 336, 337, 338, 339, 340, 341, 342, 343, 344, 345, 346, 347, 348, 349, 350, 351, 352, 353, 354, 355, 356, 357, 358, 359, 360, 361, 362, 363, 364, 365, 366, 367, 368, 369, 370, 371, 372, 373, 374, 375, 376, 377, 378, 379, 380, 381, 382, 383, 384, 385, 386, 387, 388, 389, 390, 391, 392, 393, 394, 395, 396, 397, 398, 399, 400, 401, 402, 403, 404, 405, 406, 407, 408, 409, 410, 411, 412, 413, 414, 415, 416, 417, 418, 419, 420, 421, 422, 423, 424, 425, 426, 427, 428, 429, 430, 431, 432, 433, 434, 435, 436, 437, 438, 439, 440, 441, 442, 443, 444, 445, 446, 447, 448, 449, 450, 451, 452, 453, 454, 455, 456, 457, 458, 459, 460, 461, 462, 463, 464, 465, 466, 467, 468, 469, 470, 471, 472, 473, 474, 475, 476, 477, 478, 479, 480, 481, 482, 483, 484, 485, 486, 487, 488, 489, 490, 491, 492, 493, 494, 495, 496, 497, 498, 499, 500, 501, 502, 503, 504, 505, 506, 507, 508, 509, 510, 511, 512, 513, 514, 515, 516, 517, 518, 519, 520, 521, 522, 523, 524, 525, 526, 527, 528, 529, 530, 531, 532, 533, 534, 535, 536, 537, 538, 539, 540, 541, 542, 543, 544, 545, 546, 547, 548, 549, 550, 551, 552, 553, 554, 555, 556, 557, 558, 559, 560:
+			case 8, 9, 307, 308, 309, 310, 311, 312, 313, 314, 315, 316, 317, 318, 319, 320, 321, 322, 323, 324, 325, 326, 327, 328, 329, 330, 331, 332, 333, 334, 335, 336, 337, 338, 339, 340, 341, 342, 343, 344, 345, 346, 347, 348, 349, 350, 351, 352, 353, 354, 355, 356, 357, 358, 359, 360, 361, 362, 363, 364, 365, 366, 367, 368, 369, 370, 371, 372, 373, 374, 375, 376, 377, 378, 379, 380, 381, 382, 383, 384, 385, 386, 387, 388, 389, 390, 391, 392, 393, 394, 395, 396, 397, 398, 399, 400, 401, 402, 403, 404, 405, 406, 407, 408, 409, 410, 411, 412, 413, 414, 415, 416, 417, 418, 419, 420, 421, 422, 423, 424, 425, 426, 427, 428, 429, 430, 431, 432, 433, 434, 435, 436, 437, 438, 439, 440, 441, 442, 443, 444, 445, 446, 447, 448, 449, 450, 451, 452, 453, 454, 455, 456, 457, 458, 459, 460, 461, 462, 463, 464, 465, 466, 467, 468, 469, 470, 471, 472, 473, 474, 475, 476, 477, 478, 479, 480, 481, 482, 483, 484, 485, 486, 487, 488, 489, 490, 491, 492, 493, 494, 495, 496, 497, 498, 499, 500, 501, 502, 503, 504, 505, 506, 507, 508, 509, 510, 511, 512, 513, 514, 515, 516, 517, 518, 519, 520, 521, 522, 523, 524, 525, 526, 527, 528, 529, 530, 531, 532, 533, 534, 535, 536, 537, 538, 539, 540, 541, 542, 543, 544, 545, 546, 547, 548, 549, 550, 551, 552, 553, 554, 555, 556, 557, 558, 559, 560:
 //line rfc5424/machine.go.rl:166
+				m.err = fmt.Errorf(errHostname, m.p)
+				(m.p)--
 
-	m.err = fmt.Errorf(errHostname, m.p)
-	( m.p)--
+				{
+					goto st607
+				}
 
-    {goto st607 }
-
-		case 10, 11, 260, 261, 262, 263, 264, 265, 266, 267, 268, 269, 270, 271, 272, 273, 274, 275, 276, 277, 278, 279, 280, 281, 282, 283, 284, 285, 286, 287, 288, 289, 290, 291, 292, 293, 294, 295, 296, 297, 298, 299, 300, 301, 302, 303, 304, 305, 306:
+			case 10, 11, 260, 261, 262, 263, 264, 265, 266, 267, 268, 269, 270, 271, 272, 273, 274, 275, 276, 277, 278, 279, 280, 281, 282, 283, 284, 285, 286, 287, 288, 289, 290, 291, 292, 293, 294, 295, 296, 297, 298, 299, 300, 301, 302, 303, 304, 305, 306:
 //line rfc5424/machine.go.rl:172
+				m.err = fmt.Errorf(errAppname, m.p)
+				(m.p)--
 
-	m.err = fmt.Errorf(errAppname, m.p)
-	( m.p)--
+				{
+					goto st607
+				}
 
-    {goto st607 }
-
-		case 12, 13, 133, 134, 135, 136, 137, 138, 139, 140, 141, 142, 143, 144, 145, 146, 147, 148, 149, 150, 151, 152, 153, 154, 155, 156, 157, 158, 159, 160, 161, 162, 163, 164, 165, 166, 167, 168, 169, 170, 171, 172, 173, 174, 175, 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191, 192, 193, 194, 195, 196, 197, 198, 199, 200, 201, 202, 203, 204, 205, 206, 207, 208, 209, 210, 211, 212, 213, 214, 215, 216, 217, 218, 219, 220, 221, 222, 223, 224, 225, 226, 227, 228, 229, 230, 231, 232, 233, 234, 235, 236, 237, 238, 239, 240, 241, 242, 243, 244, 245, 246, 247, 248, 249, 250, 251, 252, 253, 254, 255, 256, 257, 258, 259:
+			case 12, 13, 133, 134, 135, 136, 137, 138, 139, 140, 141, 142, 143, 144, 145, 146, 147, 148, 149, 150, 151, 152, 153, 154, 155, 156, 157, 158, 159, 160, 161, 162, 163, 164, 165, 166, 167, 168, 169, 170, 171, 172, 173, 174, 175, 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191, 192, 193, 194, 195, 196, 197, 198, 199, 200, 201, 202, 203, 204, 205, 206, 207, 208, 209, 210, 211, 212, 213, 214, 215, 216, 217, 218, 219, 220, 221, 222, 223, 224, 225, 226, 227, 228, 229, 230, 231, 232, 233, 234, 235, 236, 237, 238, 239, 240, 241, 242, 243, 244, 245, 246, 247, 248, 249, 250, 251, 252, 253, 254, 255, 256, 257, 258, 259:
 //line rfc5424/machine.go.rl:178
+				m.err = fmt.Errorf(errProcid, m.p)
+				(m.p)--
 
-	m.err = fmt.Errorf(errProcid, m.p)
-	( m.p)--
+				{
+					goto st607
+				}
 
-    {goto st607 }
-
-		case 14, 15, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 124, 125, 126, 127, 128, 129, 130, 131, 132:
+			case 14, 15, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 124, 125, 126, 127, 128, 129, 130, 131, 132:
 //line rfc5424/machine.go.rl:184
+				m.err = fmt.Errorf(errMsgid, m.p)
+				(m.p)--
 
-	m.err = fmt.Errorf(errMsgid, m.p)
-	( m.p)--
+				{
+					goto st607
+				}
 
-    {goto st607 }
-
-		case 16:
+			case 16:
 //line rfc5424/machine.go.rl:190
+				m.err = fmt.Errorf(errStructuredData, m.p)
+				(m.p)--
 
-	m.err = fmt.Errorf(errStructuredData, m.p)
-	( m.p)--
+				{
+					goto st607
+				}
 
-    {goto st607 }
-
-		case 2, 3, 600, 601, 602:
+			case 2, 3, 600, 601, 602:
 //line rfc5424/machine.go.rl:142
+				m.err = fmt.Errorf(errPrival, m.p)
+				(m.p)--
 
-	m.err = fmt.Errorf(errPrival, m.p)
-	( m.p)--
-
-    {goto st607 }
+				{
+					goto st607
+				}
 
 //line rfc5424/machine.go.rl:148
+				m.err = fmt.Errorf(errPri, m.p)
+				(m.p)--
 
-	m.err = fmt.Errorf(errPri, m.p)
-	( m.p)--
+				{
+					goto st607
+				}
 
-    {goto st607 }
-
-		case 24:
+			case 24:
 //line rfc5424/machine.go.rl:196
+				delete(output.StructuredData, m.currentelem)
+				if len(output.StructuredData) == 0 {
+					output.StructuredData = nil
+				}
+				m.err = fmt.Errorf(errSdID, m.p)
+				(m.p)--
 
-	delete(*m.output.StructuredData, m.currentelem)
-	if len(*m.output.StructuredData) == 0 {
-		m.output.StructuredData = nil
-	}
-	m.err = fmt.Errorf(errSdID, m.p)
-	( m.p)--
-
-    {goto st607 }
+				{
+					goto st607
+				}
 
 //line rfc5424/machine.go.rl:190
+				m.err = fmt.Errorf(errStructuredData, m.p)
+				(m.p)--
 
-	m.err = fmt.Errorf(errStructuredData, m.p)
-	( m.p)--
+				{
+					goto st607
+				}
 
-    {goto st607 }
-
-		case 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 62, 64, 65, 66, 67, 68, 69, 70:
+			case 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 62, 64, 65, 66, 67, 68, 69, 70:
 //line rfc5424/machine.go.rl:206
+				if elements, ok := interface{}(output.StructuredData).(map[string]map[string]string); ok {
+					delete((elements)[m.currentelem], m.currentparam)
+				}
+				m.err = fmt.Errorf(errSdParam, m.p)
+				(m.p)--
 
-	if elements, ok := interface{}(m.output.StructuredData).(*map[string]map[string]string); ok {
-		delete((*elements)[m.currentelem], m.currentparam)
-	}
-	m.err = fmt.Errorf(errSdParam, m.p)
-	( m.p)--
-
-    {goto st607 }
+				{
+					goto st607
+				}
 
 //line rfc5424/machine.go.rl:190
+				m.err = fmt.Errorf(errStructuredData, m.p)
+				(m.p)--
 
-	m.err = fmt.Errorf(errStructuredData, m.p)
-	( m.p)--
+				{
+					goto st607
+				}
 
-    {goto st607 }
-
-		case 17, 18, 19, 20, 21, 22, 23:
+			case 17, 18, 19, 20, 21, 22, 23:
 //line rfc5424/machine.go.rl:215
 
-	// If error encountered within the message rule ...
-	if m.msg_at > 0 {
-		// Save the text until valid (m.p is where the parser has stopped)
-		if trunc := string(m.data[m.msg_at:m.p]); trunc != "" {
-			m.output.Message = &trunc
-		}
-	}
+				// If error encountered within the message rule ...
+				if m.msg_at > 0 {
+					// Save the text until valid (m.p is where the parser has stopped)
+					if trunc := string(m.data[m.msg_at:m.p]); trunc != "" {
+						output.Message = trunc
+					}
+				}
 
-	m.err = fmt.Errorf(errMsg, m.p)
-	( m.p)--
+				m.err = fmt.Errorf(errMsg, m.p)
+				(m.p)--
 
-    {goto st607 }
+				{
+					goto st607
+				}
 
 //line rfc5424/machine.go.rl:235
+				m.err = fmt.Errorf(errParse, m.p)
+				(m.p)--
 
-	m.err = fmt.Errorf(errParse, m.p)
-	( m.p)--
+				{
+					goto st607
+				}
 
-    {goto st607 }
-
-		case 604:
+			case 604:
 //line rfc5424/machine.go.rl:32
-
-	m.pb = m.p
+				m.pb = m.p
 
 //line rfc5424/machine.go.rl:36
-
-	m.msg_at = m.p
+				m.msg_at = m.p
 
 //line rfc5424/machine.go.rl:136
+				if msg := string(m.text()); msg != "" {
+					output.Message = msg
+				}
 
-	if msg := string(m.text()); msg != "" {
-		m.output.Message = &msg
-	}
-
-		case 25, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100, 101:
+			case 25, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100, 101:
 //line rfc5424/machine.go.rl:87
+				if elements, ok := interface{}(output.StructuredData).(map[string]map[string]string); ok {
+					id := string(m.text())
+					if _, ok := (elements)[id]; ok {
+						// As per RFC5424 section 6.3.2 SD-ID MUST NOT exist more than once in a message
+						m.err = fmt.Errorf(errSdIDDuplicated, m.p)
+						(m.p)--
 
-	if elements, ok := interface{}(m.output.StructuredData).(*map[string]map[string]string); ok {
-		id := string(m.text())
-		if _, ok := (*elements)[id]; ok {
-			// As per RFC5424 section 6.3.2 SD-ID MUST NOT exist more than once in a message
-			m.err = fmt.Errorf(errSdIDDuplicated, m.p)
-			( m.p)--
-
-			{goto st607 }
-		} else {
-			(*elements)[id] = map[string]string{}
-			m.currentelem = id
-		}
-	}
+						{
+							goto st607
+						}
+					} else {
+						(elements)[id] = map[string]string{}
+						m.currentelem = id
+					}
+				}
 
 //line rfc5424/machine.go.rl:196
+				delete(output.StructuredData, m.currentelem)
+				if len(output.StructuredData) == 0 {
+					output.StructuredData = nil
+				}
+				m.err = fmt.Errorf(errSdID, m.p)
+				(m.p)--
 
-	delete(*m.output.StructuredData, m.currentelem)
-	if len(*m.output.StructuredData) == 0 {
-		m.output.StructuredData = nil
-	}
-	m.err = fmt.Errorf(errSdID, m.p)
-	( m.p)--
-
-    {goto st607 }
+				{
+					goto st607
+				}
 
 //line rfc5424/machine.go.rl:190
+				m.err = fmt.Errorf(errStructuredData, m.p)
+				(m.p)--
 
-	m.err = fmt.Errorf(errStructuredData, m.p)
-	( m.p)--
+				{
+					goto st607
+				}
 
-    {goto st607 }
-
-		case 60, 61, 63:
+			case 60, 61, 63:
 //line rfc5424/machine.go.rl:229
+				m.err = fmt.Errorf(errEscape, m.p)
+				(m.p)--
 
-	m.err = fmt.Errorf(errEscape, m.p)
-	( m.p)--
-
-    {goto st607 }
+				{
+					goto st607
+				}
 
 //line rfc5424/machine.go.rl:206
+				if elements, ok := interface{}(output.StructuredData).(map[string]map[string]string); ok {
+					delete((elements)[m.currentelem], m.currentparam)
+				}
+				m.err = fmt.Errorf(errSdParam, m.p)
+				(m.p)--
 
-	if elements, ok := interface{}(m.output.StructuredData).(*map[string]map[string]string); ok {
-		delete((*elements)[m.currentelem], m.currentparam)
-	}
-	m.err = fmt.Errorf(errSdParam, m.p)
-	( m.p)--
-
-    {goto st607 }
+				{
+					goto st607
+				}
 
 //line rfc5424/machine.go.rl:190
+				m.err = fmt.Errorf(errStructuredData, m.p)
+				(m.p)--
 
-	m.err = fmt.Errorf(errStructuredData, m.p)
-	( m.p)--
-
-    {goto st607 }
+				{
+					goto st607
+				}
 
 //line rfc5424/machine.go:10702
+			}
 		}
-	}
 
-	_out: {}
+	_out:
+		{
+		}
 	}
 
 //line rfc5424/machine.go.rl:407
-
+	err = m.err
 	if m.cs < rfc5424_first_final || m.cs == rfc5424_en_fail {
-		if bestEffort != nil && *bestEffort != false && m.output.Valid() {
+		if bestEffort && output.Valid() {
 			// An error occurred but partial parsing is on and partial message is minimally valid
-			return m.output, m.err
+			return
 		}
-		return nil, m.err
+		output = SyslogMessage{} //reset the output
 	}
-
-	return m.output, nil
+	return
 }

--- a/rfc5424/machine.go.rl
+++ b/rfc5424/machine.go.rl
@@ -38,11 +38,11 @@ action markmsg {
 }
 
 action set_prival {
-	m.output.SetPriority(uint8(unsafeUTF8DecimalCodePointsToInt(m.text())))
+	output.SetPriority(uint8(unsafeUTF8DecimalCodePointsToInt(m.text())))
 }
 
 action set_version {
-	m.output.Version = uint16(unsafeUTF8DecimalCodePointsToInt(m.text()))
+	output.Version = uint16(unsafeUTF8DecimalCodePointsToInt(m.text()))
 }
 
 action set_timestamp {
@@ -51,41 +51,41 @@ action set_timestamp {
 		fhold;
     	fgoto fail;
     } else {
-        m.output.Timestamp = &t
+        output.Timestamp = t
     }
 }
 
 action set_hostname {
 	if hostname := string(m.text()); hostname != "-" {
-		m.output.Hostname = &hostname
+		output.Hostname = hostname
 	}
 }
 
 action set_appname {
 	if appname := string(m.text()); appname != "-" {
-		m.output.Appname = &appname
+		output.Appname = appname
 	}
 }
 
 action set_procid {
 	if procid := string(m.text()); procid != "-" {
-		m.output.ProcID = &procid
+		output.ProcID = procid
 	}
 }
 
 action set_msgid {
 	if msgid := string(m.text()); msgid != "-" {
-		m.output.MsgID = &msgid
+		output.MsgID = msgid
 	}
 }
 
 
 action ini_elements {
-	m.output.StructuredData = &(map[string]map[string]string{})
+	output.StructuredData = (map[string]map[string]string{})
 }
 
 action set_id {
-	if elements, ok := interface{}(m.output.StructuredData).(*map[string]map[string]string); ok {
+	if elements, ok := interface{}(output.StructuredData).(*map[string]map[string]string); ok {
 		id := string(m.text())
 		if _, ok := (*elements)[id]; ok {
 			// As per RFC5424 section 6.3.2 SD-ID MUST NOT exist more than once in a message
@@ -112,7 +112,7 @@ action set_paramname {
 }
 
 action set_paramvalue {
-	if elements, ok := interface{}(m.output.StructuredData).(*map[string]map[string]string); ok {
+	if elements, ok := interface{}(output.StructuredData).(*map[string]map[string]string); ok {
 		// (fixme) > what if SD-PARAM-NAME already exist for the current element (ie., current SD-ID)?
 
 		// Store text
@@ -135,7 +135,7 @@ action set_paramvalue {
 
 action set_msg {
 	if msg := string(m.text()); msg != "" {
-		m.output.Message = &msg
+		output.Message = msg
 	}
 }
 
@@ -194,9 +194,9 @@ action err_structureddata {
 }
 
 action err_sdid {
-	delete(*m.output.StructuredData, m.currentelem)
-	if len(*m.output.StructuredData) == 0 {
-		m.output.StructuredData = nil
+	delete(output.StructuredData, m.currentelem)
+	if len(output.StructuredData) == 0 {
+		output.StructuredData = nil
 	}
 	m.err = fmt.Errorf(errSdID, m.p)
 	fhold;
@@ -204,7 +204,7 @@ action err_sdid {
 }
 
 action err_sdparam {
-	if elements, ok := interface{}(m.output.StructuredData).(*map[string]map[string]string); ok {
+	if elements, ok := interface{}(output.StructuredData).(*map[string]map[string]string); ok {
 		delete((*elements)[m.currentelem], m.currentparam)
 	}
 	m.err = fmt.Errorf(errSdParam, m.p)
@@ -217,7 +217,7 @@ action err_msg {
 	if m.msg_at > 0 {
 		// Save the text until valid (m.p is where the parser has stopped)
 		if trunc := string(m.data[m.msg_at:m.p]); trunc != "" {
-			m.output.Message = &trunc
+			output.Message = trunc
 		}
 	}
 
@@ -353,7 +353,6 @@ type machine struct {
 	p, pe, eof   int
 	pb           int
 	err          error
-	output       *SyslogMessage
 	currentelem  string
 	currentparam string
 	msg_at       int
@@ -400,18 +399,18 @@ func (m *machine) Parse(input []byte, bestEffort *bool) (*SyslogMessage, error) 
 	m.pe = len(input)
 	m.eof = len(input)
 	m.err = nil
-	m.output = &SyslogMessage{}
+	output = &SyslogMessage{}
 
     %% write init;
     %% write exec;
 
 	if m.cs < rfc5424_first_final || m.cs == rfc5424_en_fail {
-		if bestEffort != nil && *bestEffort != false && m.output.Valid() {
+		if bestEffort != nil && *bestEffort != false && output.Valid() {
 			// An error occurred but partial parsing is on and partial message is minimally valid
-			return m.output, m.err
+			return output, m.err
 		}
 		return nil, m.err
 	}
 
-	return m.output, nil
+	return output, nil
 }

--- a/rfc5424/machine_test.go
+++ b/rfc5424/machine_test.go
@@ -8,9 +8,9 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func timeParse(layout, value string) *time.Time {
+func timeParse(layout, value string) time.Time {
 	t, _ := time.Parse(layout, value)
-	return &t
+	return t
 }
 
 func getStringAddress(str string) *string {
@@ -29,9 +29,9 @@ func rxpad(str string, lim int) string {
 type testCase struct {
 	input        []byte
 	valid        bool
-	value        *SyslogMessage
+	value        SyslogMessage
 	errorString  string
-	partialValue *SyslogMessage
+	partialValue SyslogMessage
 }
 
 var testCases = []testCase{
@@ -39,21 +39,21 @@ var testCases = []testCase{
 	{
 		[]byte(""),
 		false,
-		nil,
+		SyslogMessage{},
 		"expecting a priority value within angle brackets [col 0]",
-		nil,
+		SyslogMessage{},
 	},
 	// Invalid, multiple syslog messages on multiple lines
 	{
 		[]byte(`<1>1 - - - - - -
 	<2>1 - - - - - -`),
 		false,
-		nil,
+		SyslogMessage{},
 		"parsing error [col 16]",
-		&SyslogMessage{
-			Priority: getUint8Address(1),
-			severity: getUint8Address(1),
-			facility: getUint8Address(0),
+		SyslogMessage{
+			Priority: 1,
+			severity: 1,
+			facility: 0,
 			Version:  1,
 		},
 	},
@@ -61,96 +61,96 @@ var testCases = []testCase{
 	{
 		[]byte("<1>1 - \nhostname - - - -"),
 		false,
-		nil,
+		SyslogMessage{},
 		"expecting an hostname (from 1 to max 255 US-ASCII characters) or a nil value [col 7]",
-		&SyslogMessage{
-			facility: getUint8Address(0),
-			severity: getUint8Address(1),
-			Priority: getUint8Address(1),
+		SyslogMessage{
+			facility: 0,
+			severity: 1,
+			Priority: 1,
 			Version:  1,
 		},
 	},
 	{
 		[]byte("<1>1 - host\x0Aname - - - -"),
 		false,
-		nil,
+		SyslogMessage{},
 		"expecting an hostname (from 1 to max 255 US-ASCII characters) or a nil value [col 11]",
-		&SyslogMessage{
-			facility: getUint8Address(0),
-			severity: getUint8Address(1),
-			Priority: getUint8Address(1),
+		SyslogMessage{
+			facility: 0,
+			severity: 1,
+			Priority: 1,
 			Version:  1,
 		},
 	},
 	{
 		[]byte("<1>1 - - \nan - - -"),
 		false,
-		nil,
+		SyslogMessage{},
 		"expecting an app-name (from 1 to max 48 US-ASCII characters) or a nil value [col 9]",
-		&SyslogMessage{
-			facility: getUint8Address(0),
-			severity: getUint8Address(1),
-			Priority: getUint8Address(1),
+		SyslogMessage{
+			facility: 0,
+			severity: 1,
+			Priority: 1,
 			Version:  1,
 		},
 	},
 	{
 		[]byte("<1>1 - - a\x0An - - -"),
 		false,
-		nil,
+		SyslogMessage{},
 		"expecting an app-name (from 1 to max 48 US-ASCII characters) or a nil value [col 10]",
-		&SyslogMessage{
-			facility: getUint8Address(0),
-			severity: getUint8Address(1),
-			Priority: getUint8Address(1),
+		SyslogMessage{
+			facility: 0,
+			severity: 1,
+			Priority: 1,
 			Version:  1,
 		},
 	},
 	{
 		[]byte("<1>1 - - - \npid - -"),
 		false,
-		nil,
+		SyslogMessage{},
 		"expecting a procid (from 1 to max 128 US-ASCII characters) or a nil value [col 11]",
-		&SyslogMessage{
-			facility: getUint8Address(0),
-			severity: getUint8Address(1),
-			Priority: getUint8Address(1),
+		SyslogMessage{
+			facility: 0,
+			severity: 1,
+			Priority: 1,
 			Version:  1,
 		},
 	},
 	{
 		[]byte("<1>1 - - - p\x0Aid - -"),
 		false,
-		nil,
+		SyslogMessage{},
 		"expecting a procid (from 1 to max 128 US-ASCII characters) or a nil value [col 12]",
-		&SyslogMessage{
-			facility: getUint8Address(0),
-			severity: getUint8Address(1),
-			Priority: getUint8Address(1),
+		SyslogMessage{
+			facility: 0,
+			severity: 1,
+			Priority: 1,
 			Version:  1,
 		},
 	},
 	{
 		[]byte("<1>1 - - - - \nmid -"),
 		false,
-		nil,
+		SyslogMessage{},
 		"expecting a msgid (from 1 to max 32 US-ASCII characters) or a nil value [col 13]",
-		&SyslogMessage{
-			facility: getUint8Address(0),
-			severity: getUint8Address(1),
-			Priority: getUint8Address(1),
+		SyslogMessage{
+			facility: 0,
+			severity: 1,
+			Priority: 1,
 			Version:  1,
 		},
 	},
 	{
 		[]byte("<1>1 - - - - m\x0Aid -"),
 		false,
-		nil,
+		SyslogMessage{},
 		"expecting a msgid (from 1 to max 32 US-ASCII characters) or a nil value [col 14]",
-		&SyslogMessage{
-			facility: getUint8Address(0),
-			severity: getUint8Address(1),
-			Priority: getUint8Address(1),
+		SyslogMessage{
+			facility: 0,
+			severity: 1,
+			Priority: 1,
 			Version:  1,
 		},
 	},
@@ -158,9 +158,9 @@ var testCases = []testCase{
 	{
 		[]byte("(190>122 2018-11-22"),
 		false,
-		nil,
+		SyslogMessage{},
 		"expecting a priority value within angle brackets [col 0]",
-		nil,
+		SyslogMessage{},
 	},
 	// (fixme) > Malformed pri outputs wrong error (inner error regarding prival, not the outer one regarding pri)
 	// {
@@ -168,110 +168,110 @@ var testCases = []testCase{
 	// 	false,
 	// 	nil,
 	// 	"expecting a priority value within angle brackets [col 3]",
-	// 	nil, // nil since cannot reach version
+	// 	SyslogMessage{}, // nil since cannot reach version
 	// },
 	// Invalid, missing pri
 	{
 		[]byte("122 - - - - - -"),
 		false,
-		nil,
+		SyslogMessage{},
 		"expecting a priority value within angle brackets [col 0]",
-		nil,
+		SyslogMessage{},
 	},
 	// Invalid, missing prival
 	{
 		[]byte("<>122 2018-11-22"),
 		false,
-		nil,
+		SyslogMessage{},
 		"expecting a priority value in the range 1-191 or equal to 0 [col 1]",
-		nil,
+		SyslogMessage{},
 	},
 	// Invalid, prival with too much digits
 	{
 		[]byte("<19000021>122 2018-11-22"),
 		false,
-		nil,
+		SyslogMessage{},
 		"expecting a priority value in the range 1-191 or equal to 0 [col 4]",
-		nil, // no valid partial message since was not able to reach and extract version (which is mandatory for a valid message)
+		SyslogMessage{}, // no valid partial message since was not able to reach and extract version (which is mandatory for a valid message)
 	},
 	// Invalid, prival too high
 	{
 		[]byte("<192>122 2018-11-22"),
 		false,
-		nil,
+		SyslogMessage{},
 		"expecting a priority value in the range 1-191 or equal to 0 [col 3]",
-		nil,
+		SyslogMessage{},
 	},
 	// Invalid, 0 starting prival
 	{
 		[]byte("<002>122 2018-11-22"),
 		false,
-		nil,
+		SyslogMessage{},
 		"expecting a priority value in the range 1-191 or equal to 0 [col 2]",
-		nil,
+		SyslogMessage{},
 	},
 	// Invalid, non numeric prival
 	{
 		[]byte("<aaa>122 2018-11-22"),
 		false,
-		nil,
+		SyslogMessage{},
 		"expecting a priority value in the range 1-191 or equal to 0 [col 1]",
-		nil,
+		SyslogMessage{},
 	},
 	// Invalid, missing version
 	{
 		[]byte("<100> 2018-11-22"),
 		false,
-		nil,
+		SyslogMessage{},
 		"expecting a version value in the range 1-999 [col 5]",
-		nil,
+		SyslogMessage{},
 	},
 	// Invalid, 0 version
 	{
 		[]byte("<103>0 2018-11-22"),
 		false,
-		nil,
+		SyslogMessage{},
 		"expecting a version value in the range 1-999 [col 5]",
-		nil,
+		SyslogMessage{},
 	},
 	// Invalid, out of range version
 	{
 		[]byte("<101>1000 2018-11-22"),
 		false,
-		nil,
+		SyslogMessage{},
 		"expecting a version value in the range 1-999 [col 8]",
-		nil,
+		SyslogMessage{},
 	},
 	// Invalid, non numeric version
 	{
 		[]byte("<102>abc 2018-11-22"),
 		false,
-		nil,
+		SyslogMessage{},
 		"expecting a version value in the range 1-999 [col 5]",
-		nil,
+		SyslogMessage{},
 	},
 	// Invalid, wrong year
 	{
 		[]byte("<101>122 201-11-22"),
 		false,
-		nil,
+		SyslogMessage{},
 		"expecting a RFC3339 or a RFC3339NANO timestamp or a nil value [col 12]",
-		&SyslogMessage{
-			Priority: getUint8Address(101),
-			facility: getUint8Address(12),
-			severity: getUint8Address(5),
+		SyslogMessage{
+			Priority: 101,
+			facility: 12,
+			severity: 5,
 			Version:  122,
 		},
 	},
 	{
 		[]byte("<101>189 0-11-22"),
 		false,
-		nil,
+		SyslogMessage{},
 		"expecting a RFC3339 or a RFC3339NANO timestamp or a nil value [col 10]",
-		&SyslogMessage{
-			Priority: getUint8Address(101),
-			facility: getUint8Address(12),
-			severity: getUint8Address(5),
+		SyslogMessage{
+			Priority: 101,
+			facility: 12,
+			severity: 5,
 			Version:  189,
 		},
 	},
@@ -279,12 +279,12 @@ var testCases = []testCase{
 	{
 		[]byte("<101>122 2018-112-22"),
 		false,
-		nil,
+		SyslogMessage{},
 		"expecting a RFC3339 or a RFC3339NANO timestamp or a nil value [col 16]",
-		&SyslogMessage{
-			Priority: getUint8Address(101),
-			facility: getUint8Address(12),
-			severity: getUint8Address(5),
+		SyslogMessage{
+			Priority: 101,
+			facility: 12,
+			severity: 5,
 			Version:  122,
 		},
 	},
@@ -292,12 +292,12 @@ var testCases = []testCase{
 	{
 		[]byte("<101>123 2018-02-32"),
 		false,
-		nil,
+		SyslogMessage{},
 		"expecting a RFC3339 or a RFC3339NANO timestamp or a nil value [col 18]",
-		&SyslogMessage{
-			Priority: getUint8Address(101),
-			facility: getUint8Address(12),
-			severity: getUint8Address(5),
+		SyslogMessage{
+			Priority: 101,
+			facility: 12,
+			severity: 5,
 			Version:  123,
 		},
 	},
@@ -305,12 +305,12 @@ var testCases = []testCase{
 	{
 		[]byte("<101>124 2018-02-01:25:15Z"),
 		false,
-		nil,
+		SyslogMessage{},
 		"expecting a RFC3339 or a RFC3339NANO timestamp or a nil value [col 19]",
-		&SyslogMessage{
-			Priority: getUint8Address(101),
-			facility: getUint8Address(12),
-			severity: getUint8Address(5),
+		SyslogMessage{
+			Priority: 101,
+			facility: 12,
+			severity: 5,
 			Version:  124,
 		},
 	},
@@ -318,12 +318,12 @@ var testCases = []testCase{
 	{
 		[]byte("<101>125 2003-09-29T22:99:16Z"),
 		false,
-		nil,
+		SyslogMessage{},
 		"expecting a RFC3339 or a RFC3339NANO timestamp or a nil value [col 23]",
-		&SyslogMessage{
-			Priority: getUint8Address(101),
-			facility: getUint8Address(12),
-			severity: getUint8Address(5),
+		SyslogMessage{
+			Priority: 101,
+			facility: 12,
+			severity: 5,
 			Version:  125,
 		},
 	},
@@ -331,12 +331,12 @@ var testCases = []testCase{
 	{
 		[]byte("<101>126 2003-09-29T22:09:99Z"),
 		false,
-		nil,
+		SyslogMessage{},
 		"expecting a RFC3339 or a RFC3339NANO timestamp or a nil value [col 26]",
-		&SyslogMessage{
-			Priority: getUint8Address(101),
-			facility: getUint8Address(12),
-			severity: getUint8Address(5),
+		SyslogMessage{
+			Priority: 101,
+			facility: 12,
+			severity: 5,
 			Version:  126,
 		},
 	},
@@ -344,36 +344,36 @@ var testCases = []testCase{
 	{
 		[]byte("<101>127 2003-09-29T22:09:01.000000000009Z"),
 		false,
-		nil,
+		SyslogMessage{},
 		"expecting a RFC3339 or a RFC3339NANO timestamp or a nil value [col 35]",
-		&SyslogMessage{
-			Priority: getUint8Address(101),
-			facility: getUint8Address(12),
-			severity: getUint8Address(5),
+		SyslogMessage{
+			Priority: 101,
+			facility: 12,
+			severity: 5,
 			Version:  127,
 		},
 	},
 	{
 		[]byte("<101>128 2003-09-29T22:09:01.Z"),
 		false,
-		nil,
+		SyslogMessage{},
 		"expecting a RFC3339 or a RFC3339NANO timestamp or a nil value [col 29]",
-		&SyslogMessage{
-			Priority: getUint8Address(101),
-			facility: getUint8Address(12),
-			severity: getUint8Address(5),
+		SyslogMessage{
+			Priority: 101,
+			facility: 12,
+			severity: 5,
 			Version:  128,
 		},
 	},
 	{
 		[]byte("<101>28 2003-09-29T22:09:01."),
 		false,
-		nil,
+		SyslogMessage{},
 		"expecting a RFC3339 or a RFC3339NANO timestamp or a nil value [col 28]",
-		&SyslogMessage{
-			Priority: getUint8Address(101),
-			facility: getUint8Address(12),
-			severity: getUint8Address(5),
+		SyslogMessage{
+			Priority: 101,
+			facility: 12,
+			severity: 5,
 			Version:  28,
 		},
 	},
@@ -381,48 +381,48 @@ var testCases = []testCase{
 	{
 		[]byte("<101>129 2003-09-29T22:09:01A"),
 		false,
-		nil,
+		SyslogMessage{},
 		"expecting a RFC3339 or a RFC3339NANO timestamp or a nil value [col 28]",
-		&SyslogMessage{
-			Priority: getUint8Address(101),
-			facility: getUint8Address(12),
-			severity: getUint8Address(5),
+		SyslogMessage{
+			Priority: 101,
+			facility: 12,
+			severity: 5,
 			Version:  129,
 		},
 	},
 	{
 		[]byte("<101>130 2003-08-24T05:14:15.000003-24:00"),
 		false,
-		nil,
+		SyslogMessage{},
 		"expecting a RFC3339 or a RFC3339NANO timestamp or a nil value [col 37]",
-		&SyslogMessage{
-			Priority: getUint8Address(101),
-			facility: getUint8Address(12),
-			severity: getUint8Address(5),
+		SyslogMessage{
+			Priority: 101,
+			facility: 12,
+			severity: 5,
 			Version:  130,
 		},
 	},
 	{
 		[]byte("<101>131 2003-08-24T05:14:15.000003-60:00"),
 		false,
-		nil,
+		SyslogMessage{},
 		"expecting a RFC3339 or a RFC3339NANO timestamp or a nil value [col 36]",
-		&SyslogMessage{
-			Priority: getUint8Address(101),
-			facility: getUint8Address(12),
-			severity: getUint8Address(5),
+		SyslogMessage{
+			Priority: 101,
+			facility: 12,
+			severity: 5,
 			Version:  131,
 		},
 	},
 	{
 		[]byte("<101>132 2003-08-24T05:14:15.000003-07:61"),
 		false,
-		nil,
+		SyslogMessage{},
 		"expecting a RFC3339 or a RFC3339NANO timestamp or a nil value [col 39]",
-		&SyslogMessage{
-			Priority: getUint8Address(101),
-			facility: getUint8Address(12),
-			severity: getUint8Address(5),
+		SyslogMessage{
+			Priority: 101,
+			facility: 12,
+			severity: 5,
 			Version:  132,
 		},
 	},
@@ -430,36 +430,36 @@ var testCases = []testCase{
 	{
 		[]byte("<101>11 2003-09-31T22:14:15.003Z"),
 		false,
-		nil,
+		SyslogMessage{},
 		"parsing time \"2003-09-31T22:14:15.003Z\": day out of range [col 32]",
-		&SyslogMessage{
-			Priority: getUint8Address(101),
-			facility: getUint8Address(12),
-			severity: getUint8Address(5),
+		SyslogMessage{
+			Priority: 101,
+			facility: 12,
+			severity: 5,
 			Version:  11,
 		},
 	},
 	{
 		[]byte("<101>12 2003-09-31T22:14:16Z"),
 		false,
-		nil,
+		SyslogMessage{},
 		"parsing time \"2003-09-31T22:14:16Z\": day out of range [col 28]",
-		&SyslogMessage{
-			Priority: getUint8Address(101),
-			facility: getUint8Address(12),
-			severity: getUint8Address(5),
+		SyslogMessage{
+			Priority: 101,
+			facility: 12,
+			severity: 5,
 			Version:  12,
 		},
 	},
 	{
 		[]byte("<101>12 2018-02-29T22:14:16+01:00"),
 		false,
-		nil,
+		SyslogMessage{},
 		"parsing time \"2018-02-29T22:14:16+01:00\": day out of range [col 33]",
-		&SyslogMessage{
-			Priority: getUint8Address(101),
-			facility: getUint8Address(12),
-			severity: getUint8Address(5),
+		SyslogMessage{
+			Priority: 101,
+			facility: 12,
+			severity: 5,
 			Version:  12,
 		},
 	},
@@ -467,24 +467,24 @@ var testCases = []testCase{
 	{
 		[]byte("<1>1 - abcdefghilmnopqrstuvzabcdefghilmnopqrstuvzabcdefghilmnopqrstuvzabcdefghilmnopqrstuvzabcdefghilmnopqrstuvzabcdefghilmnopqrstuvzabcdefghilmnopqrstuvzabcdefghilmnopqrstuvzabcdefghilmnopqrstuvzabcdefghilmnopqrstuvzabcdefghilmnopqrstuvzabcdefghilmnopqrstuvzabcX - - - -"),
 		false,
-		nil,
+		SyslogMessage{},
 		"expecting an hostname (from 1 to max 255 US-ASCII characters) or a nil value [col 262]",
-		&SyslogMessage{
-			Priority: getUint8Address(1),
-			facility: getUint8Address(0),
-			severity: getUint8Address(1),
+		SyslogMessage{
+			Priority: 1,
+			facility: 0,
+			severity: 1,
 			Version:  1,
 		},
 	},
 	{
 		[]byte("<1>1 2003-09-29T22:14:16Z abcdefghilmnopqrstuvzabcdefghilmnopqrstuvzabcdefghilmnopqrstuvzabcdefghilmnopqrstuvzabcdefghilmnopqrstuvzabcdefghilmnopqrstuvzabcdefghilmnopqrstuvzabcdefghilmnopqrstuvzabcdefghilmnopqrstuvzabcdefghilmnopqrstuvzabcdefghilmnopqrstuvzabcdefghilmnopqrstuvzabcX - - - -"),
 		false,
-		nil,
+		SyslogMessage{},
 		"expecting an hostname (from 1 to max 255 US-ASCII characters) or a nil value [col 281]",
-		&SyslogMessage{
-			Priority:  getUint8Address(1),
-			facility:  getUint8Address(0),
-			severity:  getUint8Address(1),
+		SyslogMessage{
+			Priority:  1,
+			facility:  0,
+			severity:  1,
 			Version:   1,
 			Timestamp: timeParse(time.RFC3339Nano, "2003-09-29T22:14:16Z"),
 		},
@@ -493,24 +493,24 @@ var testCases = []testCase{
 	{
 		[]byte("<1>1 - - abcdefghilmnopqrstuvzabcdefghilmnopqrstuvzabcdefX - - -"),
 		false,
-		nil,
+		SyslogMessage{},
 		"expecting an app-name (from 1 to max 48 US-ASCII characters) or a nil value [col 57]",
-		&SyslogMessage{
-			Priority: getUint8Address(1),
-			facility: getUint8Address(0),
-			severity: getUint8Address(1),
+		SyslogMessage{
+			Priority: 1,
+			facility: 0,
+			severity: 1,
 			Version:  1,
 		},
 	},
 	{
 		[]byte("<1>1 2003-09-29T22:14:16Z - abcdefghilmnopqrstuvzabcdefghilmnopqrstuvzabcdefX - - -"),
 		false,
-		nil,
+		SyslogMessage{},
 		"expecting an app-name (from 1 to max 48 US-ASCII characters) or a nil value [col 76]",
-		&SyslogMessage{
-			Priority:  getUint8Address(1),
-			facility:  getUint8Address(0),
-			severity:  getUint8Address(1),
+		SyslogMessage{
+			Priority:  1,
+			facility:  0,
+			severity:  1,
 			Version:   1,
 			Timestamp: timeParse(time.RFC3339Nano, "2003-09-29T22:14:16Z"),
 		},
@@ -518,40 +518,40 @@ var testCases = []testCase{
 	{
 		[]byte("<1>1 - host abcdefghilmnopqrstuvzabcdefghilmnopqrstuvzabcdefX - - -"),
 		false,
-		nil,
+		SyslogMessage{},
 		"expecting an app-name (from 1 to max 48 US-ASCII characters) or a nil value [col 60]",
-		&SyslogMessage{
-			Priority: getUint8Address(1),
-			facility: getUint8Address(0),
-			severity: getUint8Address(1),
+		SyslogMessage{
+			Priority: 1,
+			facility: 0,
+			severity: 1,
 			Version:  1,
-			Hostname: getStringAddress("host"),
+			Hostname: "host",
 		},
 	},
 	{
 		[]byte("<1>1 2003-09-29T22:14:16Z host abcdefghilmnopqrstuvzabcdefghilmnopqrstuvzabcdefX - - -"),
 		false,
-		nil,
+		SyslogMessage{},
 		"expecting an app-name (from 1 to max 48 US-ASCII characters) or a nil value [col 79]",
-		&SyslogMessage{
-			Priority:  getUint8Address(1),
-			facility:  getUint8Address(0),
-			severity:  getUint8Address(1),
+		SyslogMessage{
+			Priority:  1,
+			facility:  0,
+			severity:  1,
 			Version:   1,
 			Timestamp: timeParse(time.RFC3339Nano, "2003-09-29T22:14:16Z"),
-			Hostname:  getStringAddress("host"),
+			Hostname:  "host",
 		},
 	},
 	// Invalid, procid too long
 	{
 		[]byte("<1>1 - - - abcdefghilmnopqrstuvzabcdefghilmnopqrstuvzabcdefghilmnopqrstuvzabcdefghilmnopqrstuvzabcdefghilmnopqrstuvzabcdefghilmnopqrstuvzabX - -"),
 		false,
-		nil,
+		SyslogMessage{},
 		"expecting a procid (from 1 to max 128 US-ASCII characters) or a nil value [col 139]",
-		&SyslogMessage{
-			Priority: getUint8Address(1),
-			facility: getUint8Address(0),
-			severity: getUint8Address(1),
+		SyslogMessage{
+			Priority: 1,
+			facility: 0,
+			severity: 1,
 			Version:  1,
 		},
 	},
@@ -559,12 +559,12 @@ var testCases = []testCase{
 	{
 		[]byte("<1>1 - - - - abcdefghilmnopqrstuvzabcdefghilmX -"),
 		false,
-		nil,
+		SyslogMessage{},
 		"expecting a msgid (from 1 to max 32 US-ASCII characters) or a nil value [col 45]",
-		&SyslogMessage{
-			Priority: getUint8Address(1),
-			facility: getUint8Address(0),
-			severity: getUint8Address(1),
+		SyslogMessage{
+			Priority: 1,
+			facility: 0,
+			severity: 1,
 			Version:  1,
 		},
 	},
@@ -572,48 +572,48 @@ var testCases = []testCase{
 	{
 		[]byte("<1>1 -   - - - -"),
 		false,
-		nil,
+		SyslogMessage{},
 		"expecting an hostname (from 1 to max 255 US-ASCII characters) or a nil value [col 7]",
-		&SyslogMessage{
-			Priority: getUint8Address(1),
-			facility: getUint8Address(0),
-			severity: getUint8Address(1),
+		SyslogMessage{
+			Priority: 1,
+			facility: 0,
+			severity: 1,
 			Version:  1,
 		},
 	},
 	{
 		[]byte("<1>1 - -   - - -"),
 		false,
-		nil,
+		SyslogMessage{},
 		"expecting an app-name (from 1 to max 48 US-ASCII characters) or a nil value [col 9]",
-		&SyslogMessage{
-			Priority: getUint8Address(1),
-			facility: getUint8Address(0),
-			severity: getUint8Address(1),
+		SyslogMessage{
+			Priority: 1,
+			facility: 0,
+			severity: 1,
 			Version:  1,
 		},
 	},
 	{
 		[]byte("<1>1 - - -   - -"),
 		false,
-		nil,
+		SyslogMessage{},
 		"expecting a procid (from 1 to max 128 US-ASCII characters) or a nil value [col 11]",
-		&SyslogMessage{
-			Priority: getUint8Address(1),
-			facility: getUint8Address(0),
-			severity: getUint8Address(1),
+		SyslogMessage{
+			Priority: 1,
+			facility: 0,
+			severity: 1,
 			Version:  1,
 		},
 	},
 	{
 		[]byte("<1>1 - - - -   -"),
 		false,
-		nil,
+		SyslogMessage{},
 		"expecting a msgid (from 1 to max 32 US-ASCII characters) or a nil value [col 13]",
-		&SyslogMessage{
-			Priority: getUint8Address(1),
-			facility: getUint8Address(0),
-			severity: getUint8Address(1),
+		SyslogMessage{
+			Priority: 1,
+			facility: 0,
+			severity: 1,
 			Version:  1,
 		},
 	},
@@ -621,12 +621,12 @@ var testCases = []testCase{
 	{
 		[]byte("<1>1 - - - - - X"),
 		false,
-		nil,
+		SyslogMessage{},
 		"expecting a structured data section containing one or more elements (`[id( key=\"value\")*]+`) or a nil value [col 15]",
-		&SyslogMessage{
-			Priority: getUint8Address(1),
-			facility: getUint8Address(0),
-			severity: getUint8Address(1),
+		SyslogMessage{
+			Priority: 1,
+			facility: 0,
+			severity: 1,
 			Version:  1,
 		},
 	},
@@ -634,12 +634,12 @@ var testCases = []testCase{
 	{
 		[]byte("<1>1 - - - - - []"),
 		false,
-		nil,
+		SyslogMessage{},
 		"expecting a structured data element id (from 1 to max 32 US-ASCII characters; except `=`, ` `, `]`, and `\"` [col 16]",
-		&SyslogMessage{
-			Priority:       getUint8Address(1),
-			facility:       getUint8Address(0),
-			severity:       getUint8Address(1),
+		SyslogMessage{
+			Priority:       1,
+			facility:       0,
+			severity:       1,
 			Version:        1,
 			StructuredData: nil,
 		},
@@ -648,12 +648,12 @@ var testCases = []testCase{
 	{
 		[]byte("<1>1 - - - - - [ ]"),
 		false,
-		nil,
+		SyslogMessage{},
 		"expecting a structured data element id (from 1 to max 32 US-ASCII characters; except `=`, ` `, `]`, and `\"` [col 16]",
-		&SyslogMessage{
-			Priority:       getUint8Address(1),
-			facility:       getUint8Address(0),
-			severity:       getUint8Address(1),
+		SyslogMessage{
+			Priority:       1,
+			facility:       0,
+			severity:       1,
 			Version:        1,
 			StructuredData: nil,
 		},
@@ -662,12 +662,12 @@ var testCases = []testCase{
 	{
 		[]byte("<1>1 - - - - - [=]"),
 		false,
-		nil,
+		SyslogMessage{},
 		"expecting a structured data element id (from 1 to max 32 US-ASCII characters; except `=`, ` `, `]`, and `\"` [col 16]",
-		&SyslogMessage{
-			Priority:       getUint8Address(1),
-			facility:       getUint8Address(0),
-			severity:       getUint8Address(1),
+		SyslogMessage{
+			Priority:       1,
+			facility:       0,
+			severity:       1,
 			Version:        1,
 			StructuredData: nil,
 		},
@@ -676,12 +676,12 @@ var testCases = []testCase{
 	{
 		[]byte("<1>1 - - - - - []]"),
 		false,
-		nil,
+		SyslogMessage{},
 		"expecting a structured data element id (from 1 to max 32 US-ASCII characters; except `=`, ` `, `]`, and `\"` [col 16]",
-		&SyslogMessage{
-			Priority:       getUint8Address(1),
-			facility:       getUint8Address(0),
-			severity:       getUint8Address(1),
+		SyslogMessage{
+			Priority:       1,
+			facility:       0,
+			severity:       1,
 			Version:        1,
 			StructuredData: nil,
 		},
@@ -690,12 +690,12 @@ var testCases = []testCase{
 	{
 		[]byte(`<1>1 - - - - - ["]`),
 		false,
-		nil,
+		SyslogMessage{},
 		"expecting a structured data element id (from 1 to max 32 US-ASCII characters; except `=`, ` `, `]`, and `\"` [col 16]",
-		&SyslogMessage{
-			Priority:       getUint8Address(1),
-			facility:       getUint8Address(0),
-			severity:       getUint8Address(1),
+		SyslogMessage{
+			Priority:       1,
+			facility:       0,
+			severity:       1,
 			Version:        1,
 			StructuredData: nil,
 		},
@@ -704,12 +704,12 @@ var testCases = []testCase{
 	{
 		[]byte(`<1>1 - - - - - [abcdefghilmnopqrstuvzabcdefghilmX]`),
 		false,
-		nil,
+		SyslogMessage{},
 		"expecting a structured data element id (from 1 to max 32 US-ASCII characters; except `=`, ` `, `]`, and `\"` [col 48]",
-		&SyslogMessage{
-			Priority:       getUint8Address(1),
-			facility:       getUint8Address(0),
-			severity:       getUint8Address(1),
+		SyslogMessage{
+			Priority:       1,
+			facility:       0,
+			severity:       1,
 			Version:        1,
 			StructuredData: nil,
 		},
@@ -718,14 +718,14 @@ var testCases = []testCase{
 	{
 		[]byte(`<1>1 - - - - - [id abcdefghilmnopqrstuvzabcdefghilmX="val"]`),
 		false,
-		nil,
+		SyslogMessage{},
 		"expecting a structured data parameter (`key=\"value\"`, both part from 1 to max 32 US-ASCII characters; key cannot contain `=`, ` `, `]`, and `\"`, while value cannot contain `]`, backslash, and `\"` unless escaped) [col 51]",
-		&SyslogMessage{
-			Priority: getUint8Address(1),
-			facility: getUint8Address(0),
-			severity: getUint8Address(1),
+		SyslogMessage{
+			Priority: 1,
+			facility: 0,
+			severity: 1,
 			Version:  1,
-			StructuredData: &map[string]map[string]string{
+			StructuredData: map[string]map[string]string{
 				"id": map[string]string{},
 			},
 		},
@@ -734,40 +734,40 @@ var testCases = []testCase{
 	{
 		[]byte("<1>1 - - - - - -"),
 		true,
-		&SyslogMessage{
-			facility: getUint8Address(0),
-			severity: getUint8Address(1),
-			Priority: getUint8Address(1),
+		SyslogMessage{
+			facility: 0,
+			severity: 1,
+			Priority: 1,
 			Version:  1,
 		},
 		"",
-		nil,
+		SyslogMessage{},
 	},
 	{
 		[]byte("<0>1 - - - - - -"),
 		true,
-		&SyslogMessage{
-			Priority: getUint8Address(0),
-			facility: getUint8Address(0),
-			severity: getUint8Address(0),
+		SyslogMessage{
+			Priority: 0,
+			facility: 0,
+			severity: 0,
 			Version:  1,
 		},
 		"",
-		nil,
+		SyslogMessage{},
 	},
 	// Valid, average message
 	{
 		[]byte(`<29>1 2016-02-21T04:32:57+00:00 web1 someservice - - [origin x-service="someservice"][meta sequenceId="14125553"] 127.0.0.1 - - 1456029177 "GET /v1/ok HTTP/1.1" 200 145 "-" "hacheck 0.9.0" 24306 127.0.0.1:40124 575`),
 		true,
-		&SyslogMessage{
-			facility:  getUint8Address(3),
-			severity:  getUint8Address(5),
-			Priority:  getUint8Address(29),
+		SyslogMessage{
+			facility:  3,
+			severity:  5,
+			Priority:  29,
 			Version:   1,
 			Timestamp: timeParse(time.RFC3339Nano, "2016-02-21T04:32:57+00:00"),
-			Hostname:  getStringAddress("web1"),
-			Appname:   getStringAddress("someservice"),
-			StructuredData: &map[string]map[string]string{
+			Hostname:  "web1",
+			Appname:   "someservice",
+			StructuredData: map[string]map[string]string{
 				"origin": map[string]string{
 					"x-service": "someservice",
 				},
@@ -775,103 +775,103 @@ var testCases = []testCase{
 					"sequenceId": "14125553",
 				},
 			},
-			Message: getStringAddress(`127.0.0.1 - - 1456029177 "GET /v1/ok HTTP/1.1" 200 145 "-" "hacheck 0.9.0" 24306 127.0.0.1:40124 575`),
+			Message: `127.0.0.1 - - 1456029177 "GET /v1/ok HTTP/1.1" 200 145 "-" "hacheck 0.9.0" 24306 127.0.0.1:40124 575`,
 		},
 		"",
-		nil,
+		SyslogMessage{},
 	},
 	// Valid, hostname, appname, procid, msgid can contain dashes
 	{
 		[]byte("<1>100 - host-name - - - -"),
 		true,
-		&SyslogMessage{
-			facility: getUint8Address(0),
-			severity: getUint8Address(1),
-			Priority: getUint8Address(1),
+		SyslogMessage{
+			facility: 0,
+			severity: 1,
+			Priority: 1,
 			Version:  100,
-			Hostname: getStringAddress("host-name"),
+			Hostname: "host-name",
 		},
 		"",
-		nil,
+		SyslogMessage{},
 	},
 	{
 		[]byte("<1>101 - host-name app-name - - -"),
 		true,
-		&SyslogMessage{
-			facility: getUint8Address(0),
-			severity: getUint8Address(1),
-			Priority: getUint8Address(1),
+		SyslogMessage{
+			facility: 0,
+			severity: 1,
+			Priority: 1,
 			Version:  101,
-			Hostname: getStringAddress("host-name"),
-			Appname:  getStringAddress("app-name"),
+			Hostname: "host-name",
+			Appname:  "app-name",
 		},
 		"",
-		nil,
+		SyslogMessage{},
 	},
 	{
 		[]byte("<1>102 - host-name app-name proc-id - -"),
 		true,
-		&SyslogMessage{
-			facility: getUint8Address(0),
-			severity: getUint8Address(1),
-			Priority: getUint8Address(1),
+		SyslogMessage{
+			facility: 0,
+			severity: 1,
+			Priority: 1,
 			Version:  102,
-			Hostname: getStringAddress("host-name"),
-			Appname:  getStringAddress("app-name"),
-			ProcID:   getStringAddress("proc-id"),
+			Hostname: "host-name",
+			Appname:  "app-name",
+			ProcID:   "proc-id",
 		},
 		"",
-		nil,
+		SyslogMessage{},
 	},
 	{
 		[]byte("<1>103 - host-name app-name proc-id msg-id -"),
 		true,
-		&SyslogMessage{
-			facility: getUint8Address(0),
-			severity: getUint8Address(1),
-			Priority: getUint8Address(1),
+		SyslogMessage{
+			facility: 0,
+			severity: 1,
+			Priority: 1,
 			Version:  103,
-			Hostname: getStringAddress("host-name"),
-			Appname:  getStringAddress("app-name"),
-			ProcID:   getStringAddress("proc-id"),
-			MsgID:    getStringAddress("msg-id"),
+			Hostname: "host-name",
+			Appname:  "app-name",
+			ProcID:   "proc-id",
+			MsgID:    "msg-id",
 		},
 		"",
-		nil,
+		SyslogMessage{},
 	},
 	// Valid, w/0 structured data and w/o message, with other fields all max length
 	{
 		[]byte("<191>999 2018-12-31T23:59:59.999999-23:59 abcdefghilmnopqrstuvzabcdefghilmnopqrstuvzabcdefghilmnopqrstuvzabcdefghilmnopqrstuvzabcdefghilmnopqrstuvzabcdefghilmnopqrstuvzabcdefghilmnopqrstuvzabcdefghilmnopqrstuvzabcdefghilmnopqrstuvzabcdefghilmnopqrstuvzabcdefghilmnopqrstuvzabcdefghilmnopqrstuvzabc abcdefghilmnopqrstuvzabcdefghilmnopqrstuvzabcdef abcdefghilmnopqrstuvzabcdefghilmnopqrstuvzabcdefghilmnopqrstuvzabcdefghilmnopqrstuvzabcdefghilmnopqrstuvzabcdefghilmnopqrstuvzab abcdefghilmnopqrstuvzabcdefghilm -"),
 		true,
-		&SyslogMessage{
-			Priority:  getUint8Address(191),
-			facility:  getUint8Address(23),
-			severity:  getUint8Address(7),
+		SyslogMessage{
+			Priority:  191,
+			facility:  23,
+			severity:  7,
 			Version:   999,
 			Timestamp: timeParse(time.RFC3339Nano, "2018-12-31T23:59:59.999999-23:59"),
-			Hostname:  getStringAddress("abcdefghilmnopqrstuvzabcdefghilmnopqrstuvzabcdefghilmnopqrstuvzabcdefghilmnopqrstuvzabcdefghilmnopqrstuvzabcdefghilmnopqrstuvzabcdefghilmnopqrstuvzabcdefghilmnopqrstuvzabcdefghilmnopqrstuvzabcdefghilmnopqrstuvzabcdefghilmnopqrstuvzabcdefghilmnopqrstuvzabc"),
-			Appname:   getStringAddress("abcdefghilmnopqrstuvzabcdefghilmnopqrstuvzabcdef"),
-			ProcID:    getStringAddress("abcdefghilmnopqrstuvzabcdefghilmnopqrstuvzabcdefghilmnopqrstuvzabcdefghilmnopqrstuvzabcdefghilmnopqrstuvzabcdefghilmnopqrstuvzab"),
-			MsgID:     getStringAddress("abcdefghilmnopqrstuvzabcdefghilm"),
+			Hostname:  "abcdefghilmnopqrstuvzabcdefghilmnopqrstuvzabcdefghilmnopqrstuvzabcdefghilmnopqrstuvzabcdefghilmnopqrstuvzabcdefghilmnopqrstuvzabcdefghilmnopqrstuvzabcdefghilmnopqrstuvzabcdefghilmnopqrstuvzabcdefghilmnopqrstuvzabcdefghilmnopqrstuvzabcdefghilmnopqrstuvzabc",
+			Appname:   "abcdefghilmnopqrstuvzabcdefghilmnopqrstuvzabcdef",
+			ProcID:    "abcdefghilmnopqrstuvzabcdefghilmnopqrstuvzabcdefghilmnopqrstuvzabcdefghilmnopqrstuvzabcdefghilmnopqrstuvzabcdefghilmnopqrstuvzab",
+			MsgID:     "abcdefghilmnopqrstuvzabcdefghilm",
 		},
 		"",
-		nil,
+		SyslogMessage{},
 	},
 	// Valid, all fields max length, with structured data and message
 	{
 		[]byte(`<191>999 2018-12-31T23:59:59.999999-23:59 abcdefghilmnopqrstuvzabcdefghilmnopqrstuvzabcdefghilmnopqrstuvzabcdefghilmnopqrstuvzabcdefghilmnopqrstuvzabcdefghilmnopqrstuvzabcdefghilmnopqrstuvzabcdefghilmnopqrstuvzabcdefghilmnopqrstuvzabcdefghilmnopqrstuvzabcdefghilmnopqrstuvzabcdefghilmnopqrstuvzabc abcdefghilmnopqrstuvzabcdefghilmnopqrstuvzabcdef abcdefghilmnopqrstuvzabcdefghilmnopqrstuvzabcdefghilmnopqrstuvzabcdefghilmnopqrstuvzabcdefghilmnopqrstuvzabcdefghilmnopqrstuvzab abcdefghilmnopqrstuvzabcdefghilm [an@id key1="val1" key2="val2"][another@id key1="val1"] Some message "GET"`),
 		true,
-		&SyslogMessage{
-			Priority:  getUint8Address(191),
-			facility:  getUint8Address(23),
-			severity:  getUint8Address(7),
+		SyslogMessage{
+			Priority:  191,
+			facility:  23,
+			severity:  7,
 			Version:   999,
 			Timestamp: timeParse(time.RFC3339Nano, "2018-12-31T23:59:59.999999-23:59"),
-			Hostname:  getStringAddress("abcdefghilmnopqrstuvzabcdefghilmnopqrstuvzabcdefghilmnopqrstuvzabcdefghilmnopqrstuvzabcdefghilmnopqrstuvzabcdefghilmnopqrstuvzabcdefghilmnopqrstuvzabcdefghilmnopqrstuvzabcdefghilmnopqrstuvzabcdefghilmnopqrstuvzabcdefghilmnopqrstuvzabcdefghilmnopqrstuvzabc"),
-			Appname:   getStringAddress("abcdefghilmnopqrstuvzabcdefghilmnopqrstuvzabcdef"),
-			ProcID:    getStringAddress("abcdefghilmnopqrstuvzabcdefghilmnopqrstuvzabcdefghilmnopqrstuvzabcdefghilmnopqrstuvzabcdefghilmnopqrstuvzabcdefghilmnopqrstuvzab"),
-			MsgID:     getStringAddress("abcdefghilmnopqrstuvzabcdefghilm"),
-			StructuredData: &map[string]map[string]string{
+			Hostname:  "abcdefghilmnopqrstuvzabcdefghilmnopqrstuvzabcdefghilmnopqrstuvzabcdefghilmnopqrstuvzabcdefghilmnopqrstuvzabcdefghilmnopqrstuvzabcdefghilmnopqrstuvzabcdefghilmnopqrstuvzabcdefghilmnopqrstuvzabcdefghilmnopqrstuvzabcdefghilmnopqrstuvzabcdefghilmnopqrstuvzabc",
+			Appname:   "abcdefghilmnopqrstuvzabcdefghilmnopqrstuvzabcdef",
+			ProcID:    "abcdefghilmnopqrstuvzabcdefghilmnopqrstuvzabcdefghilmnopqrstuvzabcdefghilmnopqrstuvzabcdefghilmnopqrstuvzabcdefghilmnopqrstuvzab",
+			MsgID:     "abcdefghilmnopqrstuvzabcdefghilm",
+			StructuredData: map[string]map[string]string{
 				"an@id": map[string]string{
 					"key1": "val1",
 					"key2": "val2",
@@ -880,237 +880,237 @@ var testCases = []testCase{
 					"key1": "val1",
 				},
 			},
-			Message: getStringAddress(`Some message "GET"`),
+			Message: `Some message "GET"`,
 		},
 		"",
-		nil,
+		SyslogMessage{},
 	},
 	// Valid, w/o structure data, w/0 procid
 	{
 		[]byte("<34>1 2003-10-11T22:14:15.003Z mymachine.example.com su - ID47 - BOM'su root' failed for lonvick on /dev/pts/8"),
 		true,
-		&SyslogMessage{
-			facility:       getUint8Address(4),
-			severity:       getUint8Address(2),
-			Priority:       getUint8Address(34),
+		SyslogMessage{
+			facility:       4,
+			severity:       2,
+			Priority:       34,
 			Version:        1,
 			Timestamp:      timeParse(time.RFC3339Nano, "2003-10-11T22:14:15.003Z"),
-			Hostname:       getStringAddress("mymachine.example.com"),
-			Appname:        getStringAddress("su"),
-			ProcID:         nil,
-			MsgID:          getStringAddress("ID47"),
+			Hostname:       "mymachine.example.com",
+			Appname:        "su",
+			ProcID:         ``,
+			MsgID:          "ID47",
 			StructuredData: nil,
-			Message:        getStringAddress("BOM'su root' failed for lonvick on /dev/pts/8"),
+			Message:        "BOM'su root' failed for lonvick on /dev/pts/8",
 		},
 		"",
-		nil,
+		SyslogMessage{},
 	},
 	// Valid, w/o structure data, w/o timestamp
 	{
 		[]byte("<187>222 - mymachine.example.com su - ID47 - 'su root' failed for lonvick on /dev/pts/8"),
 		true,
-		&SyslogMessage{
-			facility:       getUint8Address(23),
-			severity:       getUint8Address(3),
-			Priority:       getUint8Address(187),
+		SyslogMessage{
+			facility:       23,
+			severity:       3,
+			Priority:       187,
 			Version:        222,
-			Timestamp:      nil,
-			Hostname:       getStringAddress("mymachine.example.com"),
-			Appname:        getStringAddress("su"),
-			ProcID:         nil,
-			MsgID:          getStringAddress("ID47"),
+			Timestamp:      time.Time{},
+			Hostname:       "mymachine.example.com",
+			Appname:        "su",
+			ProcID:         ``,
+			MsgID:          "ID47",
 			StructuredData: nil,
-			Message:        getStringAddress("'su root' failed for lonvick on /dev/pts/8"),
+			Message:        "'su root' failed for lonvick on /dev/pts/8",
 		},
 		"",
-		nil,
+		SyslogMessage{},
 	},
 	// Valid, w/o structure data, w/o msgid
 	{
 		[]byte("<165>1 2003-08-24T05:14:15.000003-07:00 192.0.2.1 myproc 8710 - - %% Time to make the do-nuts."),
 		true,
-		&SyslogMessage{
-			facility:       getUint8Address(20),
-			severity:       getUint8Address(5),
-			Priority:       getUint8Address(165),
+		SyslogMessage{
+			facility:       20,
+			severity:       5,
+			Priority:       165,
 			Version:        1,
 			Timestamp:      timeParse(time.RFC3339Nano, "2003-08-24T05:14:15.000003-07:00"),
-			Hostname:       getStringAddress("192.0.2.1"),
-			Appname:        getStringAddress("myproc"),
-			ProcID:         getStringAddress("8710"),
-			MsgID:          nil,
+			Hostname:       "192.0.2.1",
+			Appname:        "myproc",
+			ProcID:         "8710",
+			MsgID:          ``,
 			StructuredData: nil,
-			Message:        getStringAddress("%% Time to make the do-nuts."),
+			Message:        "%% Time to make the do-nuts.",
 		},
 		"",
-		nil,
+		SyslogMessage{},
 	},
 	// Valid, w/o structure data, w/o hostname, w/o appname, w/o procid, w/o msgid, w/o msg
 	{
 		[]byte("<165>2 2003-08-24T05:14:15.000003-07:00 - - - - -"),
 		true,
-		&SyslogMessage{
-			facility:       getUint8Address(20),
-			severity:       getUint8Address(5),
-			Priority:       getUint8Address(165),
+		SyslogMessage{
+			facility:       20,
+			severity:       5,
+			Priority:       165,
 			Version:        2,
 			Timestamp:      timeParse(time.RFC3339Nano, "2003-08-24T05:14:15.000003-07:00"),
-			Hostname:       nil,
-			Appname:        nil,
-			ProcID:         nil,
-			MsgID:          nil,
+			Hostname:       ``,
+			Appname:        ``,
+			ProcID:         ``,
+			MsgID:          ``,
 			StructuredData: nil,
-			Message:        nil,
+			Message:        ``,
 		},
 		"",
-		nil,
+		SyslogMessage{},
 	},
 	// Valid, w/o structure data, w/o hostname, w/o appname, w/o procid, w/o msgid, empty msg
 	{
 		[]byte("<165>222 2003-08-24T05:14:15.000003-07:00 - - - - - "),
 		true,
-		&SyslogMessage{
-			facility:       getUint8Address(20),
-			severity:       getUint8Address(5),
-			Priority:       getUint8Address(165),
+		SyslogMessage{
+			facility:       20,
+			severity:       5,
+			Priority:       165,
 			Version:        222,
 			Timestamp:      timeParse(time.RFC3339Nano, "2003-08-24T05:14:15.000003-07:00"),
-			Hostname:       nil,
-			Appname:        nil,
-			ProcID:         nil,
-			MsgID:          nil,
+			Hostname:       ``,
+			Appname:        ``,
+			ProcID:         ``,
+			MsgID:          ``,
 			StructuredData: nil,
-			Message:        nil,
+			Message:        ``,
 		},
 		"",
-		nil,
+		SyslogMessage{},
 	},
 	// Valid, with structured data is, w/o structured data params
 	{
 		[]byte("<78>1 2016-01-15T00:04:01+00:00 host1 CROND 10391 - [sdid] some_message"),
 		true,
-		&SyslogMessage{
-			facility:  getUint8Address(9),
-			severity:  getUint8Address(6),
-			Priority:  getUint8Address(78),
+		SyslogMessage{
+			facility:  9,
+			severity:  6,
+			Priority:  78,
 			Version:   1,
 			Timestamp: timeParse(time.RFC3339Nano, "2016-01-15T00:04:01+00:00"),
-			Hostname:  getStringAddress("host1"),
-			Appname:   getStringAddress("CROND"),
-			ProcID:    getStringAddress("10391"),
-			MsgID:     nil,
-			StructuredData: &map[string]map[string]string{
+			Hostname:  "host1",
+			Appname:   "CROND",
+			ProcID:    "10391",
+			MsgID:     ``,
+			StructuredData: map[string]map[string]string{
 				"sdid": map[string]string{},
 			},
-			Message: getStringAddress("some_message"),
+			Message: "some_message",
 		},
 		"",
-		nil,
+		SyslogMessage{},
 	},
 	// Valid, with structured data id, with structured data params
 	{
 		[]byte(`<78>1 2016-01-15T00:04:01+00:00 host1 CROND 10391 - [sdid x="⌘"] some_message`),
 		true,
-		&SyslogMessage{
-			facility:  getUint8Address(9),
-			severity:  getUint8Address(6),
-			Priority:  getUint8Address(78),
+		SyslogMessage{
+			facility:  9,
+			severity:  6,
+			Priority:  78,
 			Version:   1,
 			Timestamp: timeParse(time.RFC3339Nano, "2016-01-15T00:04:01+00:00"),
-			Hostname:  getStringAddress("host1"),
-			Appname:   getStringAddress("CROND"),
-			ProcID:    getStringAddress("10391"),
-			MsgID:     nil,
-			StructuredData: &map[string]map[string]string{
+			Hostname:  "host1",
+			Appname:   "CROND",
+			ProcID:    "10391",
+			MsgID:     ``,
+			StructuredData: map[string]map[string]string{
 				"sdid": map[string]string{
 					"x": "⌘",
 				},
 			},
-			Message: getStringAddress("some_message"),
+			Message: "some_message",
 		},
 		"",
-		nil,
+		SyslogMessage{},
 	},
 	// Valid, with structured data is, with structured data params
 	{
 		[]byte(`<78>2 2016-01-15T00:04:01+00:00 host1 CROND 10391 - [sdid x="hey \\u2318 hey"] some_message`),
 		true,
-		&SyslogMessage{
-			facility:  getUint8Address(9),
-			severity:  getUint8Address(6),
-			Priority:  getUint8Address(78),
+		SyslogMessage{
+			facility:  9,
+			severity:  6,
+			Priority:  78,
 			Version:   2,
 			Timestamp: timeParse(time.RFC3339Nano, "2016-01-15T00:04:01+00:00"),
-			Hostname:  getStringAddress("host1"),
-			Appname:   getStringAddress("CROND"),
-			ProcID:    getStringAddress("10391"),
-			MsgID:     nil,
-			StructuredData: &map[string]map[string]string{
+			Hostname:  "host1",
+			Appname:   "CROND",
+			ProcID:    "10391",
+			MsgID:     ``,
+			StructuredData: map[string]map[string]string{
 				"sdid": map[string]string{
 					"x": `hey \u2318 hey`,
 				},
 			},
-			Message: getStringAddress("some_message"),
+			Message: "some_message",
 		},
 		"",
-		nil,
+		SyslogMessage{},
 	},
 	// Valid, with (escaped) backslash within structured data param value
 	{
 		[]byte(`<29>50 2016-01-15T01:00:43Z hn S - - [meta es="\\valid"] 127.0.0.1 - - 1452819643 "GET"`),
 		true,
-		&SyslogMessage{
-			Priority:  getUint8Address(29),
-			facility:  getUint8Address(3),
-			severity:  getUint8Address(5),
+		SyslogMessage{
+			Priority:  29,
+			facility:  3,
+			severity:  5,
 			Version:   50,
 			Timestamp: timeParse(time.RFC3339Nano, "2016-01-15T01:00:43Z"),
-			Hostname:  getStringAddress("hn"),
-			Appname:   getStringAddress("S"),
-			StructuredData: &map[string]map[string]string{
+			Hostname:  "hn",
+			Appname:   "S",
+			StructuredData: map[string]map[string]string{
 				"meta": map[string]string{
 					"es": `\valid`,
 				},
 			},
-			Message: getStringAddress(`127.0.0.1 - - 1452819643 "GET"`),
+			Message: `127.0.0.1 - - 1452819643 "GET"`,
 		},
 		"",
-		nil,
+		SyslogMessage{},
 	},
 	{
 		[]byte(`<29>52 2016-01-15T01:00:43Z hn S - - [meta one="\\one" two="\\two"] 127.0.0.1 - - 1452819643 "GET"`),
 		true,
-		&SyslogMessage{
-			Priority:  getUint8Address(29),
-			facility:  getUint8Address(3),
-			severity:  getUint8Address(5),
+		SyslogMessage{
+			Priority:  29,
+			facility:  3,
+			severity:  5,
 			Version:   52,
 			Timestamp: timeParse(time.RFC3339Nano, "2016-01-15T01:00:43Z"),
-			Hostname:  getStringAddress("hn"),
-			Appname:   getStringAddress("S"),
-			StructuredData: &map[string]map[string]string{
+			Hostname:  "hn",
+			Appname:   "S",
+			StructuredData: map[string]map[string]string{
 				"meta": map[string]string{
 					"one": `\one`,
 					"two": `\two`,
 				},
 			},
-			Message: getStringAddress(`127.0.0.1 - - 1452819643 "GET"`),
+			Message: `127.0.0.1 - - 1452819643 "GET"`,
 		},
 		"",
-		nil,
+		SyslogMessage{},
 	},
 	{
 		[]byte(`<29>53 2016-01-15T01:00:43Z hn S - - [meta one="\\one"][other two="\\two" double="\\a\\b"] 127.0.0.1 - - 1452819643 "GET"`),
 		true,
-		&SyslogMessage{
-			Priority:  getUint8Address(29),
-			facility:  getUint8Address(3),
-			severity:  getUint8Address(5),
+		SyslogMessage{
+			Priority:  29,
+			facility:  3,
+			severity:  5,
 			Version:   53,
 			Timestamp: timeParse(time.RFC3339Nano, "2016-01-15T01:00:43Z"),
-			Hostname:  getStringAddress("hn"),
-			Appname:   getStringAddress("S"),
-			StructuredData: &map[string]map[string]string{
+			Hostname:  "hn",
+			Appname:   "S",
+			StructuredData: map[string]map[string]string{
 				"meta": map[string]string{
 					"one": `\one`,
 				},
@@ -1119,109 +1119,109 @@ var testCases = []testCase{
 					"double": `\a\b`,
 				},
 			},
-			Message: getStringAddress(`127.0.0.1 - - 1452819643 "GET"`),
+			Message: `127.0.0.1 - - 1452819643 "GET"`,
 		},
 		"",
-		nil,
+		SyslogMessage{},
 	},
 	{
 		[]byte(`<29>51 2016-01-15T01:00:43Z hn S - - [meta es="\\double\\slash"] 127.0.0.1 - - 1452819643 "GET"`),
 		true,
-		&SyslogMessage{
-			Priority:  getUint8Address(29),
-			facility:  getUint8Address(3),
-			severity:  getUint8Address(5),
+		SyslogMessage{
+			Priority:  29,
+			facility:  3,
+			severity:  5,
 			Version:   51,
 			Timestamp: timeParse(time.RFC3339Nano, "2016-01-15T01:00:43Z"),
-			Hostname:  getStringAddress("hn"),
-			Appname:   getStringAddress("S"),
-			StructuredData: &map[string]map[string]string{
+			Hostname:  "hn",
+			Appname:   "S",
+			StructuredData: map[string]map[string]string{
 				"meta": map[string]string{
 					"es": `\double\slash`,
 				},
 			},
-			Message: getStringAddress(`127.0.0.1 - - 1452819643 "GET"`),
+			Message: `127.0.0.1 - - 1452819643 "GET"`,
 		},
 		"",
-		nil,
+		SyslogMessage{},
 	},
 	{
 		[]byte(`<29>54 2016-01-15T01:00:43Z hn S - - [meta es="in \\middle of the string"] 127.0.0.1 - - 1452819643 "GET"`),
 		true,
-		&SyslogMessage{
-			Priority:  getUint8Address(29),
-			facility:  getUint8Address(3),
-			severity:  getUint8Address(5),
+		SyslogMessage{
+			Priority:  29,
+			facility:  3,
+			severity:  5,
 			Version:   54,
 			Timestamp: timeParse(time.RFC3339Nano, "2016-01-15T01:00:43Z"),
-			Hostname:  getStringAddress("hn"),
-			Appname:   getStringAddress("S"),
-			StructuredData: &map[string]map[string]string{
+			Hostname:  "hn",
+			Appname:   "S",
+			StructuredData: map[string]map[string]string{
 				"meta": map[string]string{
 					"es": `in \middle of the string`,
 				},
 			},
-			Message: getStringAddress(`127.0.0.1 - - 1452819643 "GET"`),
+			Message: `127.0.0.1 - - 1452819643 "GET"`,
 		},
 		"",
-		nil,
+		SyslogMessage{},
 	},
 	{
 		[]byte(`<29>55 2016-01-15T01:00:43Z hn S - - [meta es="at the \\end"] 127.0.0.1 - - 1452819643 "GET"`),
 		true,
-		&SyslogMessage{
-			Priority:  getUint8Address(29),
-			facility:  getUint8Address(3),
-			severity:  getUint8Address(5),
+		SyslogMessage{
+			Priority:  29,
+			facility:  3,
+			severity:  5,
 			Version:   55,
 			Timestamp: timeParse(time.RFC3339Nano, "2016-01-15T01:00:43Z"),
-			Hostname:  getStringAddress("hn"),
-			Appname:   getStringAddress("S"),
-			StructuredData: &map[string]map[string]string{
+			Hostname:  "hn",
+			Appname:   "S",
+			StructuredData: map[string]map[string]string{
 				"meta": map[string]string{
 					"es": `at the \end`,
 				},
 			},
-			Message: getStringAddress(`127.0.0.1 - - 1452819643 "GET"`),
+			Message: `127.0.0.1 - - 1452819643 "GET"`,
 		},
 		"",
-		nil,
+		SyslogMessage{},
 	},
 	// Valid, with control characters within structured data param value
 	{
 		[]byte("<29>50 2016-01-15T01:00:43Z hn S - - [meta es=\"\t5Ὂg̀9!℃ᾭGa b\"] 127.0.0.1 - - 1452819643 \"GET\""),
 		true,
-		&SyslogMessage{
-			Priority:  getUint8Address(29),
-			facility:  getUint8Address(3),
-			severity:  getUint8Address(5),
+		SyslogMessage{
+			Priority:  29,
+			facility:  3,
+			severity:  5,
 			Version:   50,
 			Timestamp: timeParse(time.RFC3339Nano, "2016-01-15T01:00:43Z"),
-			Hostname:  getStringAddress("hn"),
-			Appname:   getStringAddress("S"),
-			StructuredData: &map[string]map[string]string{
+			Hostname:  "hn",
+			Appname:   "S",
+			StructuredData: map[string]map[string]string{
 				"meta": map[string]string{
 					"es": "\t5Ὂg̀9!℃ᾭGa b",
 				},
 			},
-			Message: getStringAddress(`127.0.0.1 - - 1452819643 "GET"`),
+			Message: `127.0.0.1 - - 1452819643 "GET"`,
 		},
 		"",
-		nil,
+		SyslogMessage{},
 	},
 	// Valid, with utf8 within structured data param value
 	{
 		[]byte(`<29>50 2016-01-15T01:00:43Z hn S - - [meta gr="κόσμε" es="ñ"][beta pr="₡"] 𐌼 "GET"`),
 		true,
-		&SyslogMessage{
-			Priority:  getUint8Address(29),
-			facility:  getUint8Address(3),
-			severity:  getUint8Address(5),
+		SyslogMessage{
+			Priority:  29,
+			facility:  3,
+			severity:  5,
 			Version:   50,
 			Timestamp: timeParse(time.RFC3339Nano, "2016-01-15T01:00:43Z"),
-			Hostname:  getStringAddress("hn"),
-			Appname:   getStringAddress("S"),
-			StructuredData: &map[string]map[string]string{
+			Hostname:  "hn",
+			Appname:   "S",
+			StructuredData: map[string]map[string]string{
 				"meta": map[string]string{
 					"gr": "κόσμε",
 					"es": "ñ",
@@ -1230,26 +1230,25 @@ var testCases = []testCase{
 					"pr": "₡",
 				},
 			},
-			Message: getStringAddress(`𐌼 "GET"`),
+			Message: `𐌼 "GET"`,
 		},
 		"",
-		nil,
+		SyslogMessage{},
 	},
 	// Valid, with structured data, w/o msg
 	{
 		[]byte("<165>3 2003-10-11T22:14:15.003Z example.com evnts - ID27 [exampleSDID@32473 iut=\"3\" eventSource=\"Application\" eventID=\"1011\"][examplePriority@32473 class=\"high\"]"),
 		true,
-		&SyslogMessage{
-			facility:  getUint8Address(20),
-			severity:  getUint8Address(5),
-			Priority:  getUint8Address(165),
+		SyslogMessage{
+			facility:  20,
+			severity:  5,
+			Priority:  165,
 			Version:   3,
 			Timestamp: timeParse(time.RFC3339Nano, "2003-10-11T22:14:15.003Z"),
-			Hostname:  getStringAddress("example.com"),
-			Appname:   getStringAddress("evnts"),
-			ProcID:    nil,
-			MsgID:     getStringAddress("ID27"),
-			StructuredData: &map[string]map[string]string{
+			Hostname:  "example.com",
+			Appname:   "evnts",
+			MsgID:     "ID27",
+			StructuredData: map[string]map[string]string{
 				"exampleSDID@32473": map[string]string{
 					"iut":         "3",
 					"eventSource": "Application",
@@ -1259,27 +1258,26 @@ var testCases = []testCase{
 					"class": "high",
 				},
 			},
-			Message: nil,
 		},
 		"",
-		nil,
+		SyslogMessage{},
 	},
 	// Invalid, with duplicated structured data id
 	{
 		[]byte("<165>3 2003-10-11T22:14:15.003Z example.com evnts - ID27 [id1][id1]"),
 		false,
-		nil,
+		SyslogMessage{},
 		"duplicate structured data element id [col 66]",
-		&SyslogMessage{
-			Priority:  getUint8Address(165),
-			facility:  getUint8Address(20),
-			severity:  getUint8Address(5),
+		SyslogMessage{
+			Priority:  165,
+			facility:  20,
+			severity:  5,
 			Version:   3,
 			Timestamp: timeParse(time.RFC3339Nano, "2003-10-11T22:14:15.003Z"),
-			Hostname:  getStringAddress("example.com"),
-			Appname:   getStringAddress("evnts"),
-			MsgID:     getStringAddress("ID27"),
-			StructuredData: &map[string]map[string]string{
+			Hostname:  "example.com",
+			Appname:   "evnts",
+			MsgID:     "ID27",
+			StructuredData: map[string]map[string]string{
 				"id1": map[string]string{},
 			},
 		},
@@ -1288,18 +1286,18 @@ var testCases = []testCase{
 	{
 		[]byte("<165>3 2003-10-11T22:14:15.003Z example.com evnts - ID27 [dupe e=\"1\"][id1][dupe class=\"l\"]"),
 		false,
-		nil,
+		SyslogMessage{},
 		"duplicate structured data element id [col 79]",
-		&SyslogMessage{
-			Priority:  getUint8Address(165),
-			facility:  getUint8Address(20),
-			severity:  getUint8Address(5),
+		SyslogMessage{
+			Priority:  165,
+			facility:  20,
+			severity:  5,
 			Version:   3,
 			Timestamp: timeParse(time.RFC3339Nano, "2003-10-11T22:14:15.003Z"),
-			Hostname:  getStringAddress("example.com"),
-			Appname:   getStringAddress("evnts"),
-			MsgID:     getStringAddress("ID27"),
-			StructuredData: &map[string]map[string]string{
+			Hostname:  "example.com",
+			Appname:   "evnts",
+			MsgID:     "ID27",
+			StructuredData: map[string]map[string]string{
 				"id1": map[string]string{},
 				"dupe": map[string]string{
 					"e": "1",
@@ -1311,42 +1309,40 @@ var testCases = []testCase{
 	{
 		[]byte(`<165>4 2003-10-11T22:14:15.003Z mymachine.it e - 1 [ex@32473 iut="3" eventSource="A"] An application event log entry...`),
 		true,
-		&SyslogMessage{
-			facility:  getUint8Address(20),
-			severity:  getUint8Address(5),
-			Priority:  getUint8Address(165),
+		SyslogMessage{
+			facility:  20,
+			severity:  5,
+			Priority:  165,
 			Version:   4,
 			Timestamp: timeParse(time.RFC3339Nano, "2003-10-11T22:14:15.003Z"),
-			Hostname:  getStringAddress("mymachine.it"),
-			Appname:   getStringAddress("e"),
-			ProcID:    nil,
-			MsgID:     getStringAddress("1"),
-			StructuredData: &map[string]map[string]string{
+			Hostname:  "mymachine.it",
+			Appname:   "e",
+			MsgID:     "1",
+			StructuredData: map[string]map[string]string{
 				"ex@32473": map[string]string{
 					"iut":         "3",
 					"eventSource": "A",
 				},
 			},
-			Message: getStringAddress("An application event log entry..."),
+			Message: "An application event log entry...",
 		},
 		"",
-		nil,
+		SyslogMessage{},
 	},
 	// Valid, with double quotes in the message
 	{
 		[]byte(`<29>1 2016-01-15T01:00:43Z some-host-name SEKRETPROGRAM prg - [origin x-service="svcname"][meta sequenceId="1"] 127.0.0.1 - - 1452819643 "GET"`),
 		true,
-		&SyslogMessage{
-			facility:  getUint8Address(3),
-			severity:  getUint8Address(5),
-			Priority:  getUint8Address(29),
+		SyslogMessage{
+			facility:  3,
+			severity:  5,
+			Priority:  29,
 			Version:   1,
 			Timestamp: timeParse(time.RFC3339Nano, "2016-01-15T01:00:43Z"),
-			Hostname:  getStringAddress("some-host-name"),
-			Appname:   getStringAddress("SEKRETPROGRAM"),
-			ProcID:    getStringAddress("prg"),
-			MsgID:     nil,
-			StructuredData: &map[string]map[string]string{
+			Hostname:  "some-host-name",
+			Appname:   "SEKRETPROGRAM",
+			ProcID:    "prg",
+			StructuredData: map[string]map[string]string{
 				"origin": map[string]string{
 					"x-service": "svcname",
 				},
@@ -1354,113 +1350,110 @@ var testCases = []testCase{
 					"sequenceId": "1",
 				},
 			},
-			Message: getStringAddress("127.0.0.1 - - 1452819643 \"GET\""),
+			Message: "127.0.0.1 - - 1452819643 \"GET\"",
 		},
 		"",
-		nil,
+		SyslogMessage{},
 	},
 	// Valid, with empty structured data param value
 	{
 		[]byte(`<1>1 - - - - - [id pk=""]`),
 		true,
-		&SyslogMessage{
-			Priority: getUint8Address(1),
-			facility: getUint8Address(0),
-			severity: getUint8Address(1),
+		SyslogMessage{
+			Priority: 1,
+			facility: 0,
+			severity: 1,
 			Version:  1,
-			StructuredData: &map[string]map[string]string{
+			StructuredData: map[string]map[string]string{
 				"id": map[string]string{
 					"pk": "",
 				},
 			},
 		},
 		"",
-		nil,
+		SyslogMessage{},
 	},
 	// Valid, with double quotes in the message and escaped character within param
 	{
 		[]byte(`<29>2 2016-01-15T01:00:43Z some-host-name SEKRETPROGRAM prg - [meta escape="\]"] some "mex"`),
 		true,
-		&SyslogMessage{
-			facility:  getUint8Address(3),
-			severity:  getUint8Address(5),
-			Priority:  getUint8Address(29),
+		SyslogMessage{
+			facility:  3,
+			severity:  5,
+			Priority:  29,
 			Version:   2,
 			Timestamp: timeParse(time.RFC3339Nano, "2016-01-15T01:00:43Z"),
-			Hostname:  getStringAddress("some-host-name"),
-			Appname:   getStringAddress("SEKRETPROGRAM"),
-			ProcID:    getStringAddress("prg"),
-			MsgID:     nil,
-			StructuredData: &map[string]map[string]string{
+			Hostname:  "some-host-name",
+			Appname:   "SEKRETPROGRAM",
+			ProcID:    "prg",
+			StructuredData: map[string]map[string]string{
 				"meta": map[string]string{
 					"escape": "]",
 				},
 			},
-			Message: getStringAddress(`some "mex"`),
+			Message: `some "mex"`,
 		},
 		"",
-		nil,
+		SyslogMessage{},
 	},
 	// Valid, with escaped character within param
 	{
 		[]byte(`<29>2 2016-01-15T01:00:43Z some-host-name SEKRETPROGRAM prg - [meta escape="\\"]`),
 		true,
-		&SyslogMessage{
-			facility:  getUint8Address(3),
-			severity:  getUint8Address(5),
-			Priority:  getUint8Address(29),
+		SyslogMessage{
+			facility:  3,
+			severity:  5,
+			Priority:  29,
 			Version:   2,
 			Timestamp: timeParse(time.RFC3339Nano, "2016-01-15T01:00:43Z"),
-			Hostname:  getStringAddress("some-host-name"),
-			Appname:   getStringAddress("SEKRETPROGRAM"),
-			ProcID:    getStringAddress("prg"),
-			MsgID:     nil,
-			StructuredData: &map[string]map[string]string{
+			Hostname:  "some-host-name",
+			Appname:   "SEKRETPROGRAM",
+			ProcID:    "prg",
+			StructuredData: map[string]map[string]string{
 				"meta": map[string]string{
 					"escape": `\`,
 				},
 			},
 		},
 		"",
-		nil,
+		SyslogMessage{},
 	},
 	{
 		[]byte(`<29>2 2016-01-15T01:00:43Z some-host-name SEKRETPROGRAM prg - [meta escape="\""]`),
 		true,
-		&SyslogMessage{
-			facility:  getUint8Address(3),
-			severity:  getUint8Address(5),
-			Priority:  getUint8Address(29),
+		SyslogMessage{
+			facility:  3,
+			severity:  5,
+			Priority:  29,
 			Version:   2,
 			Timestamp: timeParse(time.RFC3339Nano, "2016-01-15T01:00:43Z"),
-			Hostname:  getStringAddress("some-host-name"),
-			Appname:   getStringAddress("SEKRETPROGRAM"),
-			ProcID:    getStringAddress("prg"),
-			MsgID:     nil,
-			StructuredData: &map[string]map[string]string{
+			Hostname:  "some-host-name",
+			Appname:   "SEKRETPROGRAM",
+			ProcID:    "prg",
+			StructuredData: map[string]map[string]string{
 				"meta": map[string]string{
 					"escape": `"`,
 				},
 			},
 		},
 		"",
-		nil,
+		SyslogMessage{},
 	},
 	// Invalid, param value can not contain closing square bracket - ie., ]
 	{
 		[]byte(`<29>3 2016-01-15T01:00:43Z hn S - - [meta escape="]"] 127.0.0.1 - - 1452819643 "GET"`),
 		false,
-		nil,
+		SyslogMessage{},
 		"expecting chars `]`, `\"`, and `\\` to be escaped within param value [col 50]",
-		&SyslogMessage{
-			facility:  getUint8Address(3),
-			severity:  getUint8Address(5),
-			Priority:  getUint8Address(29),
+		SyslogMessage{
+			facility:  3,
+			severity:  5,
+			Priority:  29,
 			Version:   3,
 			Timestamp: timeParse(time.RFC3339Nano, "2016-01-15T01:00:43Z"),
-			Hostname:  getStringAddress("hn"),
-			Appname:   getStringAddress("S"),
-			StructuredData: &map[string]map[string]string{
+			Hostname:  "hn",
+			Appname:   "S",
+			StructuredData: map[string]map[string]string{
 				"meta": map[string]string{},
 			},
 		},
@@ -1468,17 +1461,17 @@ var testCases = []testCase{
 	{
 		[]byte(`<29>5 2016-01-15T01:00:43Z hn S - - [meta escape="]q"] 127.0.0.1 - - 1452819643 "GET"`),
 		false,
-		nil,
+		SyslogMessage{},
 		"expecting chars `]`, `\"`, and `\\` to be escaped within param value [col 50]",
-		&SyslogMessage{
-			facility:  getUint8Address(3),
-			severity:  getUint8Address(5),
-			Priority:  getUint8Address(29),
+		SyslogMessage{
+			facility:  3,
+			severity:  5,
+			Priority:  29,
 			Version:   5,
 			Timestamp: timeParse(time.RFC3339Nano, "2016-01-15T01:00:43Z"),
-			Hostname:  getStringAddress("hn"),
-			Appname:   getStringAddress("S"),
-			StructuredData: &map[string]map[string]string{
+			Hostname:  "hn",
+			Appname:   "S",
+			StructuredData: map[string]map[string]string{
 				"meta": map[string]string{},
 			},
 		},
@@ -1486,17 +1479,17 @@ var testCases = []testCase{
 	{
 		[]byte(`<29>4 2016-01-15T01:00:43Z hn S - - [meta escape="p]"] 127.0.0.1 - - 1452819643 "GET"`),
 		false,
-		nil,
+		SyslogMessage{},
 		"expecting chars `]`, `\"`, and `\\` to be escaped within param value [col 51]",
-		&SyslogMessage{
-			facility:  getUint8Address(3),
-			severity:  getUint8Address(5),
-			Priority:  getUint8Address(29),
+		SyslogMessage{
+			facility:  3,
+			severity:  5,
+			Priority:  29,
 			Version:   4,
 			Timestamp: timeParse(time.RFC3339Nano, "2016-01-15T01:00:43Z"),
-			Hostname:  getStringAddress("hn"),
-			Appname:   getStringAddress("S"),
-			StructuredData: &map[string]map[string]string{
+			Hostname:  "hn",
+			Appname:   "S",
+			StructuredData: map[string]map[string]string{
 				"meta": map[string]string{},
 			},
 		},
@@ -1505,17 +1498,17 @@ var testCases = []testCase{
 	{
 		[]byte(`<29>4 2017-01-15T01:00:43Z hn S - - [meta escape="""] 127.0.0.1 - - 1452819643 "GET"`),
 		false,
-		nil,
+		SyslogMessage{},
 		"expecting a structured data parameter (`key=\"value\"`, both part from 1 to max 32 US-ASCII characters; key cannot contain `=`, ` `, `]`, and `\"`, while value cannot contain `]`, backslash, and `\"` unless escaped) [col 51]",
-		&SyslogMessage{
-			facility:  getUint8Address(3),
-			severity:  getUint8Address(5),
-			Priority:  getUint8Address(29),
+		SyslogMessage{
+			facility:  3,
+			severity:  5,
+			Priority:  29,
 			Version:   4,
 			Timestamp: timeParse(time.RFC3339Nano, "2017-01-15T01:00:43Z"),
-			Hostname:  getStringAddress("hn"),
-			Appname:   getStringAddress("S"),
-			StructuredData: &map[string]map[string]string{
+			Hostname:  "hn",
+			Appname:   "S",
+			StructuredData: map[string]map[string]string{
 				"meta": map[string]string{},
 			},
 		},
@@ -1523,17 +1516,17 @@ var testCases = []testCase{
 	{
 		[]byte(`<29>6 2016-01-15T01:00:43Z hn S - - [meta escape="a""] 127.0.0.1 - - 1452819643 "GET"`),
 		false,
-		nil,
+		SyslogMessage{},
 		"expecting a structured data parameter (`key=\"value\"`, both part from 1 to max 32 US-ASCII characters; key cannot contain `=`, ` `, `]`, and `\"`, while value cannot contain `]`, backslash, and `\"` unless escaped) [col 52]",
-		&SyslogMessage{
-			facility:  getUint8Address(3),
-			severity:  getUint8Address(5),
-			Priority:  getUint8Address(29),
+		SyslogMessage{
+			facility:  3,
+			severity:  5,
+			Priority:  29,
 			Version:   6,
 			Timestamp: timeParse(time.RFC3339Nano, "2016-01-15T01:00:43Z"),
-			Hostname:  getStringAddress("hn"),
-			Appname:   getStringAddress("S"),
-			StructuredData: &map[string]map[string]string{
+			Hostname:  "hn",
+			Appname:   "S",
+			StructuredData: map[string]map[string]string{
 				"meta": map[string]string{},
 			},
 		},
@@ -1541,17 +1534,17 @@ var testCases = []testCase{
 	{
 		[]byte(`<29>4 2018-01-15T01:00:43Z hn S - - [meta escape=""b"] 127.0.0.1 - - 1452819643 "GET"`),
 		false,
-		nil,
+		SyslogMessage{},
 		"expecting a structured data parameter (`key=\"value\"`, both part from 1 to max 32 US-ASCII characters; key cannot contain `=`, ` `, `]`, and `\"`, while value cannot contain `]`, backslash, and `\"` unless escaped) [col 51]",
-		&SyslogMessage{
-			facility:  getUint8Address(3),
-			severity:  getUint8Address(5),
-			Priority:  getUint8Address(29),
+		SyslogMessage{
+			facility:  3,
+			severity:  5,
+			Priority:  29,
 			Version:   4,
 			Timestamp: timeParse(time.RFC3339Nano, "2018-01-15T01:00:43Z"),
-			Hostname:  getStringAddress("hn"),
-			Appname:   getStringAddress("S"),
-			StructuredData: &map[string]map[string]string{
+			Hostname:  "hn",
+			Appname:   "S",
+			StructuredData: map[string]map[string]string{
 				"meta": map[string]string{},
 			},
 		},
@@ -1560,17 +1553,17 @@ var testCases = []testCase{
 	{
 		[]byte(`<29>5 2019-01-15T01:00:43Z hn S - - [meta escape="\"] 127.0.0.1 - - 1452819643 "GET"`),
 		false,
-		nil,
+		SyslogMessage{},
 		"expecting chars `]`, `\"`, and `\\` to be escaped within param value [col 52]",
-		&SyslogMessage{
-			facility:  getUint8Address(3),
-			severity:  getUint8Address(5),
-			Priority:  getUint8Address(29),
+		SyslogMessage{
+			facility:  3,
+			severity:  5,
+			Priority:  29,
 			Version:   5,
 			Timestamp: timeParse(time.RFC3339Nano, "2019-01-15T01:00:43Z"),
-			Hostname:  getStringAddress("hn"),
-			Appname:   getStringAddress("S"),
-			StructuredData: &map[string]map[string]string{
+			Hostname:  "hn",
+			Appname:   "S",
+			StructuredData: map[string]map[string]string{
 				"meta": map[string]string{},
 			},
 		},
@@ -1578,17 +1571,17 @@ var testCases = []testCase{
 	{
 		[]byte(`<29>7 2019-01-15T01:00:43Z hn S - - [meta escape="a\"] 127.0.0.1 - - 1452819643 "GET"`),
 		false,
-		nil,
+		SyslogMessage{},
 		"expecting chars `]`, `\"`, and `\\` to be escaped within param value [col 53]",
-		&SyslogMessage{
-			facility:  getUint8Address(3),
-			severity:  getUint8Address(5),
-			Priority:  getUint8Address(29),
+		SyslogMessage{
+			facility:  3,
+			severity:  5,
+			Priority:  29,
 			Version:   7,
 			Timestamp: timeParse(time.RFC3339Nano, "2019-01-15T01:00:43Z"),
-			Hostname:  getStringAddress("hn"),
-			Appname:   getStringAddress("S"),
-			StructuredData: &map[string]map[string]string{
+			Hostname:  "hn",
+			Appname:   "S",
+			StructuredData: map[string]map[string]string{
 				"meta": map[string]string{},
 			},
 		},
@@ -1596,17 +1589,17 @@ var testCases = []testCase{
 	{
 		[]byte(`<29>8 2016-01-15T01:00:43Z hn S - - [meta escape="\n"] 127.0.0.1 - - 1452819643 "GET"`),
 		false,
-		nil,
+		SyslogMessage{},
 		"expecting chars `]`, `\"`, and `\\` to be escaped within param value [col 51]",
-		&SyslogMessage{
-			facility:  getUint8Address(3),
-			severity:  getUint8Address(5),
-			Priority:  getUint8Address(29),
+		SyslogMessage{
+			facility:  3,
+			severity:  5,
+			Priority:  29,
 			Version:   8,
 			Timestamp: timeParse(time.RFC3339Nano, "2016-01-15T01:00:43Z"),
-			Hostname:  getStringAddress("hn"),
-			Appname:   getStringAddress("S"),
-			StructuredData: &map[string]map[string]string{
+			Hostname:  "hn",
+			Appname:   "S",
+			StructuredData: map[string]map[string]string{
 				"meta": map[string]string{},
 			},
 		},
@@ -1615,578 +1608,578 @@ var testCases = []testCase{
 	{
 		[]byte("<1>1 - - - - - - \xEF\xBB\xBF"),
 		true,
-		&SyslogMessage{
-			Priority: getUint8Address(1),
-			facility: getUint8Address(0),
-			severity: getUint8Address(1),
+		SyslogMessage{
+			Priority: 1,
+			facility: 0,
+			severity: 1,
 			Version:  1,
-			Message:  getStringAddress("\ufeff"),
+			Message:  "\ufeff",
 		},
 		"",
-		nil,
+		SyslogMessage{},
 	},
 	// Valid, greek
 	{
 		[]byte("<1>1 - - - - - - κόσμε"),
 		true,
-		&SyslogMessage{
-			Priority: getUint8Address(1),
-			facility: getUint8Address(0),
-			severity: getUint8Address(1),
+		SyslogMessage{
+			Priority: 1,
+			facility: 0,
+			severity: 1,
 			Version:  1,
-			Message:  getStringAddress("κόσμε"),
+			Message:  "κόσμε",
 		},
 		"",
-		nil,
+		SyslogMessage{},
 	},
 	// Valid, 2 octet sequence
 	{
 		[]byte("<1>1 - - - - - - "),
 		true,
-		&SyslogMessage{
-			Priority: getUint8Address(1),
-			facility: getUint8Address(0),
-			severity: getUint8Address(1),
+		SyslogMessage{
+			Priority: 1,
+			facility: 0,
+			severity: 1,
 			Version:  1,
-			Message:  getStringAddress(""),
+			Message:  "",
 		},
 		"",
-		nil,
+		SyslogMessage{},
 	},
 	// Valid, spanish (2 octet sequence)
 	{
 		[]byte("<1>1 - - - - - - \xc3\xb1"),
 		true,
-		&SyslogMessage{
-			Priority: getUint8Address(1),
-			facility: getUint8Address(0),
-			severity: getUint8Address(1),
+		SyslogMessage{
+			Priority: 1,
+			facility: 0,
+			severity: 1,
 			Version:  1,
-			Message:  getStringAddress("ñ"),
+			Message:  "ñ",
 		},
 		"",
-		nil,
+		SyslogMessage{},
 	},
 	// Valid, colon currency sign (3 octet sequence)
 	{
 		[]byte("<1>1 - - - - - - \xe2\x82\xa1"),
 		true,
-		&SyslogMessage{
-			Priority: getUint8Address(1),
-			facility: getUint8Address(0),
-			severity: getUint8Address(1),
+		SyslogMessage{
+			Priority: 1,
+			facility: 0,
+			severity: 1,
 			Version:  1,
-			Message:  getStringAddress("₡"),
+			Message:  "₡",
 		},
 		"",
-		nil,
+		SyslogMessage{},
 	},
 	// Valid, gothic letter (4 octet sequence)
 	{
 		[]byte("<1>1 - - - - - - \xEF\xBB\xBF \xf0\x90\x8c\xbc"),
 		true,
-		&SyslogMessage{
-			Priority: getUint8Address(1),
-			facility: getUint8Address(0),
-			severity: getUint8Address(1),
+		SyslogMessage{
+			Priority: 1,
+			facility: 0,
+			severity: 1,
 			Version:  1,
-			Message:  getStringAddress("\ufeff 𐌼"),
+			Message:  "\ufeff 𐌼",
 		},
 		"",
-		nil,
+		SyslogMessage{},
 	},
 	// Valid, 5 octet sequence
 	{
 		[]byte("<1>1 - - - - - - \xC8\x80\x30\x30\x30"),
 		true,
-		&SyslogMessage{
-			Priority: getUint8Address(1),
-			facility: getUint8Address(0),
-			severity: getUint8Address(1),
+		SyslogMessage{
+			Priority: 1,
+			facility: 0,
+			severity: 1,
 			Version:  1,
-			Message:  getStringAddress("Ȁ000"),
+			Message:  "Ȁ000",
 		},
 		"",
-		nil,
+		SyslogMessage{},
 	},
 	// Valid, 6 octet sequence
 	{
 		[]byte("<1>1 - - - - - - \xE4\x80\x80\x30\x30\x30"),
 		true,
-		&SyslogMessage{
-			Priority: getUint8Address(1),
-			facility: getUint8Address(0),
-			severity: getUint8Address(1),
+		SyslogMessage{
+			Priority: 1,
+			facility: 0,
+			severity: 1,
 			Version:  1,
-			Message:  getStringAddress("䀀000"),
+			Message:  "䀀000",
 		},
 		"",
-		nil,
+		SyslogMessage{},
 	},
 	// Valid, UTF-8 boundary conditions
 	{
 		[]byte("<1>1 - - - - - - \xC4\x90\x30\x30\x30"),
 		true,
-		&SyslogMessage{
-			Priority: getUint8Address(1),
-			facility: getUint8Address(0),
-			severity: getUint8Address(1),
+		SyslogMessage{
+			Priority: 1,
+			facility: 0,
+			severity: 1,
 			Version:  1,
-			Message:  getStringAddress("Đ000"),
+			Message:  "Đ000",
 		},
 		"",
-		nil,
+		SyslogMessage{},
 	},
 	{
 		[]byte("<1>1 - - - - - - \x0D\x37\x46\x46"),
 		true,
-		&SyslogMessage{
-			Priority: getUint8Address(1),
-			facility: getUint8Address(0),
-			severity: getUint8Address(1),
+		SyslogMessage{
+			Priority: 1,
+			facility: 0,
+			severity: 1,
 			Version:  1,
-			Message:  getStringAddress("\r7FF"),
+			Message:  "\r7FF",
 		},
 		"",
-		nil,
+		SyslogMessage{},
 	},
 	// Valid, Tamil poetry of Subramaniya Bharathiyar
 	{
 		[]byte("<1>1 - - - - - - யாமறிந்த மொழிகளிலே தமிழ்மொழி போல் இனிதாவது எங்கும் காணோம், பாமரராய் விலங்குகளாய், உலகனைத்தும் இகழ்ச்சிசொலப் பான்மை கெட்டு, நாமமது தமிழரெனக் கொண்டு இங்கு வாழ்ந்திடுதல் நன்றோ? சொல்லீர்! தேமதுரத் தமிழோசை உலகமெலாம் பரவும்வகை செய்தல் வேண்டும்."),
 		true,
-		&SyslogMessage{
-			Priority: getUint8Address(1),
-			facility: getUint8Address(0),
-			severity: getUint8Address(1),
+		SyslogMessage{
+			Priority: 1,
+			facility: 0,
+			severity: 1,
 			Version:  1,
-			Message:  getStringAddress("யாமறிந்த மொழிகளிலே தமிழ்மொழி போல் இனிதாவது எங்கும் காணோம், பாமரராய் விலங்குகளாய், உலகனைத்தும் இகழ்ச்சிசொலப் பான்மை கெட்டு, நாமமது தமிழரெனக் கொண்டு இங்கு வாழ்ந்திடுதல் நன்றோ? சொல்லீர்! தேமதுரத் தமிழோசை உலகமெலாம் பரவும்வகை செய்தல் வேண்டும்."),
+			Message:  "யாமறிந்த மொழிகளிலே தமிழ்மொழி போல் இனிதாவது எங்கும் காணோம், பாமரராய் விலங்குகளாய், உலகனைத்தும் இகழ்ச்சிசொலப் பான்மை கெட்டு, நாமமது தமிழரெனக் கொண்டு இங்கு வாழ்ந்திடுதல் நன்றோ? சொல்லீர்! தேமதுரத் தமிழோசை உலகமெலாம் பரவும்வகை செய்தல் வேண்டும்.",
 		},
 		"",
-		nil,
+		SyslogMessage{},
 	},
 	// Valid, I Can Eat Glass (Milanese)
 	{
 		[]byte("<1>1 - - - - - - Sôn bôn de magnà el véder, el me fa minga mal."),
 		true,
-		&SyslogMessage{
-			Priority: getUint8Address(1),
-			facility: getUint8Address(0),
-			severity: getUint8Address(1),
+		SyslogMessage{
+			Priority: 1,
+			facility: 0,
+			severity: 1,
 			Version:  1,
-			Message:  getStringAddress("Sôn bôn de magnà el véder, el me fa minga mal."),
+			Message:  "Sôn bôn de magnà el véder, el me fa minga mal.",
 		},
 		"",
-		nil,
+		SyslogMessage{},
 	},
 	// Valid, I Can Eat Glass (Romano)
 	{
 		[]byte("<1>1 - - - - - - Me posso magna' er vetro, e nun me fa male."),
 		true,
-		&SyslogMessage{
-			Priority: getUint8Address(1),
-			facility: getUint8Address(0),
-			severity: getUint8Address(1),
+		SyslogMessage{
+			Priority: 1,
+			facility: 0,
+			severity: 1,
 			Version:  1,
-			Message:  getStringAddress("Me posso magna' er vetro, e nun me fa male."),
+			Message:  "Me posso magna' er vetro, e nun me fa male.",
 		},
 		"",
-		nil,
+		SyslogMessage{},
 	},
 	// Valid, I Can Eat Glass (Braille)
 	{
 		[]byte("<1>1 - - - - - - ⠊⠀⠉⠁⠝⠀⠑⠁⠞⠀⠛⠇⠁⠎⠎⠀⠁⠝⠙⠀⠊⠞⠀⠙⠕⠑⠎⠝⠞⠀⠓⠥⠗⠞⠀⠍⠑"),
 		true,
-		&SyslogMessage{
-			Priority: getUint8Address(1),
-			facility: getUint8Address(0),
-			severity: getUint8Address(1),
+		SyslogMessage{
+			Priority: 1,
+			facility: 0,
+			severity: 1,
 			Version:  1,
-			Message:  getStringAddress("⠊⠀⠉⠁⠝⠀⠑⠁⠞⠀⠛⠇⠁⠎⠎⠀⠁⠝⠙⠀⠊⠞⠀⠙⠕⠑⠎⠝⠞⠀⠓⠥⠗⠞⠀⠍⠑"),
+			Message:  "⠊⠀⠉⠁⠝⠀⠑⠁⠞⠀⠛⠇⠁⠎⠎⠀⠁⠝⠙⠀⠊⠞⠀⠙⠕⠑⠎⠝⠞⠀⠓⠥⠗⠞⠀⠍⠑",
 		},
 		"",
-		nil,
+		SyslogMessage{},
 	},
 	// Valid, I Can Eat Glass (Sanskrit)
 	{
 		[]byte("<1>1 - - - - - - काचं शक्नोम्यत्तुम् । नोपहिनस्ति माम् ॥"),
 		true,
-		&SyslogMessage{
-			Priority: getUint8Address(1),
-			facility: getUint8Address(0),
-			severity: getUint8Address(1),
+		SyslogMessage{
+			Priority: 1,
+			facility: 0,
+			severity: 1,
 			Version:  1,
-			Message:  getStringAddress("काचं शक्नोम्यत्तुम् । नोपहिनस्ति माम् ॥"),
+			Message:  "काचं शक्नोम्यत्तुम् । नोपहिनस्ति माम् ॥",
 		},
 		"",
-		nil,
+		SyslogMessage{},
 	},
 	// Valid, I Can Eat Glass (Urdu)
 	{
 		[]byte("<1>1 - - - - - - میں کانچ کھا سکتا ہوں اور مجھے تکلیف نہیں ہوتی ۔"),
 		true,
-		&SyslogMessage{
-			Priority: getUint8Address(1),
-			facility: getUint8Address(0),
-			severity: getUint8Address(1),
+		SyslogMessage{
+			Priority: 1,
+			facility: 0,
+			severity: 1,
 			Version:  1,
-			Message:  getStringAddress("میں کانچ کھا سکتا ہوں اور مجھے تکلیف نہیں ہوتی ۔"),
+			Message:  "میں کانچ کھا سکتا ہوں اور مجھے تکلیف نہیں ہوتی ۔",
 		},
 		"",
-		nil,
+		SyslogMessage{},
 	},
 	// Valid, I Can Eat Glass (Yiddish)
 	{
 		[]byte("<1>1 - - - - - - איך קען עסן גלאָז און עס טוט מיר נישט װײ."),
 		true,
-		&SyslogMessage{
-			Priority: getUint8Address(1),
-			facility: getUint8Address(0),
-			severity: getUint8Address(1),
+		SyslogMessage{
+			Priority: 1,
+			facility: 0,
+			severity: 1,
 			Version:  1,
-			Message:  getStringAddress("איך קען עסן גלאָז און עס טוט מיר נישט װײ."),
+			Message:  "איך קען עסן גלאָז און עס טוט מיר נישט װײ.",
 		},
 		"",
-		nil,
+		SyslogMessage{},
 	},
 	// Valid, I Can Eat Glass (Polish)
 	{
 		[]byte("<1>1 - - - - - - Mogę jeść szkło, i mi nie szkodzi."),
 		true,
-		&SyslogMessage{
-			Priority: getUint8Address(1),
-			facility: getUint8Address(0),
-			severity: getUint8Address(1),
+		SyslogMessage{
+			Priority: 1,
+			facility: 0,
+			severity: 1,
 			Version:  1,
-			Message:  getStringAddress("Mogę jeść szkło, i mi nie szkodzi."),
+			Message:  "Mogę jeść szkło, i mi nie szkodzi.",
 		},
 		"",
-		nil,
+		SyslogMessage{},
 	},
 	// Valid, I Can Eat Glass (Japanese)
 	{
 		[]byte("<1>1 - - - - - - 私はガラスを食べられます。それは私を傷つけません。"),
 		true,
-		&SyslogMessage{
-			Priority: getUint8Address(1),
-			facility: getUint8Address(0),
-			severity: getUint8Address(1),
+		SyslogMessage{
+			Priority: 1,
+			facility: 0,
+			severity: 1,
 			Version:  1,
-			Message:  getStringAddress("私はガラスを食べられます。それは私を傷つけません。"),
+			Message:  "私はガラスを食べられます。それは私を傷つけません。",
 		},
 		"",
-		nil,
+		SyslogMessage{},
 	},
 	// Valid, I Can Eat Glass (Arabic)
 	{
 		[]byte("<1>1 - - - - - - أنا قادر على أكل الزجاج و هذا لا يؤلمني."),
 		true,
-		&SyslogMessage{
-			Priority: getUint8Address(1),
-			facility: getUint8Address(0),
-			severity: getUint8Address(1),
+		SyslogMessage{
+			Priority: 1,
+			facility: 0,
+			severity: 1,
 			Version:  1,
-			Message:  getStringAddress("أنا قادر على أكل الزجاج و هذا لا يؤلمني."),
+			Message:  "أنا قادر على أكل الزجاج و هذا لا يؤلمني.",
 		},
 		"",
-		nil,
+		SyslogMessage{},
 	},
 	// Valid, russian alphabet
 	{
 		[]byte("<1>1 - - - - - - абвгдеёжзийклмнопрстуфхцчшщъыьэюя"),
 		true,
-		&SyslogMessage{
-			Priority: getUint8Address(1),
-			facility: getUint8Address(0),
-			severity: getUint8Address(1),
+		SyslogMessage{
+			Priority: 1,
+			facility: 0,
+			severity: 1,
 			Version:  1,
-			Message:  getStringAddress("абвгдеёжзийклмнопрстуфхцчшщъыьэюя"),
+			Message:  "абвгдеёжзийклмнопрстуфхцчшщъыьэюя",
 		},
 		"",
-		nil,
+		SyslogMessage{},
 	},
 	// Valid, armenian letters
 	{
 		[]byte("<1>1 - - - - - - ԰ԱԲԳԴԵԶԷԸԹԺԻԼԽԾԿՀՁՂՃՄՅՆՇՈՉՊՋՌՍՎՏՐՑՒՓՔՕՖ՗՘ՙ՚՛՜՝՞՟աբգդեզէըթիլխծկհձղճմյնշոչպջռսվտրցւփքօֆևֈ։֊֋֌֍֎֏"),
 		true,
-		&SyslogMessage{
-			Priority: getUint8Address(1),
-			facility: getUint8Address(0),
-			severity: getUint8Address(1),
+		SyslogMessage{
+			Priority: 1,
+			facility: 0,
+			severity: 1,
 			Version:  1,
-			Message:  getStringAddress("\u0530ԱԲԳԴԵԶԷԸԹԺԻԼԽԾԿՀՁՂՃՄՅՆՇՈՉՊՋՌՍՎՏՐՑՒՓՔՕՖ\u0557\u0558ՙ՚՛՜՝՞՟աբգդեզէըթիլխծկհձղճմյնշոչպջռսվտրցւփքօֆև\u0588։֊\u058b\u058c֍֎֏"),
+			Message:  "\u0530ԱԲԳԴԵԶԷԸԹԺԻԼԽԾԿՀՁՂՃՄՅՆՇՈՉՊՋՌՍՎՏՐՑՒՓՔՕՖ\u0557\u0558ՙ՚՛՜՝՞՟աբգդեզէըթիլխծկհձղճմյնշոչպջռսվտրցւփքօֆև\u0588։֊\u058b\u058c֍֎֏",
 		},
 		"",
-		nil,
+		SyslogMessage{},
 	},
 	// Valid, new line within message
 	{
 		[]byte("<1>1 - - - - - - x\x0Ay"),
 		true,
-		&SyslogMessage{
-			facility: getUint8Address(0),
-			severity: getUint8Address(1),
-			Priority: getUint8Address(1),
+		SyslogMessage{
+			facility: 0,
+			severity: 1,
+			Priority: 1,
 			Version:  1,
-			Message:  getStringAddress("x\ny"),
+			Message:  "x\ny",
 		},
 		"",
-		nil,
+		SyslogMessage{},
 	},
 	{
 		[]byte(`<1>2 - - - - - - x
 y`),
 		true,
-		&SyslogMessage{
-			facility: getUint8Address(0),
-			severity: getUint8Address(1),
-			Priority: getUint8Address(1),
+		SyslogMessage{
+			facility: 0,
+			severity: 1,
+			Priority: 1,
 			Version:  2,
-			Message:  getStringAddress("x\ny"),
+			Message:  "x\ny",
 		},
 		"",
-		nil,
+		SyslogMessage{},
 	},
 	// Invalid, out of range code within message
 	{
 		[]byte("<1>1 - - - - - - \xEF\xBB\xBF\xC1"),
 		false,
-		nil,
+		SyslogMessage{},
 		"expecting a free-form optional message in UTF-8 (starting with or without BOM) [col 20]",
-		&SyslogMessage{
-			Priority: getUint8Address(1),
-			facility: getUint8Address(0),
-			severity: getUint8Address(1),
+		SyslogMessage{
+			Priority: 1,
+			facility: 0,
+			severity: 1,
 			Version:  1,
-			Message:  getStringAddress("\xEF\xBB\xBF"),
+			Message:  "\xEF\xBB\xBF",
 		},
 	},
 	{
 		[]byte("<1>2 - - - - - - \xC1"),
 		false,
-		nil,
+		SyslogMessage{},
 		"expecting a free-form optional message in UTF-8 (starting with or without BOM) [col 17]",
-		&SyslogMessage{
-			Priority: getUint8Address(1),
-			facility: getUint8Address(0),
-			severity: getUint8Address(1),
+		SyslogMessage{
+			Priority: 1,
+			facility: 0,
+			severity: 1,
 			Version:  2,
 		},
 	},
 	{
 		[]byte("<1>1 - - - - - - \xEF\xBB\xBF\xc3\x28"), // invalid 2 octet sequence
 		false,
-		nil,
+		SyslogMessage{},
 		"expecting a free-form optional message in UTF-8 (starting with or without BOM) [col 21]",
-		&SyslogMessage{
-			Priority: getUint8Address(1),
-			facility: getUint8Address(0),
-			severity: getUint8Address(1),
+		SyslogMessage{
+			Priority: 1,
+			facility: 0,
+			severity: 1,
 			Version:  1,
-			Message:  getStringAddress("\xEF\xBB\xBF\xc3"),
+			Message:  "\xEF\xBB\xBF\xc3",
 		},
 	},
 	{
 		[]byte("<1>1 - - - - - - \xc3\x28"), // invalid 2 octet sequence
 		false,
-		nil,
+		SyslogMessage{},
 		"expecting a free-form optional message in UTF-8 (starting with or without BOM) [col 18]",
-		&SyslogMessage{
-			Priority: getUint8Address(1),
-			facility: getUint8Address(0),
-			severity: getUint8Address(1),
+		SyslogMessage{
+			Priority: 1,
+			facility: 0,
+			severity: 1,
 			Version:  1,
-			Message:  getStringAddress("\xc3"),
+			Message:  "\xc3",
 		},
 	},
 	{
 		[]byte("<1>1 - - - - - - \xEF\xBB\xBF\xa0\xa1"), // invalid sequence identifier
 		false,
-		nil,
+		SyslogMessage{},
 		"expecting a free-form optional message in UTF-8 (starting with or without BOM) [col 20]",
-		&SyslogMessage{
-			Priority: getUint8Address(1),
-			facility: getUint8Address(0),
-			severity: getUint8Address(1),
+		SyslogMessage{
+			Priority: 1,
+			facility: 0,
+			severity: 1,
 			Version:  1,
-			Message:  getStringAddress("\xEF\xBB\xBF"),
+			Message:  "\xEF\xBB\xBF",
 		},
 	},
 	{
 		[]byte("<1>1 - - - - - - \xa0\xa1"), // invalid sequence identifier
 		false,
-		nil,
+		SyslogMessage{},
 		"expecting a free-form optional message in UTF-8 (starting with or without BOM) [col 17]",
-		&SyslogMessage{
-			Priority: getUint8Address(1),
-			facility: getUint8Address(0),
-			severity: getUint8Address(1),
+		SyslogMessage{
+			Priority: 1,
+			facility: 0,
+			severity: 1,
 			Version:  1,
 		},
 	},
 	{
 		[]byte("<1>1 - - - - - - \xEF\xBB\xBF\xe2\x28\xa1"), // invalid 3 octet sequence (2nd octet)
 		false,
-		nil,
+		SyslogMessage{},
 		"expecting a free-form optional message in UTF-8 (starting with or without BOM) [col 21]",
-		&SyslogMessage{
-			Priority: getUint8Address(1),
-			facility: getUint8Address(0),
-			severity: getUint8Address(1),
+		SyslogMessage{
+			Priority: 1,
+			facility: 0,
+			severity: 1,
 			Version:  1,
-			Message:  getStringAddress("\xEF\xBB\xBF\xe2"),
+			Message:  "\xEF\xBB\xBF\xe2",
 		},
 	},
 	{
 		[]byte("<1>1 - - - - - - \xe2\x28\xa1"), // invalid 3 octet sequence (2nd octet)
 		false,
-		nil,
+		SyslogMessage{},
 		"expecting a free-form optional message in UTF-8 (starting with or without BOM) [col 18]",
-		&SyslogMessage{
-			Priority: getUint8Address(1),
-			facility: getUint8Address(0),
-			severity: getUint8Address(1),
+		SyslogMessage{
+			Priority: 1,
+			facility: 0,
+			severity: 1,
 			Version:  1,
-			Message:  getStringAddress("\xe2"),
+			Message:  "\xe2",
 		},
 	},
 	{
 		[]byte("<1>1 - - - - - - \xEF\xBB\xBF\xe2\x82\x28"), // invalid 3 octet sequence (3nd octet)
 		false,
-		nil,
+		SyslogMessage{},
 		"expecting a free-form optional message in UTF-8 (starting with or without BOM) [col 22]",
-		&SyslogMessage{
-			Priority: getUint8Address(1),
-			facility: getUint8Address(0),
-			severity: getUint8Address(1),
+		SyslogMessage{
+			Priority: 1,
+			facility: 0,
+			severity: 1,
 			Version:  1,
-			Message:  getStringAddress("\xEF\xBB\xBF\xe2\x82"),
+			Message:  "\xEF\xBB\xBF\xe2\x82",
 		},
 	},
 	{
 		[]byte("<1>1 - - - - - - \xe2\x82\x28"), // invalid 3 octet sequence (3nd octet)
 		false,
-		nil,
+		SyslogMessage{},
 		"expecting a free-form optional message in UTF-8 (starting with or without BOM) [col 19]",
-		&SyslogMessage{
-			Priority: getUint8Address(1),
-			facility: getUint8Address(0),
-			severity: getUint8Address(1),
+		SyslogMessage{
+			Priority: 1,
+			facility: 0,
+			severity: 1,
 			Version:  1,
-			Message:  getStringAddress("\xe2\x82"),
+			Message:  "\xe2\x82",
 		},
 	},
 	{
 		[]byte("<1>1 - - - - - - \xEF\xBB\xBF\xf0\x28\x8c\xbc"), // invalid 4 octet sequence (2nd octet)
 		false,
-		nil,
+		SyslogMessage{},
 		"expecting a free-form optional message in UTF-8 (starting with or without BOM) [col 21]",
-		&SyslogMessage{
-			Priority: getUint8Address(1),
-			facility: getUint8Address(0),
-			severity: getUint8Address(1),
+		SyslogMessage{
+			Priority: 1,
+			facility: 0,
+			severity: 1,
 			Version:  1,
-			Message:  getStringAddress("\xEF\xBB\xBF\xf0"),
+			Message:  "\xEF\xBB\xBF\xf0",
 		},
 	},
 	{
 		[]byte("<1>1 - - - - - - \xf0\x28\x8c\xbc"), // invalid 4 octet sequence (2nd octet)
 		false,
-		nil,
+		SyslogMessage{},
 		"expecting a free-form optional message in UTF-8 (starting with or without BOM) [col 18]",
-		&SyslogMessage{
-			Priority: getUint8Address(1),
-			facility: getUint8Address(0),
-			severity: getUint8Address(1),
+		SyslogMessage{
+			Priority: 1,
+			facility: 0,
+			severity: 1,
 			Version:  1,
-			Message:  getStringAddress("\xf0"),
+			Message:  "\xf0",
 		},
 	},
 	{
 		[]byte("<1>1 - - - - - - \xEF\xBB\xBF\xf0\x90\x28\xbc"), // invalid 4 octet sequence (3nd octet)
 		false,
-		nil,
+		SyslogMessage{},
 		"expecting a free-form optional message in UTF-8 (starting with or without BOM) [col 22]",
-		&SyslogMessage{
-			Priority: getUint8Address(1),
-			facility: getUint8Address(0),
-			severity: getUint8Address(1),
+		SyslogMessage{
+			Priority: 1,
+			facility: 0,
+			severity: 1,
 			Version:  1,
-			Message:  getStringAddress("\xEF\xBB\xBF\xf0\x90"),
+			Message:  "\xEF\xBB\xBF\xf0\x90",
 		},
 	},
 	{
 		[]byte("<1>1 - - - - - - \xf0\x90\x28\xbc"), // invalid 4 octet sequence (3nd octet)
 		false,
-		nil,
+		SyslogMessage{},
 		"expecting a free-form optional message in UTF-8 (starting with or without BOM) [col 19]",
-		&SyslogMessage{
-			Priority: getUint8Address(1),
-			facility: getUint8Address(0),
-			severity: getUint8Address(1),
+		SyslogMessage{
+			Priority: 1,
+			facility: 0,
+			severity: 1,
 			Version:  1,
-			Message:  getStringAddress("\xf0\x90"),
+			Message:  "\xf0\x90",
 		},
 	},
 	{
 		[]byte("<1>1 - - - - - - \xEF\xBB\xBF\xf0\x28\x8c\x28"), // invalid 4 octet sequence (4nd octet)
 		false,
-		nil,
+		SyslogMessage{},
 		"expecting a free-form optional message in UTF-8 (starting with or without BOM) [col 21]",
-		&SyslogMessage{
-			Priority: getUint8Address(1),
-			facility: getUint8Address(0),
-			severity: getUint8Address(1),
+		SyslogMessage{
+			Priority: 1,
+			facility: 0,
+			severity: 1,
 			Version:  1,
-			Message:  getStringAddress("\xEF\xBB\xBF\xf0"),
+			Message:  "\xEF\xBB\xBF\xf0",
 		},
 	},
 	{
 		[]byte("<1>1 - - - - - - \xf0\x28\x8c\x28"), // invalid 4 octet sequence (4nd octet)
 		false,
-		nil,
+		SyslogMessage{},
 		"expecting a free-form optional message in UTF-8 (starting with or without BOM) [col 18]",
-		&SyslogMessage{
-			Priority: getUint8Address(1),
-			facility: getUint8Address(0),
-			severity: getUint8Address(1),
+		SyslogMessage{
+			Priority: 1,
+			facility: 0,
+			severity: 1,
 			Version:  1,
-			Message:  getStringAddress("\xf0"),
+			Message:  "\xf0",
 		},
 	},
 	// Invalid, impossible bytes
 	{
 		[]byte("<1>1 - - - - - - \xfe\xfe\xff\xff"),
 		false,
-		nil,
+		SyslogMessage{},
 		"expecting a free-form optional message in UTF-8 (starting with or without BOM) [col 17]",
-		&SyslogMessage{
-			Priority: getUint8Address(1),
-			facility: getUint8Address(0),
-			severity: getUint8Address(1),
+		SyslogMessage{
+			Priority: 1,
+			facility: 0,
+			severity: 1,
 			Version:  1,
 		},
 	},
 	{
 		[]byte("<1>1 - - - - - - \xfe"),
 		false,
-		nil,
+		SyslogMessage{},
 		"expecting a free-form optional message in UTF-8 (starting with or without BOM) [col 17]",
-		&SyslogMessage{
-			Priority: getUint8Address(1),
-			facility: getUint8Address(0),
-			severity: getUint8Address(1),
+		SyslogMessage{
+			Priority: 1,
+			facility: 0,
+			severity: 1,
 			Version:  1,
 		},
 	},
 	{
 		[]byte("<1>1 - - - - - - \xff"),
 		false,
-		nil,
+		SyslogMessage{},
 		"expecting a free-form optional message in UTF-8 (starting with or without BOM) [col 17]",
-		&SyslogMessage{
-			Priority: getUint8Address(1),
-			facility: getUint8Address(0),
-			severity: getUint8Address(1),
+		SyslogMessage{
+			Priority: 1,
+			facility: 0,
+			severity: 1,
 			Version:  1,
 		},
 	},
@@ -2194,62 +2187,62 @@ y`),
 	{
 		[]byte("<1>1 - - - - - - \xfc\x80\x80\x80\x80\xaf"),
 		false,
-		nil,
+		SyslogMessage{},
 		"expecting a free-form optional message in UTF-8 (starting with or without BOM) [col 17]",
-		&SyslogMessage{
-			Priority: getUint8Address(1),
-			facility: getUint8Address(0),
-			severity: getUint8Address(1),
+		SyslogMessage{
+			Priority: 1,
+			facility: 0,
+			severity: 1,
 			Version:  1,
 		},
 	},
 	{
 		[]byte("<1>1 - - - - - - \xf8\x80\x80\x80\xaf"),
 		false,
-		nil,
+		SyslogMessage{},
 		"expecting a free-form optional message in UTF-8 (starting with or without BOM) [col 17]",
-		&SyslogMessage{
-			Priority: getUint8Address(1),
-			facility: getUint8Address(0),
-			severity: getUint8Address(1),
+		SyslogMessage{
+			Priority: 1,
+			facility: 0,
+			severity: 1,
 			Version:  1,
 		},
 	},
 	{
 		[]byte("<1>1 - - - - - - \xf0\x80\x80\xaf"),
 		false,
-		nil,
+		SyslogMessage{},
 		"expecting a free-form optional message in UTF-8 (starting with or without BOM) [col 18]",
-		&SyslogMessage{
-			Priority: getUint8Address(1),
-			facility: getUint8Address(0),
-			severity: getUint8Address(1),
+		SyslogMessage{
+			Priority: 1,
+			facility: 0,
+			severity: 1,
 			Version:  1,
-			Message:  getStringAddress("\xf0"),
+			Message:  "\xf0",
 		},
 	},
 	{
 		[]byte("<1>1 - - - - - - \xe0\x80\xaf"),
 		false,
-		nil,
+		SyslogMessage{},
 		"expecting a free-form optional message in UTF-8 (starting with or without BOM) [col 18]",
-		&SyslogMessage{
-			Priority: getUint8Address(1),
-			facility: getUint8Address(0),
-			severity: getUint8Address(1),
+		SyslogMessage{
+			Priority: 1,
+			facility: 0,
+			severity: 1,
 			Version:  1,
-			Message:  getStringAddress("\xe0"),
+			Message:  "\xe0",
 		},
 	},
 	{
 		[]byte("<1>1 - - - - - - \xc0\xaf"),
 		false,
-		nil,
+		SyslogMessage{},
 		"expecting a free-form optional message in UTF-8 (starting with or without BOM) [col 17]",
-		&SyslogMessage{
-			Priority: getUint8Address(1),
-			facility: getUint8Address(0),
-			severity: getUint8Address(1),
+		SyslogMessage{
+			Priority: 1,
+			facility: 0,
+			severity: 1,
 			Version:  1,
 		},
 	},
@@ -2257,197 +2250,196 @@ y`),
 	{
 		[]byte("<1>1 - - - - - - \xfc\x83\xbf\xbf\xbf\xbf"),
 		false,
-		nil,
+		SyslogMessage{},
 		"expecting a free-form optional message in UTF-8 (starting with or without BOM) [col 17]",
-		&SyslogMessage{
-			Priority: getUint8Address(1),
-			facility: getUint8Address(0),
-			severity: getUint8Address(1),
+		SyslogMessage{
+			Priority: 1,
+			facility: 0,
+			severity: 1,
 			Version:  1,
 		},
 	},
 	{
 		[]byte("<1>1 - - - - - - \xf8\x87\xbf\xbf\xbf"),
 		false,
-		nil,
+		SyslogMessage{},
 		"expecting a free-form optional message in UTF-8 (starting with or without BOM) [col 17]",
-		&SyslogMessage{
-			Priority: getUint8Address(1),
-			facility: getUint8Address(0),
-			severity: getUint8Address(1),
+		SyslogMessage{
+			Priority: 1,
+			facility: 0,
+			severity: 1,
 			Version:  1,
 		},
 	},
 	{
 		[]byte("<1>1 - - - - - - \xf0\x8f\xbf\xbf"),
 		false,
-		nil,
+		SyslogMessage{},
 		"expecting a free-form optional message in UTF-8 (starting with or without BOM) [col 18]",
-		&SyslogMessage{
-			Priority: getUint8Address(1),
-			facility: getUint8Address(0),
-			severity: getUint8Address(1),
+		SyslogMessage{
+			Priority: 1,
+			facility: 0,
+			severity: 1,
 			Version:  1,
-			Message:  getStringAddress("\xf0"),
+			Message:  "\xf0",
 		},
 	},
 	{
 		[]byte("<1>1 - - - - - - \xe0\x9f\xbf"),
 		false,
-		nil,
+		SyslogMessage{},
 		"expecting a free-form optional message in UTF-8 (starting with or without BOM) [col 18]",
-		&SyslogMessage{
-			Priority: getUint8Address(1),
-			facility: getUint8Address(0),
-			severity: getUint8Address(1),
+		SyslogMessage{
+			Priority: 1,
+			facility: 0,
+			severity: 1,
 			Version:  1,
-			Message:  getStringAddress("\xe0"),
+			Message:  "\xe0",
 		},
 	},
 	{
 		[]byte("<1>1 - - - - - - \xc1\xbf"),
 		false,
-		nil,
+		SyslogMessage{},
 		"expecting a free-form optional message in UTF-8 (starting with or without BOM) [col 17]",
-		&SyslogMessage{
-			Priority: getUint8Address(1),
-			facility: getUint8Address(0),
-			severity: getUint8Address(1),
+		SyslogMessage{
+			Priority: 1,
+			facility: 0,
+			severity: 1,
 			Version:  1,
-			Message:  nil,
 		},
 	},
 	// Invalid, illegal code positions, single utf-16 surrogates
 	{
 		[]byte("<1>1 - - - - - - \xed\xa0\x80"),
 		false,
-		nil,
+		SyslogMessage{},
 		"expecting a free-form optional message in UTF-8 (starting with or without BOM) [col 18]",
-		&SyslogMessage{
-			Priority: getUint8Address(1),
-			facility: getUint8Address(0),
-			severity: getUint8Address(1),
+		SyslogMessage{
+			Priority: 1,
+			facility: 0,
+			severity: 1,
 			Version:  1,
-			Message:  getStringAddress("\xed"),
+			Message:  "\xed",
 		},
 	},
 	{
 		[]byte("<1>1 - - - - - - \xed\xa0\x80"),
 		false,
-		nil,
+		SyslogMessage{},
 		"expecting a free-form optional message in UTF-8 (starting with or without BOM) [col 18]",
-		&SyslogMessage{
-			Priority: getUint8Address(1),
-			facility: getUint8Address(0),
-			severity: getUint8Address(1),
+		SyslogMessage{
+			Priority: 1,
+			facility: 0,
+			severity: 1,
 			Version:  1,
-			Message:  getStringAddress("\xed"),
+			Message:  "\xed",
 		},
 	},
 	{
 		[]byte("<1>1 - - - - - - \xed\xad\xbf"),
 		false,
-		nil,
+		SyslogMessage{},
 		"expecting a free-form optional message in UTF-8 (starting with or without BOM) [col 18]",
-		&SyslogMessage{
-			Priority: getUint8Address(1),
-			facility: getUint8Address(0),
-			severity: getUint8Address(1),
+		SyslogMessage{
+			Priority: 1,
+			facility: 0,
+			severity: 1,
 			Version:  1,
-			Message:  getStringAddress("\xed"),
+			Message:  "\xed",
 		},
 	},
 	{
 		[]byte("<1>1 - - - - - - \xed\xae\x80"),
 		false,
-		nil,
+		SyslogMessage{},
 		"expecting a free-form optional message in UTF-8 (starting with or without BOM) [col 18]",
-		&SyslogMessage{
-			Priority: getUint8Address(1),
-			facility: getUint8Address(0),
-			severity: getUint8Address(1),
+		SyslogMessage{
+			Priority: 1,
+			facility: 0,
+			severity: 1,
 			Version:  1,
-			Message:  getStringAddress("\xed"),
+			Message:  "\xed",
 		},
 	},
 	{
 		[]byte("<1>1 - - - - - - \xed\xaf\xbf"),
 		false,
-		nil,
+		SyslogMessage{},
 		"expecting a free-form optional message in UTF-8 (starting with or without BOM) [col 18]",
-		&SyslogMessage{
-			Priority: getUint8Address(1),
-			facility: getUint8Address(0),
-			severity: getUint8Address(1),
+		SyslogMessage{
+			Priority: 1,
+			facility: 0,
+			severity: 1,
 			Version:  1,
-			Message:  getStringAddress("\xed"),
+			Message:  "\xed",
 		},
 	},
 	{
 		[]byte("<1>1 - - - - - - \xed\xb0\x80"),
 		false,
-		nil,
+		SyslogMessage{},
 		"expecting a free-form optional message in UTF-8 (starting with or without BOM) [col 18]",
-		&SyslogMessage{
-			Priority: getUint8Address(1),
-			facility: getUint8Address(0),
-			severity: getUint8Address(1),
+		SyslogMessage{
+			Priority: 1,
+			facility: 0,
+			severity: 1,
 			Version:  1,
-			Message:  getStringAddress("\xed"),
+			Message:  "\xed",
 		},
 	},
 	{
 		[]byte("<1>1 - - - - - - \xed\xbe\x80"),
 		false,
-		nil,
+		SyslogMessage{},
 		"expecting a free-form optional message in UTF-8 (starting with or without BOM) [col 18]",
-		&SyslogMessage{
-			Priority: getUint8Address(1),
-			facility: getUint8Address(0),
-			severity: getUint8Address(1),
+		SyslogMessage{
+			Priority: 1,
+			facility: 0,
+			severity: 1,
 			Version:  1,
-			Message:  getStringAddress("\xed"),
+			Message:  "\xed",
 		},
 	},
 	{
 		[]byte("<1>1 - - - - - - \xed\xbf\xbf"),
 		false,
-		nil,
+		SyslogMessage{},
 		"expecting a free-form optional message in UTF-8 (starting with or without BOM) [col 18]",
-		&SyslogMessage{
-			Priority: getUint8Address(1),
-			facility: getUint8Address(0),
-			severity: getUint8Address(1),
+		SyslogMessage{
+			Priority: 1,
+			facility: 0,
+			severity: 1,
 			Version:  1,
-			Message:  getStringAddress("\xed"),
+			Message:  "\xed",
 		},
 	},
 	// Invalid, illegal code positions, paired utf-16 surrogates
 	{
 		[]byte("<1>1 - - - - - - \xed\xa0\x80\xed\xb0\x80"),
 		false,
-		nil,
+		SyslogMessage{},
 		"expecting a free-form optional message in UTF-8 (starting with or without BOM) [col 18]",
-		&SyslogMessage{
-			Priority: getUint8Address(1),
-			facility: getUint8Address(0),
-			severity: getUint8Address(1),
+		SyslogMessage{
+			Priority: 1,
+			facility: 0,
+			severity: 1,
 			Version:  1,
-			Message:  getStringAddress("\xed"),
+			Message:  "\xed",
 		},
 	},
 	// Invalid, out of range code within message after valid string
 	{
 		[]byte("<1>1 - - - - - - valid\xEF\xBB\xBF\xC1"),
 		false,
-		nil,
+		SyslogMessage{},
 		"expecting a free-form optional message in UTF-8 (starting with or without BOM) [col 25]",
-		&SyslogMessage{
-			Priority: getUint8Address(1),
-			facility: getUint8Address(0),
-			severity: getUint8Address(1),
+		SyslogMessage{
+			Priority: 1,
+			facility: 0,
+			severity: 1,
 			Version:  1,
-			Message:  getStringAddress("valid\ufeff"),
+			Message:  "valid\ufeff",
 		},
 	},
 
@@ -2457,10 +2449,10 @@ y`),
 	// 	false,
 	// 	nil,
 	// 	"parsing error [col 6]",
-	// 	&SyslogMessage{
-	// 		Priority: getUint8Address(1),
-	// 		facility: getUint8Address(0),
-	// 		severity: getUint8Address(1),
+	// 	SyslogMessage{
+	// 		Priority: 1,
+	// 		facility: 0,
+	// 		severity: 1,
 	// 		Version: 1,
 	// 	},
 	// },
@@ -2474,20 +2466,18 @@ func TestMachineParse(t *testing.T) {
 		t.Run(rxpad(string(tc.input), 50), func(t *testing.T) {
 			t.Parallel()
 
-			bestEffort := true
 			fsm := NewMachine()
-			message, merr := fsm.Parse(tc.input, nil)
-			partial, perr := fsm.Parse(tc.input, &bestEffort)
+			message, merr := fsm.Parse(tc.input, false)
+			partial, perr := fsm.Parse(tc.input, true)
 
 			if !tc.valid {
-				assert.Nil(t, message)
+				assert.Equal(t, SyslogMessage{}, message)
 				assert.Error(t, merr)
 				assert.EqualError(t, merr, tc.errorString)
 
 				assert.Equal(t, tc.partialValue, partial)
 				assert.EqualError(t, perr, tc.errorString)
-			}
-			if tc.valid {
+			} else {
 				assert.Nil(t, merr)
 				assert.NotEmpty(t, message)
 				assert.Equal(t, message, partial)

--- a/rfc5424/parser.go
+++ b/rfc5424/parser.go
@@ -20,17 +20,10 @@ func NewParser() *Parser {
 // Parse parses the input RFC5424 syslog message using its FSM.
 //
 // Best effort mode enables the partial parsing.
-func (p *Parser) Parse(input []byte, bestEffort *bool) (*SyslogMessage, error) {
+func (p *Parser) Parse(input []byte, bestEffort bool) (msg SyslogMessage, err error) {
 	p.Lock()
 	defer p.Unlock()
 
-	msg, err := p.machine.Parse(input, bestEffort)
-	if err != nil {
-		if bestEffort != nil && *bestEffort != false {
-			return msg, err
-		}
-		return nil, err
-	}
-
-	return msg, nil
+	msg, err = p.machine.Parse(input, bestEffort)
+	return
 }

--- a/rfc5424/parser_test.go
+++ b/rfc5424/parser_test.go
@@ -13,12 +13,11 @@ func TestParserParse(t *testing.T) {
 		t.Run(rxpad(string(tc.input), 50), func(t *testing.T) {
 			t.Parallel()
 
-			bestEffort := true
-			message, merr := p.Parse(tc.input, nil)
-			partial, perr := p.Parse(tc.input, &bestEffort)
+			message, merr := p.Parse(tc.input, false)
+			partial, perr := p.Parse(tc.input, true)
 
 			if !tc.valid {
-				assert.Nil(t, message)
+				assert.Equal(t, message, SyslogMessage{})
 				assert.Error(t, merr)
 				assert.EqualError(t, merr, tc.errorString)
 

--- a/rfc5424/performance_test.go
+++ b/rfc5424/performance_test.go
@@ -5,7 +5,7 @@ import "testing"
 // This is here to avoid compiler optimizations that
 // could remove the actual call we are benchmarking
 // during benchmarks
-var benchParseResult *SyslogMessage
+var benchParseResult SyslogMessage
 
 type benchCase struct {
 	input []byte
@@ -90,10 +90,9 @@ var benchCases = []benchCase{
 func BenchmarkParse(b *testing.B) {
 	for _, tc := range benchCases {
 		tc := tc
-		bestEffort := true
 		b.Run(rxpad(tc.label, 50), func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
-				benchParseResult, _ = NewMachine().Parse(tc.input, &bestEffort)
+				benchParseResult, _ = NewMachine().Parse(tc.input, true)
 			}
 		})
 	}

--- a/rfc5424/syslog_message.go
+++ b/rfc5424/syslog_message.go
@@ -6,17 +6,17 @@ import (
 
 // SyslogMessage represents a syslog message
 type SyslogMessage struct {
-	Priority       *uint8
-	facility       *uint8
-	severity       *uint8
+	Priority       uint8
+	facility       uint8
+	severity       uint8
 	Version        uint16 // Grammar mandates that version cannot be 0, so we can use the 0 value of uint16 to signal nil
-	Timestamp      *time.Time
-	Hostname       *string
-	Appname        *string
-	ProcID         *string
-	MsgID          *string
-	StructuredData *map[string]map[string]string
-	Message        *string
+	Timestamp      time.Time
+	Hostname       string
+	Appname        string
+	ProcID         string
+	MsgID          string
+	StructuredData map[string]map[string]string
+	Message        string
 }
 
 // Valid tells whether the message is well-formed or not.
@@ -25,7 +25,7 @@ type SyslogMessage struct {
 func (sm *SyslogMessage) Valid() bool {
 	// A nil priority or a 0 version means that the message is not valid
 	// Not checking the priority range since it's parser responsibility
-	if sm.Priority != nil && *sm.Priority >= 0 && *sm.Priority <= 191 && sm.Version > 0 && sm.Version <= 999 {
+	if sm.Priority >= 0 && sm.Priority <= 191 && sm.Version > 0 && sm.Version <= 999 {
 		return true
 	}
 
@@ -34,51 +34,43 @@ func (sm *SyslogMessage) Valid() bool {
 
 // SetPriority set the priority value and the computed facility and severity codes accordingly.
 func (sm *SyslogMessage) SetPriority(value uint8) {
-	sm.Priority = &value
-	facility := uint8(value / 8)
-	severity := uint8(value % 8)
-	sm.facility = &facility
-	sm.severity = &severity
+	sm.Priority = value
+	sm.facility = uint8(value / 8)
+	sm.severity = uint8(value % 8)
 }
 
 // Facility returns the facility code.
-func (sm *SyslogMessage) Facility() *uint8 {
+func (sm *SyslogMessage) Facility() uint8 {
 	return sm.facility
 }
 
 // Severity returns the severity code.
-func (sm *SyslogMessage) Severity() *uint8 {
+func (sm *SyslogMessage) Severity() uint8 {
 	return sm.severity
 }
 
 // FacilityMessage returns the text message for the current facility value.
-func (sm *SyslogMessage) FacilityMessage() *string {
-	if sm.facility != nil {
-		msg := facilities[*sm.facility]
-		return &msg
+func (sm *SyslogMessage) FacilityMessage() (m string) {
+	if sm.facility >= uint8(0) && sm.facility < uint8(len(facilities)) {
+		m = facilities[sm.facility]
 	}
-
-	return nil
+	return
 }
 
 // SeverityMessage returns the text message for the current severity value.
-func (sm *SyslogMessage) SeverityMessage() *string {
-	if sm.severity != nil {
-		msg := severityMessages[*sm.severity]
-		return &msg
+func (sm *SyslogMessage) SeverityMessage() (m string) {
+	if sm.severity >= uint8(0) && sm.severity < uint8(len(severityMessages)) {
+		m = severityMessages[sm.severity]
 	}
-
-	return nil
+	return
 }
 
 // SeverityLevel returns the text level for the current severity value.
-func (sm *SyslogMessage) SeverityLevel() *string {
-	if sm.severity != nil {
-		msg := severityLevels[*sm.severity]
-		return &msg
+func (sm *SyslogMessage) SeverityLevel() (m string) {
+	if sm.severity >= uint8(0) && sm.severity < uint8(len(severityMessages)) {
+		m = severityLevels[sm.severity]
 	}
-
-	return nil
+	return
 }
 
 var severityMessages = map[uint8]string{


### PR DESCRIPTION
I admittedly don't understand the purpose of all the pointers and indirection in the code, but i did a little light profiling and then rolled it in our own system and found that the extra pointers were causing more stress on the allocator and GC.  I refactored the ragel system and some of the code to remove them and got between 10 and 60% speedups.  If there is some other reason for keeping that indirection I would like to better understand it.  I am also admittedly new to ragel and code generation, so if I botched some of the code changes let me know.

Thank you for the library, it was already fast, this is a little faster and more go-like.

```
benchmark                                                               old ns/op     new ns/op     delta
BenchmarkParse/[no]_empty_input__________________________________-4     270           233           -13.70%
BenchmarkParse/[no]_multiple_syslog_messages_on_multiple_lines___-4     519           322           -37.96%
BenchmarkParse/[no]_impossible_timestamp_________________________-4     1258          1065          -15.34%
BenchmarkParse/[no]_malformed_structured_data____________________-4     608           423           -30.43%
BenchmarkParse/[no]_with_duplicated_structured_data_id___________-4     1698          1397          -17.73%
BenchmarkParse/[ok]_minimal______________________________________-4     321           122           -61.99%
BenchmarkParse/[ok]_average_message______________________________-4     2588          2228          -13.91%
BenchmarkParse/[ok]_complicated_message__________________________-4     2176          1860          -14.52%
BenchmarkParse/[ok]_very_long_message____________________________-4     4501          4081          -9.33%
BenchmarkParse/[ok]_all_max_length_and_complete__________________-4     3514          3174          -9.68%
BenchmarkParse/[ok]_all_max_length_except_structured_data_and_mes-4     2115          1846          -12.72%
BenchmarkParse/[ok]_minimal_with_message_containing_newline______-4     384           157           -59.11%
BenchmarkParse/[ok]_w/o_procid,_w/o_structured_data,_with_message-4     1082          762           -29.57%
BenchmarkParse/[ok]_minimal_with_UTF-8_message___________________-4     608           370           -39.14%
BenchmarkParse/[ok]_with_structured_data_id,_w/o_structured_data_-4     1231          950           -22.83%
BenchmarkParse/[ok]_with_multiple_structured_data________________-4     1920          1603          -16.51%
BenchmarkParse/[ok]_with_escaped_backslash_within_structured_data-4     1667          1319          -20.88%
BenchmarkParse/[ok]_with_UTF-8_structured_data_param_value,_with_-4     1813          1596          -11.97%
```