### PR TITLE
Fixing go modules transition

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/influxdata/go-syslog/v2
+module github.com/influxdata/go-syslog
 
 require (
 	github.com/davecgh/go-spew v1.1.1

--- a/nontransparent/example_test.go
+++ b/nontransparent/example_test.go
@@ -6,7 +6,7 @@ import (
 	"math/rand"
 	"strings"
 
-	"github.com/influxdata/go-syslog/v2"
+	"github.com/influxdata/go-syslog"
 	"time"
 )
 

--- a/nontransparent/parser.go
+++ b/nontransparent/parser.go
@@ -3,8 +3,8 @@ package nontransparent
 import (
 	"io"
 
-	syslog "github.com/influxdata/go-syslog/v2"
-	"github.com/influxdata/go-syslog/v2/rfc5424"
+	syslog "github.com/influxdata/go-syslog"
+	"github.com/influxdata/go-syslog/rfc5424"
 	parser "github.com/leodido/ragel-machinery/parser"
 )
 

--- a/nontransparent/parser.go.rl
+++ b/nontransparent/parser.go.rl
@@ -4,8 +4,8 @@ import (
     "io"
     
     parser "github.com/leodido/ragel-machinery/parser"
-    syslog "github.com/influxdata/go-syslog/v2"
-    "github.com/influxdata/go-syslog/v2/rfc5424"
+    syslog "github.com/influxdata/go-syslog"
+    "github.com/influxdata/go-syslog/rfc5424"
 )
 
 %%{

--- a/nontransparent/parser_test.go
+++ b/nontransparent/parser_test.go
@@ -6,8 +6,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/influxdata/go-syslog/v2"
-	"github.com/influxdata/go-syslog/v2/rfc5424"
+	"github.com/influxdata/go-syslog"
+	"github.com/influxdata/go-syslog/rfc5424"
 	"github.com/leodido/ragel-machinery"
 	"github.com/stretchr/testify/assert"
 )

--- a/octetcounting/example_test.go
+++ b/octetcounting/example_test.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	"github.com/davecgh/go-spew/spew"
-	syslog "github.com/influxdata/go-syslog/v2"
+	syslog "github.com/influxdata/go-syslog"
 )
 
 func output(out interface{}) {

--- a/octetcounting/parser.go
+++ b/octetcounting/parser.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"io"
 
-	syslog "github.com/influxdata/go-syslog/v2"
-	"github.com/influxdata/go-syslog/v2/rfc5424"
+	syslog "github.com/influxdata/go-syslog"
+	"github.com/influxdata/go-syslog/rfc5424"
 )
 
 // parser is capable to parse the input stream containing syslog messages with octetcounting framing.

--- a/octetcounting/parser_test.go
+++ b/octetcounting/parser_test.go
@@ -5,9 +5,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/influxdata/go-syslog/v2"
-	"github.com/influxdata/go-syslog/v2/rfc5424"
-	syslogtesting "github.com/influxdata/go-syslog/v2/testing"
+	"github.com/influxdata/go-syslog"
+	"github.com/influxdata/go-syslog/rfc5424"
+	syslogtesting "github.com/influxdata/go-syslog/testing"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/rfc5424/builder.go
+++ b/rfc5424/builder.go
@@ -5,20 +5,20 @@ import (
 	"sort"
 	"time"
 
-	"github.com/influxdata/go-syslog/v2/common"
+	"github.com/influxdata/go-syslog/common"
 )
 
-const builderStart int = 59
+const builder_start int = 59
 
-const builderEnTimestamp int = 8
-const builderEnHostname int = 45
-const builderEnAppname int = 46
-const builderEnProcid int = 47
-const builderEnMsgid int = 48
-const builderEnSdid int = 49
-const builderEnSdpn int = 50
-const builderEnSdpv int = 589
-const builderEnMsg int = 59
+const builder_en_timestamp int = 8
+const builder_en_hostname int = 45
+const builder_en_appname int = 46
+const builder_en_procid int = 47
+const builder_en_msgid int = 48
+const builder_en_sdid int = 49
+const builder_en_sdpn int = 50
+const builder_en_sdpv int = 589
+const builder_en_msg int = 59
 
 type entrypoint int
 
@@ -37,25 +37,25 @@ const (
 func (e entrypoint) translate() int {
 	switch e {
 	case timestamp:
-		return builderEnTimestamp
+		return builder_en_timestamp
 	case hostname:
-		return builderEnHostname
+		return builder_en_hostname
 	case appname:
-		return builderEnAppname
+		return builder_en_appname
 	case procid:
-		return builderEnProcid
+		return builder_en_procid
 	case msgid:
-		return builderEnMsgid
+		return builder_en_msgid
 	case sdid:
-		return builderEnSdid
+		return builder_en_sdid
 	case sdpn:
-		return builderEnSdpn
+		return builder_en_sdpn
 	case sdpv:
-		return builderEnSdpv
+		return builder_en_sdpv
 	case msg:
-		return builderEnMsg
+		return builder_en_msg
 	default:
-		return builderStart
+		return builder_start
 	}
 }
 
@@ -73,1194 +73,1194 @@ func (sm *SyslogMessage) set(from entrypoint, value string) *SyslogMessage {
 
 	{
 		if p == pe {
-			goto _testEof
+			goto _test_eof
 		}
 		switch cs {
 		case 59:
-			goto stCase59
+			goto st_case_59
 		case 60:
-			goto stCase60
+			goto st_case_60
 		case 0:
-			goto stCase0
+			goto st_case_0
 		case 1:
-			goto stCase1
+			goto st_case_1
 		case 2:
-			goto stCase2
+			goto st_case_2
 		case 3:
-			goto stCase3
+			goto st_case_3
 		case 4:
-			goto stCase4
+			goto st_case_4
 		case 5:
-			goto stCase5
+			goto st_case_5
 		case 6:
-			goto stCase6
+			goto st_case_6
 		case 7:
-			goto stCase7
+			goto st_case_7
 		case 8:
-			goto stCase8
+			goto st_case_8
 		case 9:
-			goto stCase9
+			goto st_case_9
 		case 10:
-			goto stCase10
+			goto st_case_10
 		case 11:
-			goto stCase11
+			goto st_case_11
 		case 12:
-			goto stCase12
+			goto st_case_12
 		case 13:
-			goto stCase13
+			goto st_case_13
 		case 14:
-			goto stCase14
+			goto st_case_14
 		case 15:
-			goto stCase15
+			goto st_case_15
 		case 16:
-			goto stCase16
+			goto st_case_16
 		case 17:
-			goto stCase17
+			goto st_case_17
 		case 18:
-			goto stCase18
+			goto st_case_18
 		case 19:
-			goto stCase19
+			goto st_case_19
 		case 20:
-			goto stCase20
+			goto st_case_20
 		case 21:
-			goto stCase21
+			goto st_case_21
 		case 22:
-			goto stCase22
+			goto st_case_22
 		case 23:
-			goto stCase23
+			goto st_case_23
 		case 24:
-			goto stCase24
+			goto st_case_24
 		case 25:
-			goto stCase25
+			goto st_case_25
 		case 26:
-			goto stCase26
+			goto st_case_26
 		case 27:
-			goto stCase27
+			goto st_case_27
 		case 28:
-			goto stCase28
+			goto st_case_28
 		case 29:
-			goto stCase29
+			goto st_case_29
 		case 30:
-			goto stCase30
+			goto st_case_30
 		case 31:
-			goto stCase31
+			goto st_case_31
 		case 32:
-			goto stCase32
+			goto st_case_32
 		case 61:
-			goto stCase61
+			goto st_case_61
 		case 33:
-			goto stCase33
+			goto st_case_33
 		case 34:
-			goto stCase34
+			goto st_case_34
 		case 35:
-			goto stCase35
+			goto st_case_35
 		case 36:
-			goto stCase36
+			goto st_case_36
 		case 37:
-			goto stCase37
+			goto st_case_37
 		case 38:
-			goto stCase38
+			goto st_case_38
 		case 39:
-			goto stCase39
+			goto st_case_39
 		case 40:
-			goto stCase40
+			goto st_case_40
 		case 41:
-			goto stCase41
+			goto st_case_41
 		case 42:
-			goto stCase42
+			goto st_case_42
 		case 43:
-			goto stCase43
+			goto st_case_43
 		case 44:
-			goto stCase44
+			goto st_case_44
 		case 45:
-			goto stCase45
+			goto st_case_45
 		case 62:
-			goto stCase62
+			goto st_case_62
 		case 63:
-			goto stCase63
+			goto st_case_63
 		case 64:
-			goto stCase64
+			goto st_case_64
 		case 65:
-			goto stCase65
+			goto st_case_65
 		case 66:
-			goto stCase66
+			goto st_case_66
 		case 67:
-			goto stCase67
+			goto st_case_67
 		case 68:
-			goto stCase68
+			goto st_case_68
 		case 69:
-			goto stCase69
+			goto st_case_69
 		case 70:
-			goto stCase70
+			goto st_case_70
 		case 71:
-			goto stCase71
+			goto st_case_71
 		case 72:
-			goto stCase72
+			goto st_case_72
 		case 73:
-			goto stCase73
+			goto st_case_73
 		case 74:
-			goto stCase74
+			goto st_case_74
 		case 75:
-			goto stCase75
+			goto st_case_75
 		case 76:
-			goto stCase76
+			goto st_case_76
 		case 77:
-			goto stCase77
+			goto st_case_77
 		case 78:
-			goto stCase78
+			goto st_case_78
 		case 79:
-			goto stCase79
+			goto st_case_79
 		case 80:
-			goto stCase80
+			goto st_case_80
 		case 81:
-			goto stCase81
+			goto st_case_81
 		case 82:
-			goto stCase82
+			goto st_case_82
 		case 83:
-			goto stCase83
+			goto st_case_83
 		case 84:
-			goto stCase84
+			goto st_case_84
 		case 85:
-			goto stCase85
+			goto st_case_85
 		case 86:
-			goto stCase86
+			goto st_case_86
 		case 87:
-			goto stCase87
+			goto st_case_87
 		case 88:
-			goto stCase88
+			goto st_case_88
 		case 89:
-			goto stCase89
+			goto st_case_89
 		case 90:
-			goto stCase90
+			goto st_case_90
 		case 91:
-			goto stCase91
+			goto st_case_91
 		case 92:
-			goto stCase92
+			goto st_case_92
 		case 93:
-			goto stCase93
+			goto st_case_93
 		case 94:
-			goto stCase94
+			goto st_case_94
 		case 95:
-			goto stCase95
+			goto st_case_95
 		case 96:
-			goto stCase96
+			goto st_case_96
 		case 97:
-			goto stCase97
+			goto st_case_97
 		case 98:
-			goto stCase98
+			goto st_case_98
 		case 99:
-			goto stCase99
+			goto st_case_99
 		case 100:
-			goto stCase100
+			goto st_case_100
 		case 101:
-			goto stCase101
+			goto st_case_101
 		case 102:
-			goto stCase102
+			goto st_case_102
 		case 103:
-			goto stCase103
+			goto st_case_103
 		case 104:
-			goto stCase104
+			goto st_case_104
 		case 105:
-			goto stCase105
+			goto st_case_105
 		case 106:
-			goto stCase106
+			goto st_case_106
 		case 107:
-			goto stCase107
+			goto st_case_107
 		case 108:
-			goto stCase108
+			goto st_case_108
 		case 109:
-			goto stCase109
+			goto st_case_109
 		case 110:
-			goto stCase110
+			goto st_case_110
 		case 111:
-			goto stCase111
+			goto st_case_111
 		case 112:
-			goto stCase112
+			goto st_case_112
 		case 113:
-			goto stCase113
+			goto st_case_113
 		case 114:
-			goto stCase114
+			goto st_case_114
 		case 115:
-			goto stCase115
+			goto st_case_115
 		case 116:
-			goto stCase116
+			goto st_case_116
 		case 117:
-			goto stCase117
+			goto st_case_117
 		case 118:
-			goto stCase118
+			goto st_case_118
 		case 119:
-			goto stCase119
+			goto st_case_119
 		case 120:
-			goto stCase120
+			goto st_case_120
 		case 121:
-			goto stCase121
+			goto st_case_121
 		case 122:
-			goto stCase122
+			goto st_case_122
 		case 123:
-			goto stCase123
+			goto st_case_123
 		case 124:
-			goto stCase124
+			goto st_case_124
 		case 125:
-			goto stCase125
+			goto st_case_125
 		case 126:
-			goto stCase126
+			goto st_case_126
 		case 127:
-			goto stCase127
+			goto st_case_127
 		case 128:
-			goto stCase128
+			goto st_case_128
 		case 129:
-			goto stCase129
+			goto st_case_129
 		case 130:
-			goto stCase130
+			goto st_case_130
 		case 131:
-			goto stCase131
+			goto st_case_131
 		case 132:
-			goto stCase132
+			goto st_case_132
 		case 133:
-			goto stCase133
+			goto st_case_133
 		case 134:
-			goto stCase134
+			goto st_case_134
 		case 135:
-			goto stCase135
+			goto st_case_135
 		case 136:
-			goto stCase136
+			goto st_case_136
 		case 137:
-			goto stCase137
+			goto st_case_137
 		case 138:
-			goto stCase138
+			goto st_case_138
 		case 139:
-			goto stCase139
+			goto st_case_139
 		case 140:
-			goto stCase140
+			goto st_case_140
 		case 141:
-			goto stCase141
+			goto st_case_141
 		case 142:
-			goto stCase142
+			goto st_case_142
 		case 143:
-			goto stCase143
+			goto st_case_143
 		case 144:
-			goto stCase144
+			goto st_case_144
 		case 145:
-			goto stCase145
+			goto st_case_145
 		case 146:
-			goto stCase146
+			goto st_case_146
 		case 147:
-			goto stCase147
+			goto st_case_147
 		case 148:
-			goto stCase148
+			goto st_case_148
 		case 149:
-			goto stCase149
+			goto st_case_149
 		case 150:
-			goto stCase150
+			goto st_case_150
 		case 151:
-			goto stCase151
+			goto st_case_151
 		case 152:
-			goto stCase152
+			goto st_case_152
 		case 153:
-			goto stCase153
+			goto st_case_153
 		case 154:
-			goto stCase154
+			goto st_case_154
 		case 155:
-			goto stCase155
+			goto st_case_155
 		case 156:
-			goto stCase156
+			goto st_case_156
 		case 157:
-			goto stCase157
+			goto st_case_157
 		case 158:
-			goto stCase158
+			goto st_case_158
 		case 159:
-			goto stCase159
+			goto st_case_159
 		case 160:
-			goto stCase160
+			goto st_case_160
 		case 161:
-			goto stCase161
+			goto st_case_161
 		case 162:
-			goto stCase162
+			goto st_case_162
 		case 163:
-			goto stCase163
+			goto st_case_163
 		case 164:
-			goto stCase164
+			goto st_case_164
 		case 165:
-			goto stCase165
+			goto st_case_165
 		case 166:
-			goto stCase166
+			goto st_case_166
 		case 167:
-			goto stCase167
+			goto st_case_167
 		case 168:
-			goto stCase168
+			goto st_case_168
 		case 169:
-			goto stCase169
+			goto st_case_169
 		case 170:
-			goto stCase170
+			goto st_case_170
 		case 171:
-			goto stCase171
+			goto st_case_171
 		case 172:
-			goto stCase172
+			goto st_case_172
 		case 173:
-			goto stCase173
+			goto st_case_173
 		case 174:
-			goto stCase174
+			goto st_case_174
 		case 175:
-			goto stCase175
+			goto st_case_175
 		case 176:
-			goto stCase176
+			goto st_case_176
 		case 177:
-			goto stCase177
+			goto st_case_177
 		case 178:
-			goto stCase178
+			goto st_case_178
 		case 179:
-			goto stCase179
+			goto st_case_179
 		case 180:
-			goto stCase180
+			goto st_case_180
 		case 181:
-			goto stCase181
+			goto st_case_181
 		case 182:
-			goto stCase182
+			goto st_case_182
 		case 183:
-			goto stCase183
+			goto st_case_183
 		case 184:
-			goto stCase184
+			goto st_case_184
 		case 185:
-			goto stCase185
+			goto st_case_185
 		case 186:
-			goto stCase186
+			goto st_case_186
 		case 187:
-			goto stCase187
+			goto st_case_187
 		case 188:
-			goto stCase188
+			goto st_case_188
 		case 189:
-			goto stCase189
+			goto st_case_189
 		case 190:
-			goto stCase190
+			goto st_case_190
 		case 191:
-			goto stCase191
+			goto st_case_191
 		case 192:
-			goto stCase192
+			goto st_case_192
 		case 193:
-			goto stCase193
+			goto st_case_193
 		case 194:
-			goto stCase194
+			goto st_case_194
 		case 195:
-			goto stCase195
+			goto st_case_195
 		case 196:
-			goto stCase196
+			goto st_case_196
 		case 197:
-			goto stCase197
+			goto st_case_197
 		case 198:
-			goto stCase198
+			goto st_case_198
 		case 199:
-			goto stCase199
+			goto st_case_199
 		case 200:
-			goto stCase200
+			goto st_case_200
 		case 201:
-			goto stCase201
+			goto st_case_201
 		case 202:
-			goto stCase202
+			goto st_case_202
 		case 203:
-			goto stCase203
+			goto st_case_203
 		case 204:
-			goto stCase204
+			goto st_case_204
 		case 205:
-			goto stCase205
+			goto st_case_205
 		case 206:
-			goto stCase206
+			goto st_case_206
 		case 207:
-			goto stCase207
+			goto st_case_207
 		case 208:
-			goto stCase208
+			goto st_case_208
 		case 209:
-			goto stCase209
+			goto st_case_209
 		case 210:
-			goto stCase210
+			goto st_case_210
 		case 211:
-			goto stCase211
+			goto st_case_211
 		case 212:
-			goto stCase212
+			goto st_case_212
 		case 213:
-			goto stCase213
+			goto st_case_213
 		case 214:
-			goto stCase214
+			goto st_case_214
 		case 215:
-			goto stCase215
+			goto st_case_215
 		case 216:
-			goto stCase216
+			goto st_case_216
 		case 217:
-			goto stCase217
+			goto st_case_217
 		case 218:
-			goto stCase218
+			goto st_case_218
 		case 219:
-			goto stCase219
+			goto st_case_219
 		case 220:
-			goto stCase220
+			goto st_case_220
 		case 221:
-			goto stCase221
+			goto st_case_221
 		case 222:
-			goto stCase222
+			goto st_case_222
 		case 223:
-			goto stCase223
+			goto st_case_223
 		case 224:
-			goto stCase224
+			goto st_case_224
 		case 225:
-			goto stCase225
+			goto st_case_225
 		case 226:
-			goto stCase226
+			goto st_case_226
 		case 227:
-			goto stCase227
+			goto st_case_227
 		case 228:
-			goto stCase228
+			goto st_case_228
 		case 229:
-			goto stCase229
+			goto st_case_229
 		case 230:
-			goto stCase230
+			goto st_case_230
 		case 231:
-			goto stCase231
+			goto st_case_231
 		case 232:
-			goto stCase232
+			goto st_case_232
 		case 233:
-			goto stCase233
+			goto st_case_233
 		case 234:
-			goto stCase234
+			goto st_case_234
 		case 235:
-			goto stCase235
+			goto st_case_235
 		case 236:
-			goto stCase236
+			goto st_case_236
 		case 237:
-			goto stCase237
+			goto st_case_237
 		case 238:
-			goto stCase238
+			goto st_case_238
 		case 239:
-			goto stCase239
+			goto st_case_239
 		case 240:
-			goto stCase240
+			goto st_case_240
 		case 241:
-			goto stCase241
+			goto st_case_241
 		case 242:
-			goto stCase242
+			goto st_case_242
 		case 243:
-			goto stCase243
+			goto st_case_243
 		case 244:
-			goto stCase244
+			goto st_case_244
 		case 245:
-			goto stCase245
+			goto st_case_245
 		case 246:
-			goto stCase246
+			goto st_case_246
 		case 247:
-			goto stCase247
+			goto st_case_247
 		case 248:
-			goto stCase248
+			goto st_case_248
 		case 249:
-			goto stCase249
+			goto st_case_249
 		case 250:
-			goto stCase250
+			goto st_case_250
 		case 251:
-			goto stCase251
+			goto st_case_251
 		case 252:
-			goto stCase252
+			goto st_case_252
 		case 253:
-			goto stCase253
+			goto st_case_253
 		case 254:
-			goto stCase254
+			goto st_case_254
 		case 255:
-			goto stCase255
+			goto st_case_255
 		case 256:
-			goto stCase256
+			goto st_case_256
 		case 257:
-			goto stCase257
+			goto st_case_257
 		case 258:
-			goto stCase258
+			goto st_case_258
 		case 259:
-			goto stCase259
+			goto st_case_259
 		case 260:
-			goto stCase260
+			goto st_case_260
 		case 261:
-			goto stCase261
+			goto st_case_261
 		case 262:
-			goto stCase262
+			goto st_case_262
 		case 263:
-			goto stCase263
+			goto st_case_263
 		case 264:
-			goto stCase264
+			goto st_case_264
 		case 265:
-			goto stCase265
+			goto st_case_265
 		case 266:
-			goto stCase266
+			goto st_case_266
 		case 267:
-			goto stCase267
+			goto st_case_267
 		case 268:
-			goto stCase268
+			goto st_case_268
 		case 269:
-			goto stCase269
+			goto st_case_269
 		case 270:
-			goto stCase270
+			goto st_case_270
 		case 271:
-			goto stCase271
+			goto st_case_271
 		case 272:
-			goto stCase272
+			goto st_case_272
 		case 273:
-			goto stCase273
+			goto st_case_273
 		case 274:
-			goto stCase274
+			goto st_case_274
 		case 275:
-			goto stCase275
+			goto st_case_275
 		case 276:
-			goto stCase276
+			goto st_case_276
 		case 277:
-			goto stCase277
+			goto st_case_277
 		case 278:
-			goto stCase278
+			goto st_case_278
 		case 279:
-			goto stCase279
+			goto st_case_279
 		case 280:
-			goto stCase280
+			goto st_case_280
 		case 281:
-			goto stCase281
+			goto st_case_281
 		case 282:
-			goto stCase282
+			goto st_case_282
 		case 283:
-			goto stCase283
+			goto st_case_283
 		case 284:
-			goto stCase284
+			goto st_case_284
 		case 285:
-			goto stCase285
+			goto st_case_285
 		case 286:
-			goto stCase286
+			goto st_case_286
 		case 287:
-			goto stCase287
+			goto st_case_287
 		case 288:
-			goto stCase288
+			goto st_case_288
 		case 289:
-			goto stCase289
+			goto st_case_289
 		case 290:
-			goto stCase290
+			goto st_case_290
 		case 291:
-			goto stCase291
+			goto st_case_291
 		case 292:
-			goto stCase292
+			goto st_case_292
 		case 293:
-			goto stCase293
+			goto st_case_293
 		case 294:
-			goto stCase294
+			goto st_case_294
 		case 295:
-			goto stCase295
+			goto st_case_295
 		case 296:
-			goto stCase296
+			goto st_case_296
 		case 297:
-			goto stCase297
+			goto st_case_297
 		case 298:
-			goto stCase298
+			goto st_case_298
 		case 299:
-			goto stCase299
+			goto st_case_299
 		case 300:
-			goto stCase300
+			goto st_case_300
 		case 301:
-			goto stCase301
+			goto st_case_301
 		case 302:
-			goto stCase302
+			goto st_case_302
 		case 303:
-			goto stCase303
+			goto st_case_303
 		case 304:
-			goto stCase304
+			goto st_case_304
 		case 305:
-			goto stCase305
+			goto st_case_305
 		case 306:
-			goto stCase306
+			goto st_case_306
 		case 307:
-			goto stCase307
+			goto st_case_307
 		case 308:
-			goto stCase308
+			goto st_case_308
 		case 309:
-			goto stCase309
+			goto st_case_309
 		case 310:
-			goto stCase310
+			goto st_case_310
 		case 311:
-			goto stCase311
+			goto st_case_311
 		case 312:
-			goto stCase312
+			goto st_case_312
 		case 313:
-			goto stCase313
+			goto st_case_313
 		case 314:
-			goto stCase314
+			goto st_case_314
 		case 315:
-			goto stCase315
+			goto st_case_315
 		case 316:
-			goto stCase316
+			goto st_case_316
 		case 46:
-			goto stCase46
+			goto st_case_46
 		case 317:
-			goto stCase317
+			goto st_case_317
 		case 318:
-			goto stCase318
+			goto st_case_318
 		case 319:
-			goto stCase319
+			goto st_case_319
 		case 320:
-			goto stCase320
+			goto st_case_320
 		case 321:
-			goto stCase321
+			goto st_case_321
 		case 322:
-			goto stCase322
+			goto st_case_322
 		case 323:
-			goto stCase323
+			goto st_case_323
 		case 324:
-			goto stCase324
+			goto st_case_324
 		case 325:
-			goto stCase325
+			goto st_case_325
 		case 326:
-			goto stCase326
+			goto st_case_326
 		case 327:
-			goto stCase327
+			goto st_case_327
 		case 328:
-			goto stCase328
+			goto st_case_328
 		case 329:
-			goto stCase329
+			goto st_case_329
 		case 330:
-			goto stCase330
+			goto st_case_330
 		case 331:
-			goto stCase331
+			goto st_case_331
 		case 332:
-			goto stCase332
+			goto st_case_332
 		case 333:
-			goto stCase333
+			goto st_case_333
 		case 334:
-			goto stCase334
+			goto st_case_334
 		case 335:
-			goto stCase335
+			goto st_case_335
 		case 336:
-			goto stCase336
+			goto st_case_336
 		case 337:
-			goto stCase337
+			goto st_case_337
 		case 338:
-			goto stCase338
+			goto st_case_338
 		case 339:
-			goto stCase339
+			goto st_case_339
 		case 340:
-			goto stCase340
+			goto st_case_340
 		case 341:
-			goto stCase341
+			goto st_case_341
 		case 342:
-			goto stCase342
+			goto st_case_342
 		case 343:
-			goto stCase343
+			goto st_case_343
 		case 344:
-			goto stCase344
+			goto st_case_344
 		case 345:
-			goto stCase345
+			goto st_case_345
 		case 346:
-			goto stCase346
+			goto st_case_346
 		case 347:
-			goto stCase347
+			goto st_case_347
 		case 348:
-			goto stCase348
+			goto st_case_348
 		case 349:
-			goto stCase349
+			goto st_case_349
 		case 350:
-			goto stCase350
+			goto st_case_350
 		case 351:
-			goto stCase351
+			goto st_case_351
 		case 352:
-			goto stCase352
+			goto st_case_352
 		case 353:
-			goto stCase353
+			goto st_case_353
 		case 354:
-			goto stCase354
+			goto st_case_354
 		case 355:
-			goto stCase355
+			goto st_case_355
 		case 356:
-			goto stCase356
+			goto st_case_356
 		case 357:
-			goto stCase357
+			goto st_case_357
 		case 358:
-			goto stCase358
+			goto st_case_358
 		case 359:
-			goto stCase359
+			goto st_case_359
 		case 360:
-			goto stCase360
+			goto st_case_360
 		case 361:
-			goto stCase361
+			goto st_case_361
 		case 362:
-			goto stCase362
+			goto st_case_362
 		case 363:
-			goto stCase363
+			goto st_case_363
 		case 364:
-			goto stCase364
+			goto st_case_364
 		case 47:
-			goto stCase47
+			goto st_case_47
 		case 365:
-			goto stCase365
+			goto st_case_365
 		case 366:
-			goto stCase366
+			goto st_case_366
 		case 367:
-			goto stCase367
+			goto st_case_367
 		case 368:
-			goto stCase368
+			goto st_case_368
 		case 369:
-			goto stCase369
+			goto st_case_369
 		case 370:
-			goto stCase370
+			goto st_case_370
 		case 371:
-			goto stCase371
+			goto st_case_371
 		case 372:
-			goto stCase372
+			goto st_case_372
 		case 373:
-			goto stCase373
+			goto st_case_373
 		case 374:
-			goto stCase374
+			goto st_case_374
 		case 375:
-			goto stCase375
+			goto st_case_375
 		case 376:
-			goto stCase376
+			goto st_case_376
 		case 377:
-			goto stCase377
+			goto st_case_377
 		case 378:
-			goto stCase378
+			goto st_case_378
 		case 379:
-			goto stCase379
+			goto st_case_379
 		case 380:
-			goto stCase380
+			goto st_case_380
 		case 381:
-			goto stCase381
+			goto st_case_381
 		case 382:
-			goto stCase382
+			goto st_case_382
 		case 383:
-			goto stCase383
+			goto st_case_383
 		case 384:
-			goto stCase384
+			goto st_case_384
 		case 385:
-			goto stCase385
+			goto st_case_385
 		case 386:
-			goto stCase386
+			goto st_case_386
 		case 387:
-			goto stCase387
+			goto st_case_387
 		case 388:
-			goto stCase388
+			goto st_case_388
 		case 389:
-			goto stCase389
+			goto st_case_389
 		case 390:
-			goto stCase390
+			goto st_case_390
 		case 391:
-			goto stCase391
+			goto st_case_391
 		case 392:
-			goto stCase392
+			goto st_case_392
 		case 393:
-			goto stCase393
+			goto st_case_393
 		case 394:
-			goto stCase394
+			goto st_case_394
 		case 395:
-			goto stCase395
+			goto st_case_395
 		case 396:
-			goto stCase396
+			goto st_case_396
 		case 397:
-			goto stCase397
+			goto st_case_397
 		case 398:
-			goto stCase398
+			goto st_case_398
 		case 399:
-			goto stCase399
+			goto st_case_399
 		case 400:
-			goto stCase400
+			goto st_case_400
 		case 401:
-			goto stCase401
+			goto st_case_401
 		case 402:
-			goto stCase402
+			goto st_case_402
 		case 403:
-			goto stCase403
+			goto st_case_403
 		case 404:
-			goto stCase404
+			goto st_case_404
 		case 405:
-			goto stCase405
+			goto st_case_405
 		case 406:
-			goto stCase406
+			goto st_case_406
 		case 407:
-			goto stCase407
+			goto st_case_407
 		case 408:
-			goto stCase408
+			goto st_case_408
 		case 409:
-			goto stCase409
+			goto st_case_409
 		case 410:
-			goto stCase410
+			goto st_case_410
 		case 411:
-			goto stCase411
+			goto st_case_411
 		case 412:
-			goto stCase412
+			goto st_case_412
 		case 413:
-			goto stCase413
+			goto st_case_413
 		case 414:
-			goto stCase414
+			goto st_case_414
 		case 415:
-			goto stCase415
+			goto st_case_415
 		case 416:
-			goto stCase416
+			goto st_case_416
 		case 417:
-			goto stCase417
+			goto st_case_417
 		case 418:
-			goto stCase418
+			goto st_case_418
 		case 419:
-			goto stCase419
+			goto st_case_419
 		case 420:
-			goto stCase420
+			goto st_case_420
 		case 421:
-			goto stCase421
+			goto st_case_421
 		case 422:
-			goto stCase422
+			goto st_case_422
 		case 423:
-			goto stCase423
+			goto st_case_423
 		case 424:
-			goto stCase424
+			goto st_case_424
 		case 425:
-			goto stCase425
+			goto st_case_425
 		case 426:
-			goto stCase426
+			goto st_case_426
 		case 427:
-			goto stCase427
+			goto st_case_427
 		case 428:
-			goto stCase428
+			goto st_case_428
 		case 429:
-			goto stCase429
+			goto st_case_429
 		case 430:
-			goto stCase430
+			goto st_case_430
 		case 431:
-			goto stCase431
+			goto st_case_431
 		case 432:
-			goto stCase432
+			goto st_case_432
 		case 433:
-			goto stCase433
+			goto st_case_433
 		case 434:
-			goto stCase434
+			goto st_case_434
 		case 435:
-			goto stCase435
+			goto st_case_435
 		case 436:
-			goto stCase436
+			goto st_case_436
 		case 437:
-			goto stCase437
+			goto st_case_437
 		case 438:
-			goto stCase438
+			goto st_case_438
 		case 439:
-			goto stCase439
+			goto st_case_439
 		case 440:
-			goto stCase440
+			goto st_case_440
 		case 441:
-			goto stCase441
+			goto st_case_441
 		case 442:
-			goto stCase442
+			goto st_case_442
 		case 443:
-			goto stCase443
+			goto st_case_443
 		case 444:
-			goto stCase444
+			goto st_case_444
 		case 445:
-			goto stCase445
+			goto st_case_445
 		case 446:
-			goto stCase446
+			goto st_case_446
 		case 447:
-			goto stCase447
+			goto st_case_447
 		case 448:
-			goto stCase448
+			goto st_case_448
 		case 449:
-			goto stCase449
+			goto st_case_449
 		case 450:
-			goto stCase450
+			goto st_case_450
 		case 451:
-			goto stCase451
+			goto st_case_451
 		case 452:
-			goto stCase452
+			goto st_case_452
 		case 453:
-			goto stCase453
+			goto st_case_453
 		case 454:
-			goto stCase454
+			goto st_case_454
 		case 455:
-			goto stCase455
+			goto st_case_455
 		case 456:
-			goto stCase456
+			goto st_case_456
 		case 457:
-			goto stCase457
+			goto st_case_457
 		case 458:
-			goto stCase458
+			goto st_case_458
 		case 459:
-			goto stCase459
+			goto st_case_459
 		case 460:
-			goto stCase460
+			goto st_case_460
 		case 461:
-			goto stCase461
+			goto st_case_461
 		case 462:
-			goto stCase462
+			goto st_case_462
 		case 463:
-			goto stCase463
+			goto st_case_463
 		case 464:
-			goto stCase464
+			goto st_case_464
 		case 465:
-			goto stCase465
+			goto st_case_465
 		case 466:
-			goto stCase466
+			goto st_case_466
 		case 467:
-			goto stCase467
+			goto st_case_467
 		case 468:
-			goto stCase468
+			goto st_case_468
 		case 469:
-			goto stCase469
+			goto st_case_469
 		case 470:
-			goto stCase470
+			goto st_case_470
 		case 471:
-			goto stCase471
+			goto st_case_471
 		case 472:
-			goto stCase472
+			goto st_case_472
 		case 473:
-			goto stCase473
+			goto st_case_473
 		case 474:
-			goto stCase474
+			goto st_case_474
 		case 475:
-			goto stCase475
+			goto st_case_475
 		case 476:
-			goto stCase476
+			goto st_case_476
 		case 477:
-			goto stCase477
+			goto st_case_477
 		case 478:
-			goto stCase478
+			goto st_case_478
 		case 479:
-			goto stCase479
+			goto st_case_479
 		case 480:
-			goto stCase480
+			goto st_case_480
 		case 481:
-			goto stCase481
+			goto st_case_481
 		case 482:
-			goto stCase482
+			goto st_case_482
 		case 483:
-			goto stCase483
+			goto st_case_483
 		case 484:
-			goto stCase484
+			goto st_case_484
 		case 485:
-			goto stCase485
+			goto st_case_485
 		case 486:
-			goto stCase486
+			goto st_case_486
 		case 487:
-			goto stCase487
+			goto st_case_487
 		case 488:
-			goto stCase488
+			goto st_case_488
 		case 489:
-			goto stCase489
+			goto st_case_489
 		case 490:
-			goto stCase490
+			goto st_case_490
 		case 491:
-			goto stCase491
+			goto st_case_491
 		case 492:
-			goto stCase492
+			goto st_case_492
 		case 48:
-			goto stCase48
+			goto st_case_48
 		case 493:
-			goto stCase493
+			goto st_case_493
 		case 494:
-			goto stCase494
+			goto st_case_494
 		case 495:
-			goto stCase495
+			goto st_case_495
 		case 496:
-			goto stCase496
+			goto st_case_496
 		case 497:
-			goto stCase497
+			goto st_case_497
 		case 498:
-			goto stCase498
+			goto st_case_498
 		case 499:
-			goto stCase499
+			goto st_case_499
 		case 500:
-			goto stCase500
+			goto st_case_500
 		case 501:
-			goto stCase501
+			goto st_case_501
 		case 502:
-			goto stCase502
+			goto st_case_502
 		case 503:
-			goto stCase503
+			goto st_case_503
 		case 504:
-			goto stCase504
+			goto st_case_504
 		case 505:
-			goto stCase505
+			goto st_case_505
 		case 506:
-			goto stCase506
+			goto st_case_506
 		case 507:
-			goto stCase507
+			goto st_case_507
 		case 508:
-			goto stCase508
+			goto st_case_508
 		case 509:
-			goto stCase509
+			goto st_case_509
 		case 510:
-			goto stCase510
+			goto st_case_510
 		case 511:
-			goto stCase511
+			goto st_case_511
 		case 512:
-			goto stCase512
+			goto st_case_512
 		case 513:
-			goto stCase513
+			goto st_case_513
 		case 514:
-			goto stCase514
+			goto st_case_514
 		case 515:
-			goto stCase515
+			goto st_case_515
 		case 516:
-			goto stCase516
+			goto st_case_516
 		case 517:
-			goto stCase517
+			goto st_case_517
 		case 518:
-			goto stCase518
+			goto st_case_518
 		case 519:
-			goto stCase519
+			goto st_case_519
 		case 520:
-			goto stCase520
+			goto st_case_520
 		case 521:
-			goto stCase521
+			goto st_case_521
 		case 522:
-			goto stCase522
+			goto st_case_522
 		case 523:
-			goto stCase523
+			goto st_case_523
 		case 524:
-			goto stCase524
+			goto st_case_524
 		case 49:
-			goto stCase49
+			goto st_case_49
 		case 525:
-			goto stCase525
+			goto st_case_525
 		case 526:
-			goto stCase526
+			goto st_case_526
 		case 527:
-			goto stCase527
+			goto st_case_527
 		case 528:
-			goto stCase528
+			goto st_case_528
 		case 529:
-			goto stCase529
+			goto st_case_529
 		case 530:
-			goto stCase530
+			goto st_case_530
 		case 531:
-			goto stCase531
+			goto st_case_531
 		case 532:
-			goto stCase532
+			goto st_case_532
 		case 533:
-			goto stCase533
+			goto st_case_533
 		case 534:
-			goto stCase534
+			goto st_case_534
 		case 535:
-			goto stCase535
+			goto st_case_535
 		case 536:
-			goto stCase536
+			goto st_case_536
 		case 537:
-			goto stCase537
+			goto st_case_537
 		case 538:
-			goto stCase538
+			goto st_case_538
 		case 539:
-			goto stCase539
+			goto st_case_539
 		case 540:
-			goto stCase540
+			goto st_case_540
 		case 541:
-			goto stCase541
+			goto st_case_541
 		case 542:
-			goto stCase542
+			goto st_case_542
 		case 543:
-			goto stCase543
+			goto st_case_543
 		case 544:
-			goto stCase544
+			goto st_case_544
 		case 545:
-			goto stCase545
+			goto st_case_545
 		case 546:
-			goto stCase546
+			goto st_case_546
 		case 547:
-			goto stCase547
+			goto st_case_547
 		case 548:
-			goto stCase548
+			goto st_case_548
 		case 549:
-			goto stCase549
+			goto st_case_549
 		case 550:
-			goto stCase550
+			goto st_case_550
 		case 551:
-			goto stCase551
+			goto st_case_551
 		case 552:
-			goto stCase552
+			goto st_case_552
 		case 553:
-			goto stCase553
+			goto st_case_553
 		case 554:
-			goto stCase554
+			goto st_case_554
 		case 555:
-			goto stCase555
+			goto st_case_555
 		case 556:
-			goto stCase556
+			goto st_case_556
 		case 50:
-			goto stCase50
+			goto st_case_50
 		case 557:
-			goto stCase557
+			goto st_case_557
 		case 558:
-			goto stCase558
+			goto st_case_558
 		case 559:
-			goto stCase559
+			goto st_case_559
 		case 560:
-			goto stCase560
+			goto st_case_560
 		case 561:
-			goto stCase561
+			goto st_case_561
 		case 562:
-			goto stCase562
+			goto st_case_562
 		case 563:
-			goto stCase563
+			goto st_case_563
 		case 564:
-			goto stCase564
+			goto st_case_564
 		case 565:
-			goto stCase565
+			goto st_case_565
 		case 566:
-			goto stCase566
+			goto st_case_566
 		case 567:
-			goto stCase567
+			goto st_case_567
 		case 568:
-			goto stCase568
+			goto st_case_568
 		case 569:
-			goto stCase569
+			goto st_case_569
 		case 570:
-			goto stCase570
+			goto st_case_570
 		case 571:
-			goto stCase571
+			goto st_case_571
 		case 572:
-			goto stCase572
+			goto st_case_572
 		case 573:
-			goto stCase573
+			goto st_case_573
 		case 574:
-			goto stCase574
+			goto st_case_574
 		case 575:
-			goto stCase575
+			goto st_case_575
 		case 576:
-			goto stCase576
+			goto st_case_576
 		case 577:
-			goto stCase577
+			goto st_case_577
 		case 578:
-			goto stCase578
+			goto st_case_578
 		case 579:
-			goto stCase579
+			goto st_case_579
 		case 580:
-			goto stCase580
+			goto st_case_580
 		case 581:
-			goto stCase581
+			goto st_case_581
 		case 582:
-			goto stCase582
+			goto st_case_582
 		case 583:
-			goto stCase583
+			goto st_case_583
 		case 584:
-			goto stCase584
+			goto st_case_584
 		case 585:
-			goto stCase585
+			goto st_case_585
 		case 586:
-			goto stCase586
+			goto st_case_586
 		case 587:
-			goto stCase587
+			goto st_case_587
 		case 588:
-			goto stCase588
+			goto st_case_588
 		case 589:
-			goto stCase589
+			goto st_case_589
 		case 590:
-			goto stCase590
+			goto st_case_590
 		case 51:
-			goto stCase51
+			goto st_case_51
 		case 52:
-			goto stCase52
+			goto st_case_52
 		case 53:
-			goto stCase53
+			goto st_case_53
 		case 54:
-			goto stCase54
+			goto st_case_54
 		case 55:
-			goto stCase55
+			goto st_case_55
 		case 56:
-			goto stCase56
+			goto st_case_56
 		case 57:
-			goto stCase57
+			goto st_case_57
 		case 58:
-			goto stCase58
+			goto st_case_58
 		}
-		goto stOut
-	stCase59:
+		goto st_out
+	st_case_59:
 		switch data[p] {
 		case 224:
 			goto tr52
@@ -1301,9 +1301,9 @@ func (sm *SyslogMessage) set(from entrypoint, value string) *SyslogMessage {
 		goto st60
 	st60:
 		if p++; p == pe {
-			goto _testEof60
+			goto _test_eof60
 		}
-	stCase60:
+	st_case_60:
 		switch data[p] {
 		case 224:
 			goto st2
@@ -1337,7 +1337,7 @@ func (sm *SyslogMessage) set(from entrypoint, value string) *SyslogMessage {
 			goto st3
 		}
 		goto st60
-	stCase0:
+	st_case_0:
 	st0:
 		cs = 0
 		goto _out
@@ -1348,9 +1348,9 @@ func (sm *SyslogMessage) set(from entrypoint, value string) *SyslogMessage {
 		goto st1
 	st1:
 		if p++; p == pe {
-			goto _testEof1
+			goto _test_eof1
 		}
-	stCase1:
+	st_case_1:
 		if 128 <= data[p] && data[p] <= 191 {
 			goto st60
 		}
@@ -1362,9 +1362,9 @@ func (sm *SyslogMessage) set(from entrypoint, value string) *SyslogMessage {
 		goto st2
 	st2:
 		if p++; p == pe {
-			goto _testEof2
+			goto _test_eof2
 		}
-	stCase2:
+	st_case_2:
 		if 160 <= data[p] && data[p] <= 191 {
 			goto st1
 		}
@@ -1376,9 +1376,9 @@ func (sm *SyslogMessage) set(from entrypoint, value string) *SyslogMessage {
 		goto st3
 	st3:
 		if p++; p == pe {
-			goto _testEof3
+			goto _test_eof3
 		}
-	stCase3:
+	st_case_3:
 		if 128 <= data[p] && data[p] <= 191 {
 			goto st1
 		}
@@ -1390,9 +1390,9 @@ func (sm *SyslogMessage) set(from entrypoint, value string) *SyslogMessage {
 		goto st4
 	st4:
 		if p++; p == pe {
-			goto _testEof4
+			goto _test_eof4
 		}
-	stCase4:
+	st_case_4:
 		if 128 <= data[p] && data[p] <= 159 {
 			goto st1
 		}
@@ -1404,9 +1404,9 @@ func (sm *SyslogMessage) set(from entrypoint, value string) *SyslogMessage {
 		goto st5
 	st5:
 		if p++; p == pe {
-			goto _testEof5
+			goto _test_eof5
 		}
-	stCase5:
+	st_case_5:
 		if 144 <= data[p] && data[p] <= 191 {
 			goto st3
 		}
@@ -1418,9 +1418,9 @@ func (sm *SyslogMessage) set(from entrypoint, value string) *SyslogMessage {
 		goto st6
 	st6:
 		if p++; p == pe {
-			goto _testEof6
+			goto _test_eof6
 		}
-	stCase6:
+	st_case_6:
 		if 128 <= data[p] && data[p] <= 191 {
 			goto st3
 		}
@@ -1432,14 +1432,14 @@ func (sm *SyslogMessage) set(from entrypoint, value string) *SyslogMessage {
 		goto st7
 	st7:
 		if p++; p == pe {
-			goto _testEof7
+			goto _test_eof7
 		}
-	stCase7:
+	st_case_7:
 		if 128 <= data[p] && data[p] <= 143 {
 			goto st3
 		}
 		goto st0
-	stCase8:
+	st_case_8:
 		if 48 <= data[p] && data[p] <= 57 {
 			goto tr4
 		}
@@ -1451,45 +1451,45 @@ func (sm *SyslogMessage) set(from entrypoint, value string) *SyslogMessage {
 		goto st9
 	st9:
 		if p++; p == pe {
-			goto _testEof9
+			goto _test_eof9
 		}
-	stCase9:
+	st_case_9:
 		if 48 <= data[p] && data[p] <= 57 {
 			goto st10
 		}
 		goto st0
 	st10:
 		if p++; p == pe {
-			goto _testEof10
+			goto _test_eof10
 		}
-	stCase10:
+	st_case_10:
 		if 48 <= data[p] && data[p] <= 57 {
 			goto st11
 		}
 		goto st0
 	st11:
 		if p++; p == pe {
-			goto _testEof11
+			goto _test_eof11
 		}
-	stCase11:
+	st_case_11:
 		if 48 <= data[p] && data[p] <= 57 {
 			goto st12
 		}
 		goto st0
 	st12:
 		if p++; p == pe {
-			goto _testEof12
+			goto _test_eof12
 		}
-	stCase12:
+	st_case_12:
 		if data[p] == 45 {
 			goto st13
 		}
 		goto st0
 	st13:
 		if p++; p == pe {
-			goto _testEof13
+			goto _test_eof13
 		}
-	stCase13:
+	st_case_13:
 		switch data[p] {
 		case 48:
 			goto st14
@@ -1499,27 +1499,27 @@ func (sm *SyslogMessage) set(from entrypoint, value string) *SyslogMessage {
 		goto st0
 	st14:
 		if p++; p == pe {
-			goto _testEof14
+			goto _test_eof14
 		}
-	stCase14:
+	st_case_14:
 		if 49 <= data[p] && data[p] <= 57 {
 			goto st15
 		}
 		goto st0
 	st15:
 		if p++; p == pe {
-			goto _testEof15
+			goto _test_eof15
 		}
-	stCase15:
+	st_case_15:
 		if data[p] == 45 {
 			goto st16
 		}
 		goto st0
 	st16:
 		if p++; p == pe {
-			goto _testEof16
+			goto _test_eof16
 		}
-	stCase16:
+	st_case_16:
 		switch data[p] {
 		case 48:
 			goto st17
@@ -1532,27 +1532,27 @@ func (sm *SyslogMessage) set(from entrypoint, value string) *SyslogMessage {
 		goto st0
 	st17:
 		if p++; p == pe {
-			goto _testEof17
+			goto _test_eof17
 		}
-	stCase17:
+	st_case_17:
 		if 49 <= data[p] && data[p] <= 57 {
 			goto st18
 		}
 		goto st0
 	st18:
 		if p++; p == pe {
-			goto _testEof18
+			goto _test_eof18
 		}
-	stCase18:
+	st_case_18:
 		if data[p] == 84 {
 			goto st19
 		}
 		goto st0
 	st19:
 		if p++; p == pe {
-			goto _testEof19
+			goto _test_eof19
 		}
-	stCase19:
+	st_case_19:
 		if data[p] == 50 {
 			goto st41
 		}
@@ -1562,72 +1562,72 @@ func (sm *SyslogMessage) set(from entrypoint, value string) *SyslogMessage {
 		goto st0
 	st20:
 		if p++; p == pe {
-			goto _testEof20
+			goto _test_eof20
 		}
-	stCase20:
+	st_case_20:
 		if 48 <= data[p] && data[p] <= 57 {
 			goto st21
 		}
 		goto st0
 	st21:
 		if p++; p == pe {
-			goto _testEof21
+			goto _test_eof21
 		}
-	stCase21:
+	st_case_21:
 		if data[p] == 58 {
 			goto st22
 		}
 		goto st0
 	st22:
 		if p++; p == pe {
-			goto _testEof22
+			goto _test_eof22
 		}
-	stCase22:
+	st_case_22:
 		if 48 <= data[p] && data[p] <= 53 {
 			goto st23
 		}
 		goto st0
 	st23:
 		if p++; p == pe {
-			goto _testEof23
+			goto _test_eof23
 		}
-	stCase23:
+	st_case_23:
 		if 48 <= data[p] && data[p] <= 57 {
 			goto st24
 		}
 		goto st0
 	st24:
 		if p++; p == pe {
-			goto _testEof24
+			goto _test_eof24
 		}
-	stCase24:
+	st_case_24:
 		if data[p] == 58 {
 			goto st25
 		}
 		goto st0
 	st25:
 		if p++; p == pe {
-			goto _testEof25
+			goto _test_eof25
 		}
-	stCase25:
+	st_case_25:
 		if 48 <= data[p] && data[p] <= 53 {
 			goto st26
 		}
 		goto st0
 	st26:
 		if p++; p == pe {
-			goto _testEof26
+			goto _test_eof26
 		}
-	stCase26:
+	st_case_26:
 		if 48 <= data[p] && data[p] <= 57 {
 			goto st27
 		}
 		goto st0
 	st27:
 		if p++; p == pe {
-			goto _testEof27
+			goto _test_eof27
 		}
-	stCase27:
+	st_case_27:
 		switch data[p] {
 		case 43:
 			goto st28
@@ -1641,9 +1641,9 @@ func (sm *SyslogMessage) set(from entrypoint, value string) *SyslogMessage {
 		goto st0
 	st28:
 		if p++; p == pe {
-			goto _testEof28
+			goto _test_eof28
 		}
-	stCase28:
+	st_case_28:
 		if data[p] == 50 {
 			goto st33
 		}
@@ -1653,69 +1653,69 @@ func (sm *SyslogMessage) set(from entrypoint, value string) *SyslogMessage {
 		goto st0
 	st29:
 		if p++; p == pe {
-			goto _testEof29
+			goto _test_eof29
 		}
-	stCase29:
+	st_case_29:
 		if 48 <= data[p] && data[p] <= 57 {
 			goto st30
 		}
 		goto st0
 	st30:
 		if p++; p == pe {
-			goto _testEof30
+			goto _test_eof30
 		}
-	stCase30:
+	st_case_30:
 		if data[p] == 58 {
 			goto st31
 		}
 		goto st0
 	st31:
 		if p++; p == pe {
-			goto _testEof31
+			goto _test_eof31
 		}
-	stCase31:
+	st_case_31:
 		if 48 <= data[p] && data[p] <= 53 {
 			goto st32
 		}
 		goto st0
 	st32:
 		if p++; p == pe {
-			goto _testEof32
+			goto _test_eof32
 		}
-	stCase32:
+	st_case_32:
 		if 48 <= data[p] && data[p] <= 57 {
 			goto st61
 		}
 		goto st0
 	st61:
 		if p++; p == pe {
-			goto _testEof61
+			goto _test_eof61
 		}
-	stCase61:
+	st_case_61:
 		goto st0
 	st33:
 		if p++; p == pe {
-			goto _testEof33
+			goto _test_eof33
 		}
-	stCase33:
+	st_case_33:
 		if 48 <= data[p] && data[p] <= 51 {
 			goto st30
 		}
 		goto st0
 	st34:
 		if p++; p == pe {
-			goto _testEof34
+			goto _test_eof34
 		}
-	stCase34:
+	st_case_34:
 		if 48 <= data[p] && data[p] <= 57 {
 			goto st35
 		}
 		goto st0
 	st35:
 		if p++; p == pe {
-			goto _testEof35
+			goto _test_eof35
 		}
-	stCase35:
+	st_case_35:
 		switch data[p] {
 		case 43:
 			goto st28
@@ -1730,9 +1730,9 @@ func (sm *SyslogMessage) set(from entrypoint, value string) *SyslogMessage {
 		goto st0
 	st36:
 		if p++; p == pe {
-			goto _testEof36
+			goto _test_eof36
 		}
-	stCase36:
+	st_case_36:
 		switch data[p] {
 		case 43:
 			goto st28
@@ -1747,9 +1747,9 @@ func (sm *SyslogMessage) set(from entrypoint, value string) *SyslogMessage {
 		goto st0
 	st37:
 		if p++; p == pe {
-			goto _testEof37
+			goto _test_eof37
 		}
-	stCase37:
+	st_case_37:
 		switch data[p] {
 		case 43:
 			goto st28
@@ -1764,9 +1764,9 @@ func (sm *SyslogMessage) set(from entrypoint, value string) *SyslogMessage {
 		goto st0
 	st38:
 		if p++; p == pe {
-			goto _testEof38
+			goto _test_eof38
 		}
-	stCase38:
+	st_case_38:
 		switch data[p] {
 		case 43:
 			goto st28
@@ -1781,9 +1781,9 @@ func (sm *SyslogMessage) set(from entrypoint, value string) *SyslogMessage {
 		goto st0
 	st39:
 		if p++; p == pe {
-			goto _testEof39
+			goto _test_eof39
 		}
-	stCase39:
+	st_case_39:
 		switch data[p] {
 		case 43:
 			goto st28
@@ -1798,9 +1798,9 @@ func (sm *SyslogMessage) set(from entrypoint, value string) *SyslogMessage {
 		goto st0
 	st40:
 		if p++; p == pe {
-			goto _testEof40
+			goto _test_eof40
 		}
-	stCase40:
+	st_case_40:
 		switch data[p] {
 		case 43:
 			goto st28
@@ -1812,41 +1812,41 @@ func (sm *SyslogMessage) set(from entrypoint, value string) *SyslogMessage {
 		goto st0
 	st41:
 		if p++; p == pe {
-			goto _testEof41
+			goto _test_eof41
 		}
-	stCase41:
+	st_case_41:
 		if 48 <= data[p] && data[p] <= 51 {
 			goto st21
 		}
 		goto st0
 	st42:
 		if p++; p == pe {
-			goto _testEof42
+			goto _test_eof42
 		}
-	stCase42:
+	st_case_42:
 		if 48 <= data[p] && data[p] <= 57 {
 			goto st18
 		}
 		goto st0
 	st43:
 		if p++; p == pe {
-			goto _testEof43
+			goto _test_eof43
 		}
-	stCase43:
+	st_case_43:
 		if 48 <= data[p] && data[p] <= 49 {
 			goto st18
 		}
 		goto st0
 	st44:
 		if p++; p == pe {
-			goto _testEof44
+			goto _test_eof44
 		}
-	stCase44:
+	st_case_44:
 		if 48 <= data[p] && data[p] <= 50 {
 			goto st15
 		}
 		goto st0
-	stCase45:
+	st_case_45:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto tr41
 		}
@@ -1858,2297 +1858,2297 @@ func (sm *SyslogMessage) set(from entrypoint, value string) *SyslogMessage {
 		goto st62
 	st62:
 		if p++; p == pe {
-			goto _testEof62
+			goto _test_eof62
 		}
-	stCase62:
+	st_case_62:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st63
 		}
 		goto st0
 	st63:
 		if p++; p == pe {
-			goto _testEof63
+			goto _test_eof63
 		}
-	stCase63:
+	st_case_63:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st64
 		}
 		goto st0
 	st64:
 		if p++; p == pe {
-			goto _testEof64
+			goto _test_eof64
 		}
-	stCase64:
+	st_case_64:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st65
 		}
 		goto st0
 	st65:
 		if p++; p == pe {
-			goto _testEof65
+			goto _test_eof65
 		}
-	stCase65:
+	st_case_65:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st66
 		}
 		goto st0
 	st66:
 		if p++; p == pe {
-			goto _testEof66
+			goto _test_eof66
 		}
-	stCase66:
+	st_case_66:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st67
 		}
 		goto st0
 	st67:
 		if p++; p == pe {
-			goto _testEof67
+			goto _test_eof67
 		}
-	stCase67:
+	st_case_67:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st68
 		}
 		goto st0
 	st68:
 		if p++; p == pe {
-			goto _testEof68
+			goto _test_eof68
 		}
-	stCase68:
+	st_case_68:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st69
 		}
 		goto st0
 	st69:
 		if p++; p == pe {
-			goto _testEof69
+			goto _test_eof69
 		}
-	stCase69:
+	st_case_69:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st70
 		}
 		goto st0
 	st70:
 		if p++; p == pe {
-			goto _testEof70
+			goto _test_eof70
 		}
-	stCase70:
+	st_case_70:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st71
 		}
 		goto st0
 	st71:
 		if p++; p == pe {
-			goto _testEof71
+			goto _test_eof71
 		}
-	stCase71:
+	st_case_71:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st72
 		}
 		goto st0
 	st72:
 		if p++; p == pe {
-			goto _testEof72
+			goto _test_eof72
 		}
-	stCase72:
+	st_case_72:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st73
 		}
 		goto st0
 	st73:
 		if p++; p == pe {
-			goto _testEof73
+			goto _test_eof73
 		}
-	stCase73:
+	st_case_73:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st74
 		}
 		goto st0
 	st74:
 		if p++; p == pe {
-			goto _testEof74
+			goto _test_eof74
 		}
-	stCase74:
+	st_case_74:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st75
 		}
 		goto st0
 	st75:
 		if p++; p == pe {
-			goto _testEof75
+			goto _test_eof75
 		}
-	stCase75:
+	st_case_75:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st76
 		}
 		goto st0
 	st76:
 		if p++; p == pe {
-			goto _testEof76
+			goto _test_eof76
 		}
-	stCase76:
+	st_case_76:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st77
 		}
 		goto st0
 	st77:
 		if p++; p == pe {
-			goto _testEof77
+			goto _test_eof77
 		}
-	stCase77:
+	st_case_77:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st78
 		}
 		goto st0
 	st78:
 		if p++; p == pe {
-			goto _testEof78
+			goto _test_eof78
 		}
-	stCase78:
+	st_case_78:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st79
 		}
 		goto st0
 	st79:
 		if p++; p == pe {
-			goto _testEof79
+			goto _test_eof79
 		}
-	stCase79:
+	st_case_79:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st80
 		}
 		goto st0
 	st80:
 		if p++; p == pe {
-			goto _testEof80
+			goto _test_eof80
 		}
-	stCase80:
+	st_case_80:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st81
 		}
 		goto st0
 	st81:
 		if p++; p == pe {
-			goto _testEof81
+			goto _test_eof81
 		}
-	stCase81:
+	st_case_81:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st82
 		}
 		goto st0
 	st82:
 		if p++; p == pe {
-			goto _testEof82
+			goto _test_eof82
 		}
-	stCase82:
+	st_case_82:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st83
 		}
 		goto st0
 	st83:
 		if p++; p == pe {
-			goto _testEof83
+			goto _test_eof83
 		}
-	stCase83:
+	st_case_83:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st84
 		}
 		goto st0
 	st84:
 		if p++; p == pe {
-			goto _testEof84
+			goto _test_eof84
 		}
-	stCase84:
+	st_case_84:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st85
 		}
 		goto st0
 	st85:
 		if p++; p == pe {
-			goto _testEof85
+			goto _test_eof85
 		}
-	stCase85:
+	st_case_85:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st86
 		}
 		goto st0
 	st86:
 		if p++; p == pe {
-			goto _testEof86
+			goto _test_eof86
 		}
-	stCase86:
+	st_case_86:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st87
 		}
 		goto st0
 	st87:
 		if p++; p == pe {
-			goto _testEof87
+			goto _test_eof87
 		}
-	stCase87:
+	st_case_87:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st88
 		}
 		goto st0
 	st88:
 		if p++; p == pe {
-			goto _testEof88
+			goto _test_eof88
 		}
-	stCase88:
+	st_case_88:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st89
 		}
 		goto st0
 	st89:
 		if p++; p == pe {
-			goto _testEof89
+			goto _test_eof89
 		}
-	stCase89:
+	st_case_89:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st90
 		}
 		goto st0
 	st90:
 		if p++; p == pe {
-			goto _testEof90
+			goto _test_eof90
 		}
-	stCase90:
+	st_case_90:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st91
 		}
 		goto st0
 	st91:
 		if p++; p == pe {
-			goto _testEof91
+			goto _test_eof91
 		}
-	stCase91:
+	st_case_91:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st92
 		}
 		goto st0
 	st92:
 		if p++; p == pe {
-			goto _testEof92
+			goto _test_eof92
 		}
-	stCase92:
+	st_case_92:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st93
 		}
 		goto st0
 	st93:
 		if p++; p == pe {
-			goto _testEof93
+			goto _test_eof93
 		}
-	stCase93:
+	st_case_93:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st94
 		}
 		goto st0
 	st94:
 		if p++; p == pe {
-			goto _testEof94
+			goto _test_eof94
 		}
-	stCase94:
+	st_case_94:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st95
 		}
 		goto st0
 	st95:
 		if p++; p == pe {
-			goto _testEof95
+			goto _test_eof95
 		}
-	stCase95:
+	st_case_95:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st96
 		}
 		goto st0
 	st96:
 		if p++; p == pe {
-			goto _testEof96
+			goto _test_eof96
 		}
-	stCase96:
+	st_case_96:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st97
 		}
 		goto st0
 	st97:
 		if p++; p == pe {
-			goto _testEof97
+			goto _test_eof97
 		}
-	stCase97:
+	st_case_97:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st98
 		}
 		goto st0
 	st98:
 		if p++; p == pe {
-			goto _testEof98
+			goto _test_eof98
 		}
-	stCase98:
+	st_case_98:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st99
 		}
 		goto st0
 	st99:
 		if p++; p == pe {
-			goto _testEof99
+			goto _test_eof99
 		}
-	stCase99:
+	st_case_99:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st100
 		}
 		goto st0
 	st100:
 		if p++; p == pe {
-			goto _testEof100
+			goto _test_eof100
 		}
-	stCase100:
+	st_case_100:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st101
 		}
 		goto st0
 	st101:
 		if p++; p == pe {
-			goto _testEof101
+			goto _test_eof101
 		}
-	stCase101:
+	st_case_101:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st102
 		}
 		goto st0
 	st102:
 		if p++; p == pe {
-			goto _testEof102
+			goto _test_eof102
 		}
-	stCase102:
+	st_case_102:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st103
 		}
 		goto st0
 	st103:
 		if p++; p == pe {
-			goto _testEof103
+			goto _test_eof103
 		}
-	stCase103:
+	st_case_103:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st104
 		}
 		goto st0
 	st104:
 		if p++; p == pe {
-			goto _testEof104
+			goto _test_eof104
 		}
-	stCase104:
+	st_case_104:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st105
 		}
 		goto st0
 	st105:
 		if p++; p == pe {
-			goto _testEof105
+			goto _test_eof105
 		}
-	stCase105:
+	st_case_105:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st106
 		}
 		goto st0
 	st106:
 		if p++; p == pe {
-			goto _testEof106
+			goto _test_eof106
 		}
-	stCase106:
+	st_case_106:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st107
 		}
 		goto st0
 	st107:
 		if p++; p == pe {
-			goto _testEof107
+			goto _test_eof107
 		}
-	stCase107:
+	st_case_107:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st108
 		}
 		goto st0
 	st108:
 		if p++; p == pe {
-			goto _testEof108
+			goto _test_eof108
 		}
-	stCase108:
+	st_case_108:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st109
 		}
 		goto st0
 	st109:
 		if p++; p == pe {
-			goto _testEof109
+			goto _test_eof109
 		}
-	stCase109:
+	st_case_109:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st110
 		}
 		goto st0
 	st110:
 		if p++; p == pe {
-			goto _testEof110
+			goto _test_eof110
 		}
-	stCase110:
+	st_case_110:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st111
 		}
 		goto st0
 	st111:
 		if p++; p == pe {
-			goto _testEof111
+			goto _test_eof111
 		}
-	stCase111:
+	st_case_111:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st112
 		}
 		goto st0
 	st112:
 		if p++; p == pe {
-			goto _testEof112
+			goto _test_eof112
 		}
-	stCase112:
+	st_case_112:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st113
 		}
 		goto st0
 	st113:
 		if p++; p == pe {
-			goto _testEof113
+			goto _test_eof113
 		}
-	stCase113:
+	st_case_113:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st114
 		}
 		goto st0
 	st114:
 		if p++; p == pe {
-			goto _testEof114
+			goto _test_eof114
 		}
-	stCase114:
+	st_case_114:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st115
 		}
 		goto st0
 	st115:
 		if p++; p == pe {
-			goto _testEof115
+			goto _test_eof115
 		}
-	stCase115:
+	st_case_115:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st116
 		}
 		goto st0
 	st116:
 		if p++; p == pe {
-			goto _testEof116
+			goto _test_eof116
 		}
-	stCase116:
+	st_case_116:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st117
 		}
 		goto st0
 	st117:
 		if p++; p == pe {
-			goto _testEof117
+			goto _test_eof117
 		}
-	stCase117:
+	st_case_117:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st118
 		}
 		goto st0
 	st118:
 		if p++; p == pe {
-			goto _testEof118
+			goto _test_eof118
 		}
-	stCase118:
+	st_case_118:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st119
 		}
 		goto st0
 	st119:
 		if p++; p == pe {
-			goto _testEof119
+			goto _test_eof119
 		}
-	stCase119:
+	st_case_119:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st120
 		}
 		goto st0
 	st120:
 		if p++; p == pe {
-			goto _testEof120
+			goto _test_eof120
 		}
-	stCase120:
+	st_case_120:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st121
 		}
 		goto st0
 	st121:
 		if p++; p == pe {
-			goto _testEof121
+			goto _test_eof121
 		}
-	stCase121:
+	st_case_121:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st122
 		}
 		goto st0
 	st122:
 		if p++; p == pe {
-			goto _testEof122
+			goto _test_eof122
 		}
-	stCase122:
+	st_case_122:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st123
 		}
 		goto st0
 	st123:
 		if p++; p == pe {
-			goto _testEof123
+			goto _test_eof123
 		}
-	stCase123:
+	st_case_123:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st124
 		}
 		goto st0
 	st124:
 		if p++; p == pe {
-			goto _testEof124
+			goto _test_eof124
 		}
-	stCase124:
+	st_case_124:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st125
 		}
 		goto st0
 	st125:
 		if p++; p == pe {
-			goto _testEof125
+			goto _test_eof125
 		}
-	stCase125:
+	st_case_125:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st126
 		}
 		goto st0
 	st126:
 		if p++; p == pe {
-			goto _testEof126
+			goto _test_eof126
 		}
-	stCase126:
+	st_case_126:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st127
 		}
 		goto st0
 	st127:
 		if p++; p == pe {
-			goto _testEof127
+			goto _test_eof127
 		}
-	stCase127:
+	st_case_127:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st128
 		}
 		goto st0
 	st128:
 		if p++; p == pe {
-			goto _testEof128
+			goto _test_eof128
 		}
-	stCase128:
+	st_case_128:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st129
 		}
 		goto st0
 	st129:
 		if p++; p == pe {
-			goto _testEof129
+			goto _test_eof129
 		}
-	stCase129:
+	st_case_129:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st130
 		}
 		goto st0
 	st130:
 		if p++; p == pe {
-			goto _testEof130
+			goto _test_eof130
 		}
-	stCase130:
+	st_case_130:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st131
 		}
 		goto st0
 	st131:
 		if p++; p == pe {
-			goto _testEof131
+			goto _test_eof131
 		}
-	stCase131:
+	st_case_131:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st132
 		}
 		goto st0
 	st132:
 		if p++; p == pe {
-			goto _testEof132
+			goto _test_eof132
 		}
-	stCase132:
+	st_case_132:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st133
 		}
 		goto st0
 	st133:
 		if p++; p == pe {
-			goto _testEof133
+			goto _test_eof133
 		}
-	stCase133:
+	st_case_133:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st134
 		}
 		goto st0
 	st134:
 		if p++; p == pe {
-			goto _testEof134
+			goto _test_eof134
 		}
-	stCase134:
+	st_case_134:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st135
 		}
 		goto st0
 	st135:
 		if p++; p == pe {
-			goto _testEof135
+			goto _test_eof135
 		}
-	stCase135:
+	st_case_135:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st136
 		}
 		goto st0
 	st136:
 		if p++; p == pe {
-			goto _testEof136
+			goto _test_eof136
 		}
-	stCase136:
+	st_case_136:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st137
 		}
 		goto st0
 	st137:
 		if p++; p == pe {
-			goto _testEof137
+			goto _test_eof137
 		}
-	stCase137:
+	st_case_137:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st138
 		}
 		goto st0
 	st138:
 		if p++; p == pe {
-			goto _testEof138
+			goto _test_eof138
 		}
-	stCase138:
+	st_case_138:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st139
 		}
 		goto st0
 	st139:
 		if p++; p == pe {
-			goto _testEof139
+			goto _test_eof139
 		}
-	stCase139:
+	st_case_139:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st140
 		}
 		goto st0
 	st140:
 		if p++; p == pe {
-			goto _testEof140
+			goto _test_eof140
 		}
-	stCase140:
+	st_case_140:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st141
 		}
 		goto st0
 	st141:
 		if p++; p == pe {
-			goto _testEof141
+			goto _test_eof141
 		}
-	stCase141:
+	st_case_141:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st142
 		}
 		goto st0
 	st142:
 		if p++; p == pe {
-			goto _testEof142
+			goto _test_eof142
 		}
-	stCase142:
+	st_case_142:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st143
 		}
 		goto st0
 	st143:
 		if p++; p == pe {
-			goto _testEof143
+			goto _test_eof143
 		}
-	stCase143:
+	st_case_143:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st144
 		}
 		goto st0
 	st144:
 		if p++; p == pe {
-			goto _testEof144
+			goto _test_eof144
 		}
-	stCase144:
+	st_case_144:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st145
 		}
 		goto st0
 	st145:
 		if p++; p == pe {
-			goto _testEof145
+			goto _test_eof145
 		}
-	stCase145:
+	st_case_145:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st146
 		}
 		goto st0
 	st146:
 		if p++; p == pe {
-			goto _testEof146
+			goto _test_eof146
 		}
-	stCase146:
+	st_case_146:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st147
 		}
 		goto st0
 	st147:
 		if p++; p == pe {
-			goto _testEof147
+			goto _test_eof147
 		}
-	stCase147:
+	st_case_147:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st148
 		}
 		goto st0
 	st148:
 		if p++; p == pe {
-			goto _testEof148
+			goto _test_eof148
 		}
-	stCase148:
+	st_case_148:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st149
 		}
 		goto st0
 	st149:
 		if p++; p == pe {
-			goto _testEof149
+			goto _test_eof149
 		}
-	stCase149:
+	st_case_149:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st150
 		}
 		goto st0
 	st150:
 		if p++; p == pe {
-			goto _testEof150
+			goto _test_eof150
 		}
-	stCase150:
+	st_case_150:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st151
 		}
 		goto st0
 	st151:
 		if p++; p == pe {
-			goto _testEof151
+			goto _test_eof151
 		}
-	stCase151:
+	st_case_151:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st152
 		}
 		goto st0
 	st152:
 		if p++; p == pe {
-			goto _testEof152
+			goto _test_eof152
 		}
-	stCase152:
+	st_case_152:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st153
 		}
 		goto st0
 	st153:
 		if p++; p == pe {
-			goto _testEof153
+			goto _test_eof153
 		}
-	stCase153:
+	st_case_153:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st154
 		}
 		goto st0
 	st154:
 		if p++; p == pe {
-			goto _testEof154
+			goto _test_eof154
 		}
-	stCase154:
+	st_case_154:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st155
 		}
 		goto st0
 	st155:
 		if p++; p == pe {
-			goto _testEof155
+			goto _test_eof155
 		}
-	stCase155:
+	st_case_155:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st156
 		}
 		goto st0
 	st156:
 		if p++; p == pe {
-			goto _testEof156
+			goto _test_eof156
 		}
-	stCase156:
+	st_case_156:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st157
 		}
 		goto st0
 	st157:
 		if p++; p == pe {
-			goto _testEof157
+			goto _test_eof157
 		}
-	stCase157:
+	st_case_157:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st158
 		}
 		goto st0
 	st158:
 		if p++; p == pe {
-			goto _testEof158
+			goto _test_eof158
 		}
-	stCase158:
+	st_case_158:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st159
 		}
 		goto st0
 	st159:
 		if p++; p == pe {
-			goto _testEof159
+			goto _test_eof159
 		}
-	stCase159:
+	st_case_159:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st160
 		}
 		goto st0
 	st160:
 		if p++; p == pe {
-			goto _testEof160
+			goto _test_eof160
 		}
-	stCase160:
+	st_case_160:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st161
 		}
 		goto st0
 	st161:
 		if p++; p == pe {
-			goto _testEof161
+			goto _test_eof161
 		}
-	stCase161:
+	st_case_161:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st162
 		}
 		goto st0
 	st162:
 		if p++; p == pe {
-			goto _testEof162
+			goto _test_eof162
 		}
-	stCase162:
+	st_case_162:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st163
 		}
 		goto st0
 	st163:
 		if p++; p == pe {
-			goto _testEof163
+			goto _test_eof163
 		}
-	stCase163:
+	st_case_163:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st164
 		}
 		goto st0
 	st164:
 		if p++; p == pe {
-			goto _testEof164
+			goto _test_eof164
 		}
-	stCase164:
+	st_case_164:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st165
 		}
 		goto st0
 	st165:
 		if p++; p == pe {
-			goto _testEof165
+			goto _test_eof165
 		}
-	stCase165:
+	st_case_165:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st166
 		}
 		goto st0
 	st166:
 		if p++; p == pe {
-			goto _testEof166
+			goto _test_eof166
 		}
-	stCase166:
+	st_case_166:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st167
 		}
 		goto st0
 	st167:
 		if p++; p == pe {
-			goto _testEof167
+			goto _test_eof167
 		}
-	stCase167:
+	st_case_167:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st168
 		}
 		goto st0
 	st168:
 		if p++; p == pe {
-			goto _testEof168
+			goto _test_eof168
 		}
-	stCase168:
+	st_case_168:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st169
 		}
 		goto st0
 	st169:
 		if p++; p == pe {
-			goto _testEof169
+			goto _test_eof169
 		}
-	stCase169:
+	st_case_169:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st170
 		}
 		goto st0
 	st170:
 		if p++; p == pe {
-			goto _testEof170
+			goto _test_eof170
 		}
-	stCase170:
+	st_case_170:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st171
 		}
 		goto st0
 	st171:
 		if p++; p == pe {
-			goto _testEof171
+			goto _test_eof171
 		}
-	stCase171:
+	st_case_171:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st172
 		}
 		goto st0
 	st172:
 		if p++; p == pe {
-			goto _testEof172
+			goto _test_eof172
 		}
-	stCase172:
+	st_case_172:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st173
 		}
 		goto st0
 	st173:
 		if p++; p == pe {
-			goto _testEof173
+			goto _test_eof173
 		}
-	stCase173:
+	st_case_173:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st174
 		}
 		goto st0
 	st174:
 		if p++; p == pe {
-			goto _testEof174
+			goto _test_eof174
 		}
-	stCase174:
+	st_case_174:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st175
 		}
 		goto st0
 	st175:
 		if p++; p == pe {
-			goto _testEof175
+			goto _test_eof175
 		}
-	stCase175:
+	st_case_175:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st176
 		}
 		goto st0
 	st176:
 		if p++; p == pe {
-			goto _testEof176
+			goto _test_eof176
 		}
-	stCase176:
+	st_case_176:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st177
 		}
 		goto st0
 	st177:
 		if p++; p == pe {
-			goto _testEof177
+			goto _test_eof177
 		}
-	stCase177:
+	st_case_177:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st178
 		}
 		goto st0
 	st178:
 		if p++; p == pe {
-			goto _testEof178
+			goto _test_eof178
 		}
-	stCase178:
+	st_case_178:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st179
 		}
 		goto st0
 	st179:
 		if p++; p == pe {
-			goto _testEof179
+			goto _test_eof179
 		}
-	stCase179:
+	st_case_179:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st180
 		}
 		goto st0
 	st180:
 		if p++; p == pe {
-			goto _testEof180
+			goto _test_eof180
 		}
-	stCase180:
+	st_case_180:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st181
 		}
 		goto st0
 	st181:
 		if p++; p == pe {
-			goto _testEof181
+			goto _test_eof181
 		}
-	stCase181:
+	st_case_181:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st182
 		}
 		goto st0
 	st182:
 		if p++; p == pe {
-			goto _testEof182
+			goto _test_eof182
 		}
-	stCase182:
+	st_case_182:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st183
 		}
 		goto st0
 	st183:
 		if p++; p == pe {
-			goto _testEof183
+			goto _test_eof183
 		}
-	stCase183:
+	st_case_183:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st184
 		}
 		goto st0
 	st184:
 		if p++; p == pe {
-			goto _testEof184
+			goto _test_eof184
 		}
-	stCase184:
+	st_case_184:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st185
 		}
 		goto st0
 	st185:
 		if p++; p == pe {
-			goto _testEof185
+			goto _test_eof185
 		}
-	stCase185:
+	st_case_185:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st186
 		}
 		goto st0
 	st186:
 		if p++; p == pe {
-			goto _testEof186
+			goto _test_eof186
 		}
-	stCase186:
+	st_case_186:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st187
 		}
 		goto st0
 	st187:
 		if p++; p == pe {
-			goto _testEof187
+			goto _test_eof187
 		}
-	stCase187:
+	st_case_187:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st188
 		}
 		goto st0
 	st188:
 		if p++; p == pe {
-			goto _testEof188
+			goto _test_eof188
 		}
-	stCase188:
+	st_case_188:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st189
 		}
 		goto st0
 	st189:
 		if p++; p == pe {
-			goto _testEof189
+			goto _test_eof189
 		}
-	stCase189:
+	st_case_189:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st190
 		}
 		goto st0
 	st190:
 		if p++; p == pe {
-			goto _testEof190
+			goto _test_eof190
 		}
-	stCase190:
+	st_case_190:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st191
 		}
 		goto st0
 	st191:
 		if p++; p == pe {
-			goto _testEof191
+			goto _test_eof191
 		}
-	stCase191:
+	st_case_191:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st192
 		}
 		goto st0
 	st192:
 		if p++; p == pe {
-			goto _testEof192
+			goto _test_eof192
 		}
-	stCase192:
+	st_case_192:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st193
 		}
 		goto st0
 	st193:
 		if p++; p == pe {
-			goto _testEof193
+			goto _test_eof193
 		}
-	stCase193:
+	st_case_193:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st194
 		}
 		goto st0
 	st194:
 		if p++; p == pe {
-			goto _testEof194
+			goto _test_eof194
 		}
-	stCase194:
+	st_case_194:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st195
 		}
 		goto st0
 	st195:
 		if p++; p == pe {
-			goto _testEof195
+			goto _test_eof195
 		}
-	stCase195:
+	st_case_195:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st196
 		}
 		goto st0
 	st196:
 		if p++; p == pe {
-			goto _testEof196
+			goto _test_eof196
 		}
-	stCase196:
+	st_case_196:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st197
 		}
 		goto st0
 	st197:
 		if p++; p == pe {
-			goto _testEof197
+			goto _test_eof197
 		}
-	stCase197:
+	st_case_197:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st198
 		}
 		goto st0
 	st198:
 		if p++; p == pe {
-			goto _testEof198
+			goto _test_eof198
 		}
-	stCase198:
+	st_case_198:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st199
 		}
 		goto st0
 	st199:
 		if p++; p == pe {
-			goto _testEof199
+			goto _test_eof199
 		}
-	stCase199:
+	st_case_199:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st200
 		}
 		goto st0
 	st200:
 		if p++; p == pe {
-			goto _testEof200
+			goto _test_eof200
 		}
-	stCase200:
+	st_case_200:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st201
 		}
 		goto st0
 	st201:
 		if p++; p == pe {
-			goto _testEof201
+			goto _test_eof201
 		}
-	stCase201:
+	st_case_201:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st202
 		}
 		goto st0
 	st202:
 		if p++; p == pe {
-			goto _testEof202
+			goto _test_eof202
 		}
-	stCase202:
+	st_case_202:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st203
 		}
 		goto st0
 	st203:
 		if p++; p == pe {
-			goto _testEof203
+			goto _test_eof203
 		}
-	stCase203:
+	st_case_203:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st204
 		}
 		goto st0
 	st204:
 		if p++; p == pe {
-			goto _testEof204
+			goto _test_eof204
 		}
-	stCase204:
+	st_case_204:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st205
 		}
 		goto st0
 	st205:
 		if p++; p == pe {
-			goto _testEof205
+			goto _test_eof205
 		}
-	stCase205:
+	st_case_205:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st206
 		}
 		goto st0
 	st206:
 		if p++; p == pe {
-			goto _testEof206
+			goto _test_eof206
 		}
-	stCase206:
+	st_case_206:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st207
 		}
 		goto st0
 	st207:
 		if p++; p == pe {
-			goto _testEof207
+			goto _test_eof207
 		}
-	stCase207:
+	st_case_207:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st208
 		}
 		goto st0
 	st208:
 		if p++; p == pe {
-			goto _testEof208
+			goto _test_eof208
 		}
-	stCase208:
+	st_case_208:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st209
 		}
 		goto st0
 	st209:
 		if p++; p == pe {
-			goto _testEof209
+			goto _test_eof209
 		}
-	stCase209:
+	st_case_209:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st210
 		}
 		goto st0
 	st210:
 		if p++; p == pe {
-			goto _testEof210
+			goto _test_eof210
 		}
-	stCase210:
+	st_case_210:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st211
 		}
 		goto st0
 	st211:
 		if p++; p == pe {
-			goto _testEof211
+			goto _test_eof211
 		}
-	stCase211:
+	st_case_211:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st212
 		}
 		goto st0
 	st212:
 		if p++; p == pe {
-			goto _testEof212
+			goto _test_eof212
 		}
-	stCase212:
+	st_case_212:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st213
 		}
 		goto st0
 	st213:
 		if p++; p == pe {
-			goto _testEof213
+			goto _test_eof213
 		}
-	stCase213:
+	st_case_213:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st214
 		}
 		goto st0
 	st214:
 		if p++; p == pe {
-			goto _testEof214
+			goto _test_eof214
 		}
-	stCase214:
+	st_case_214:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st215
 		}
 		goto st0
 	st215:
 		if p++; p == pe {
-			goto _testEof215
+			goto _test_eof215
 		}
-	stCase215:
+	st_case_215:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st216
 		}
 		goto st0
 	st216:
 		if p++; p == pe {
-			goto _testEof216
+			goto _test_eof216
 		}
-	stCase216:
+	st_case_216:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st217
 		}
 		goto st0
 	st217:
 		if p++; p == pe {
-			goto _testEof217
+			goto _test_eof217
 		}
-	stCase217:
+	st_case_217:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st218
 		}
 		goto st0
 	st218:
 		if p++; p == pe {
-			goto _testEof218
+			goto _test_eof218
 		}
-	stCase218:
+	st_case_218:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st219
 		}
 		goto st0
 	st219:
 		if p++; p == pe {
-			goto _testEof219
+			goto _test_eof219
 		}
-	stCase219:
+	st_case_219:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st220
 		}
 		goto st0
 	st220:
 		if p++; p == pe {
-			goto _testEof220
+			goto _test_eof220
 		}
-	stCase220:
+	st_case_220:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st221
 		}
 		goto st0
 	st221:
 		if p++; p == pe {
-			goto _testEof221
+			goto _test_eof221
 		}
-	stCase221:
+	st_case_221:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st222
 		}
 		goto st0
 	st222:
 		if p++; p == pe {
-			goto _testEof222
+			goto _test_eof222
 		}
-	stCase222:
+	st_case_222:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st223
 		}
 		goto st0
 	st223:
 		if p++; p == pe {
-			goto _testEof223
+			goto _test_eof223
 		}
-	stCase223:
+	st_case_223:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st224
 		}
 		goto st0
 	st224:
 		if p++; p == pe {
-			goto _testEof224
+			goto _test_eof224
 		}
-	stCase224:
+	st_case_224:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st225
 		}
 		goto st0
 	st225:
 		if p++; p == pe {
-			goto _testEof225
+			goto _test_eof225
 		}
-	stCase225:
+	st_case_225:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st226
 		}
 		goto st0
 	st226:
 		if p++; p == pe {
-			goto _testEof226
+			goto _test_eof226
 		}
-	stCase226:
+	st_case_226:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st227
 		}
 		goto st0
 	st227:
 		if p++; p == pe {
-			goto _testEof227
+			goto _test_eof227
 		}
-	stCase227:
+	st_case_227:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st228
 		}
 		goto st0
 	st228:
 		if p++; p == pe {
-			goto _testEof228
+			goto _test_eof228
 		}
-	stCase228:
+	st_case_228:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st229
 		}
 		goto st0
 	st229:
 		if p++; p == pe {
-			goto _testEof229
+			goto _test_eof229
 		}
-	stCase229:
+	st_case_229:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st230
 		}
 		goto st0
 	st230:
 		if p++; p == pe {
-			goto _testEof230
+			goto _test_eof230
 		}
-	stCase230:
+	st_case_230:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st231
 		}
 		goto st0
 	st231:
 		if p++; p == pe {
-			goto _testEof231
+			goto _test_eof231
 		}
-	stCase231:
+	st_case_231:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st232
 		}
 		goto st0
 	st232:
 		if p++; p == pe {
-			goto _testEof232
+			goto _test_eof232
 		}
-	stCase232:
+	st_case_232:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st233
 		}
 		goto st0
 	st233:
 		if p++; p == pe {
-			goto _testEof233
+			goto _test_eof233
 		}
-	stCase233:
+	st_case_233:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st234
 		}
 		goto st0
 	st234:
 		if p++; p == pe {
-			goto _testEof234
+			goto _test_eof234
 		}
-	stCase234:
+	st_case_234:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st235
 		}
 		goto st0
 	st235:
 		if p++; p == pe {
-			goto _testEof235
+			goto _test_eof235
 		}
-	stCase235:
+	st_case_235:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st236
 		}
 		goto st0
 	st236:
 		if p++; p == pe {
-			goto _testEof236
+			goto _test_eof236
 		}
-	stCase236:
+	st_case_236:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st237
 		}
 		goto st0
 	st237:
 		if p++; p == pe {
-			goto _testEof237
+			goto _test_eof237
 		}
-	stCase237:
+	st_case_237:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st238
 		}
 		goto st0
 	st238:
 		if p++; p == pe {
-			goto _testEof238
+			goto _test_eof238
 		}
-	stCase238:
+	st_case_238:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st239
 		}
 		goto st0
 	st239:
 		if p++; p == pe {
-			goto _testEof239
+			goto _test_eof239
 		}
-	stCase239:
+	st_case_239:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st240
 		}
 		goto st0
 	st240:
 		if p++; p == pe {
-			goto _testEof240
+			goto _test_eof240
 		}
-	stCase240:
+	st_case_240:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st241
 		}
 		goto st0
 	st241:
 		if p++; p == pe {
-			goto _testEof241
+			goto _test_eof241
 		}
-	stCase241:
+	st_case_241:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st242
 		}
 		goto st0
 	st242:
 		if p++; p == pe {
-			goto _testEof242
+			goto _test_eof242
 		}
-	stCase242:
+	st_case_242:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st243
 		}
 		goto st0
 	st243:
 		if p++; p == pe {
-			goto _testEof243
+			goto _test_eof243
 		}
-	stCase243:
+	st_case_243:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st244
 		}
 		goto st0
 	st244:
 		if p++; p == pe {
-			goto _testEof244
+			goto _test_eof244
 		}
-	stCase244:
+	st_case_244:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st245
 		}
 		goto st0
 	st245:
 		if p++; p == pe {
-			goto _testEof245
+			goto _test_eof245
 		}
-	stCase245:
+	st_case_245:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st246
 		}
 		goto st0
 	st246:
 		if p++; p == pe {
-			goto _testEof246
+			goto _test_eof246
 		}
-	stCase246:
+	st_case_246:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st247
 		}
 		goto st0
 	st247:
 		if p++; p == pe {
-			goto _testEof247
+			goto _test_eof247
 		}
-	stCase247:
+	st_case_247:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st248
 		}
 		goto st0
 	st248:
 		if p++; p == pe {
-			goto _testEof248
+			goto _test_eof248
 		}
-	stCase248:
+	st_case_248:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st249
 		}
 		goto st0
 	st249:
 		if p++; p == pe {
-			goto _testEof249
+			goto _test_eof249
 		}
-	stCase249:
+	st_case_249:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st250
 		}
 		goto st0
 	st250:
 		if p++; p == pe {
-			goto _testEof250
+			goto _test_eof250
 		}
-	stCase250:
+	st_case_250:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st251
 		}
 		goto st0
 	st251:
 		if p++; p == pe {
-			goto _testEof251
+			goto _test_eof251
 		}
-	stCase251:
+	st_case_251:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st252
 		}
 		goto st0
 	st252:
 		if p++; p == pe {
-			goto _testEof252
+			goto _test_eof252
 		}
-	stCase252:
+	st_case_252:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st253
 		}
 		goto st0
 	st253:
 		if p++; p == pe {
-			goto _testEof253
+			goto _test_eof253
 		}
-	stCase253:
+	st_case_253:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st254
 		}
 		goto st0
 	st254:
 		if p++; p == pe {
-			goto _testEof254
+			goto _test_eof254
 		}
-	stCase254:
+	st_case_254:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st255
 		}
 		goto st0
 	st255:
 		if p++; p == pe {
-			goto _testEof255
+			goto _test_eof255
 		}
-	stCase255:
+	st_case_255:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st256
 		}
 		goto st0
 	st256:
 		if p++; p == pe {
-			goto _testEof256
+			goto _test_eof256
 		}
-	stCase256:
+	st_case_256:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st257
 		}
 		goto st0
 	st257:
 		if p++; p == pe {
-			goto _testEof257
+			goto _test_eof257
 		}
-	stCase257:
+	st_case_257:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st258
 		}
 		goto st0
 	st258:
 		if p++; p == pe {
-			goto _testEof258
+			goto _test_eof258
 		}
-	stCase258:
+	st_case_258:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st259
 		}
 		goto st0
 	st259:
 		if p++; p == pe {
-			goto _testEof259
+			goto _test_eof259
 		}
-	stCase259:
+	st_case_259:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st260
 		}
 		goto st0
 	st260:
 		if p++; p == pe {
-			goto _testEof260
+			goto _test_eof260
 		}
-	stCase260:
+	st_case_260:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st261
 		}
 		goto st0
 	st261:
 		if p++; p == pe {
-			goto _testEof261
+			goto _test_eof261
 		}
-	stCase261:
+	st_case_261:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st262
 		}
 		goto st0
 	st262:
 		if p++; p == pe {
-			goto _testEof262
+			goto _test_eof262
 		}
-	stCase262:
+	st_case_262:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st263
 		}
 		goto st0
 	st263:
 		if p++; p == pe {
-			goto _testEof263
+			goto _test_eof263
 		}
-	stCase263:
+	st_case_263:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st264
 		}
 		goto st0
 	st264:
 		if p++; p == pe {
-			goto _testEof264
+			goto _test_eof264
 		}
-	stCase264:
+	st_case_264:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st265
 		}
 		goto st0
 	st265:
 		if p++; p == pe {
-			goto _testEof265
+			goto _test_eof265
 		}
-	stCase265:
+	st_case_265:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st266
 		}
 		goto st0
 	st266:
 		if p++; p == pe {
-			goto _testEof266
+			goto _test_eof266
 		}
-	stCase266:
+	st_case_266:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st267
 		}
 		goto st0
 	st267:
 		if p++; p == pe {
-			goto _testEof267
+			goto _test_eof267
 		}
-	stCase267:
+	st_case_267:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st268
 		}
 		goto st0
 	st268:
 		if p++; p == pe {
-			goto _testEof268
+			goto _test_eof268
 		}
-	stCase268:
+	st_case_268:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st269
 		}
 		goto st0
 	st269:
 		if p++; p == pe {
-			goto _testEof269
+			goto _test_eof269
 		}
-	stCase269:
+	st_case_269:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st270
 		}
 		goto st0
 	st270:
 		if p++; p == pe {
-			goto _testEof270
+			goto _test_eof270
 		}
-	stCase270:
+	st_case_270:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st271
 		}
 		goto st0
 	st271:
 		if p++; p == pe {
-			goto _testEof271
+			goto _test_eof271
 		}
-	stCase271:
+	st_case_271:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st272
 		}
 		goto st0
 	st272:
 		if p++; p == pe {
-			goto _testEof272
+			goto _test_eof272
 		}
-	stCase272:
+	st_case_272:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st273
 		}
 		goto st0
 	st273:
 		if p++; p == pe {
-			goto _testEof273
+			goto _test_eof273
 		}
-	stCase273:
+	st_case_273:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st274
 		}
 		goto st0
 	st274:
 		if p++; p == pe {
-			goto _testEof274
+			goto _test_eof274
 		}
-	stCase274:
+	st_case_274:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st275
 		}
 		goto st0
 	st275:
 		if p++; p == pe {
-			goto _testEof275
+			goto _test_eof275
 		}
-	stCase275:
+	st_case_275:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st276
 		}
 		goto st0
 	st276:
 		if p++; p == pe {
-			goto _testEof276
+			goto _test_eof276
 		}
-	stCase276:
+	st_case_276:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st277
 		}
 		goto st0
 	st277:
 		if p++; p == pe {
-			goto _testEof277
+			goto _test_eof277
 		}
-	stCase277:
+	st_case_277:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st278
 		}
 		goto st0
 	st278:
 		if p++; p == pe {
-			goto _testEof278
+			goto _test_eof278
 		}
-	stCase278:
+	st_case_278:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st279
 		}
 		goto st0
 	st279:
 		if p++; p == pe {
-			goto _testEof279
+			goto _test_eof279
 		}
-	stCase279:
+	st_case_279:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st280
 		}
 		goto st0
 	st280:
 		if p++; p == pe {
-			goto _testEof280
+			goto _test_eof280
 		}
-	stCase280:
+	st_case_280:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st281
 		}
 		goto st0
 	st281:
 		if p++; p == pe {
-			goto _testEof281
+			goto _test_eof281
 		}
-	stCase281:
+	st_case_281:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st282
 		}
 		goto st0
 	st282:
 		if p++; p == pe {
-			goto _testEof282
+			goto _test_eof282
 		}
-	stCase282:
+	st_case_282:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st283
 		}
 		goto st0
 	st283:
 		if p++; p == pe {
-			goto _testEof283
+			goto _test_eof283
 		}
-	stCase283:
+	st_case_283:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st284
 		}
 		goto st0
 	st284:
 		if p++; p == pe {
-			goto _testEof284
+			goto _test_eof284
 		}
-	stCase284:
+	st_case_284:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st285
 		}
 		goto st0
 	st285:
 		if p++; p == pe {
-			goto _testEof285
+			goto _test_eof285
 		}
-	stCase285:
+	st_case_285:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st286
 		}
 		goto st0
 	st286:
 		if p++; p == pe {
-			goto _testEof286
+			goto _test_eof286
 		}
-	stCase286:
+	st_case_286:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st287
 		}
 		goto st0
 	st287:
 		if p++; p == pe {
-			goto _testEof287
+			goto _test_eof287
 		}
-	stCase287:
+	st_case_287:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st288
 		}
 		goto st0
 	st288:
 		if p++; p == pe {
-			goto _testEof288
+			goto _test_eof288
 		}
-	stCase288:
+	st_case_288:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st289
 		}
 		goto st0
 	st289:
 		if p++; p == pe {
-			goto _testEof289
+			goto _test_eof289
 		}
-	stCase289:
+	st_case_289:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st290
 		}
 		goto st0
 	st290:
 		if p++; p == pe {
-			goto _testEof290
+			goto _test_eof290
 		}
-	stCase290:
+	st_case_290:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st291
 		}
 		goto st0
 	st291:
 		if p++; p == pe {
-			goto _testEof291
+			goto _test_eof291
 		}
-	stCase291:
+	st_case_291:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st292
 		}
 		goto st0
 	st292:
 		if p++; p == pe {
-			goto _testEof292
+			goto _test_eof292
 		}
-	stCase292:
+	st_case_292:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st293
 		}
 		goto st0
 	st293:
 		if p++; p == pe {
-			goto _testEof293
+			goto _test_eof293
 		}
-	stCase293:
+	st_case_293:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st294
 		}
 		goto st0
 	st294:
 		if p++; p == pe {
-			goto _testEof294
+			goto _test_eof294
 		}
-	stCase294:
+	st_case_294:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st295
 		}
 		goto st0
 	st295:
 		if p++; p == pe {
-			goto _testEof295
+			goto _test_eof295
 		}
-	stCase295:
+	st_case_295:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st296
 		}
 		goto st0
 	st296:
 		if p++; p == pe {
-			goto _testEof296
+			goto _test_eof296
 		}
-	stCase296:
+	st_case_296:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st297
 		}
 		goto st0
 	st297:
 		if p++; p == pe {
-			goto _testEof297
+			goto _test_eof297
 		}
-	stCase297:
+	st_case_297:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st298
 		}
 		goto st0
 	st298:
 		if p++; p == pe {
-			goto _testEof298
+			goto _test_eof298
 		}
-	stCase298:
+	st_case_298:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st299
 		}
 		goto st0
 	st299:
 		if p++; p == pe {
-			goto _testEof299
+			goto _test_eof299
 		}
-	stCase299:
+	st_case_299:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st300
 		}
 		goto st0
 	st300:
 		if p++; p == pe {
-			goto _testEof300
+			goto _test_eof300
 		}
-	stCase300:
+	st_case_300:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st301
 		}
 		goto st0
 	st301:
 		if p++; p == pe {
-			goto _testEof301
+			goto _test_eof301
 		}
-	stCase301:
+	st_case_301:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st302
 		}
 		goto st0
 	st302:
 		if p++; p == pe {
-			goto _testEof302
+			goto _test_eof302
 		}
-	stCase302:
+	st_case_302:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st303
 		}
 		goto st0
 	st303:
 		if p++; p == pe {
-			goto _testEof303
+			goto _test_eof303
 		}
-	stCase303:
+	st_case_303:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st304
 		}
 		goto st0
 	st304:
 		if p++; p == pe {
-			goto _testEof304
+			goto _test_eof304
 		}
-	stCase304:
+	st_case_304:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st305
 		}
 		goto st0
 	st305:
 		if p++; p == pe {
-			goto _testEof305
+			goto _test_eof305
 		}
-	stCase305:
+	st_case_305:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st306
 		}
 		goto st0
 	st306:
 		if p++; p == pe {
-			goto _testEof306
+			goto _test_eof306
 		}
-	stCase306:
+	st_case_306:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st307
 		}
 		goto st0
 	st307:
 		if p++; p == pe {
-			goto _testEof307
+			goto _test_eof307
 		}
-	stCase307:
+	st_case_307:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st308
 		}
 		goto st0
 	st308:
 		if p++; p == pe {
-			goto _testEof308
+			goto _test_eof308
 		}
-	stCase308:
+	st_case_308:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st309
 		}
 		goto st0
 	st309:
 		if p++; p == pe {
-			goto _testEof309
+			goto _test_eof309
 		}
-	stCase309:
+	st_case_309:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st310
 		}
 		goto st0
 	st310:
 		if p++; p == pe {
-			goto _testEof310
+			goto _test_eof310
 		}
-	stCase310:
+	st_case_310:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st311
 		}
 		goto st0
 	st311:
 		if p++; p == pe {
-			goto _testEof311
+			goto _test_eof311
 		}
-	stCase311:
+	st_case_311:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st312
 		}
 		goto st0
 	st312:
 		if p++; p == pe {
-			goto _testEof312
+			goto _test_eof312
 		}
-	stCase312:
+	st_case_312:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st313
 		}
 		goto st0
 	st313:
 		if p++; p == pe {
-			goto _testEof313
+			goto _test_eof313
 		}
-	stCase313:
+	st_case_313:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st314
 		}
 		goto st0
 	st314:
 		if p++; p == pe {
-			goto _testEof314
+			goto _test_eof314
 		}
-	stCase314:
+	st_case_314:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st315
 		}
 		goto st0
 	st315:
 		if p++; p == pe {
-			goto _testEof315
+			goto _test_eof315
 		}
-	stCase315:
+	st_case_315:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st316
 		}
 		goto st0
 	st316:
 		if p++; p == pe {
-			goto _testEof316
+			goto _test_eof316
 		}
-	stCase316:
+	st_case_316:
 		goto st0
-	stCase46:
+	st_case_46:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto tr42
 		}
@@ -4160,434 +4160,434 @@ func (sm *SyslogMessage) set(from entrypoint, value string) *SyslogMessage {
 		goto st317
 	st317:
 		if p++; p == pe {
-			goto _testEof317
+			goto _test_eof317
 		}
-	stCase317:
+	st_case_317:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st318
 		}
 		goto st0
 	st318:
 		if p++; p == pe {
-			goto _testEof318
+			goto _test_eof318
 		}
-	stCase318:
+	st_case_318:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st319
 		}
 		goto st0
 	st319:
 		if p++; p == pe {
-			goto _testEof319
+			goto _test_eof319
 		}
-	stCase319:
+	st_case_319:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st320
 		}
 		goto st0
 	st320:
 		if p++; p == pe {
-			goto _testEof320
+			goto _test_eof320
 		}
-	stCase320:
+	st_case_320:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st321
 		}
 		goto st0
 	st321:
 		if p++; p == pe {
-			goto _testEof321
+			goto _test_eof321
 		}
-	stCase321:
+	st_case_321:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st322
 		}
 		goto st0
 	st322:
 		if p++; p == pe {
-			goto _testEof322
+			goto _test_eof322
 		}
-	stCase322:
+	st_case_322:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st323
 		}
 		goto st0
 	st323:
 		if p++; p == pe {
-			goto _testEof323
+			goto _test_eof323
 		}
-	stCase323:
+	st_case_323:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st324
 		}
 		goto st0
 	st324:
 		if p++; p == pe {
-			goto _testEof324
+			goto _test_eof324
 		}
-	stCase324:
+	st_case_324:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st325
 		}
 		goto st0
 	st325:
 		if p++; p == pe {
-			goto _testEof325
+			goto _test_eof325
 		}
-	stCase325:
+	st_case_325:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st326
 		}
 		goto st0
 	st326:
 		if p++; p == pe {
-			goto _testEof326
+			goto _test_eof326
 		}
-	stCase326:
+	st_case_326:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st327
 		}
 		goto st0
 	st327:
 		if p++; p == pe {
-			goto _testEof327
+			goto _test_eof327
 		}
-	stCase327:
+	st_case_327:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st328
 		}
 		goto st0
 	st328:
 		if p++; p == pe {
-			goto _testEof328
+			goto _test_eof328
 		}
-	stCase328:
+	st_case_328:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st329
 		}
 		goto st0
 	st329:
 		if p++; p == pe {
-			goto _testEof329
+			goto _test_eof329
 		}
-	stCase329:
+	st_case_329:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st330
 		}
 		goto st0
 	st330:
 		if p++; p == pe {
-			goto _testEof330
+			goto _test_eof330
 		}
-	stCase330:
+	st_case_330:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st331
 		}
 		goto st0
 	st331:
 		if p++; p == pe {
-			goto _testEof331
+			goto _test_eof331
 		}
-	stCase331:
+	st_case_331:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st332
 		}
 		goto st0
 	st332:
 		if p++; p == pe {
-			goto _testEof332
+			goto _test_eof332
 		}
-	stCase332:
+	st_case_332:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st333
 		}
 		goto st0
 	st333:
 		if p++; p == pe {
-			goto _testEof333
+			goto _test_eof333
 		}
-	stCase333:
+	st_case_333:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st334
 		}
 		goto st0
 	st334:
 		if p++; p == pe {
-			goto _testEof334
+			goto _test_eof334
 		}
-	stCase334:
+	st_case_334:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st335
 		}
 		goto st0
 	st335:
 		if p++; p == pe {
-			goto _testEof335
+			goto _test_eof335
 		}
-	stCase335:
+	st_case_335:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st336
 		}
 		goto st0
 	st336:
 		if p++; p == pe {
-			goto _testEof336
+			goto _test_eof336
 		}
-	stCase336:
+	st_case_336:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st337
 		}
 		goto st0
 	st337:
 		if p++; p == pe {
-			goto _testEof337
+			goto _test_eof337
 		}
-	stCase337:
+	st_case_337:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st338
 		}
 		goto st0
 	st338:
 		if p++; p == pe {
-			goto _testEof338
+			goto _test_eof338
 		}
-	stCase338:
+	st_case_338:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st339
 		}
 		goto st0
 	st339:
 		if p++; p == pe {
-			goto _testEof339
+			goto _test_eof339
 		}
-	stCase339:
+	st_case_339:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st340
 		}
 		goto st0
 	st340:
 		if p++; p == pe {
-			goto _testEof340
+			goto _test_eof340
 		}
-	stCase340:
+	st_case_340:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st341
 		}
 		goto st0
 	st341:
 		if p++; p == pe {
-			goto _testEof341
+			goto _test_eof341
 		}
-	stCase341:
+	st_case_341:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st342
 		}
 		goto st0
 	st342:
 		if p++; p == pe {
-			goto _testEof342
+			goto _test_eof342
 		}
-	stCase342:
+	st_case_342:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st343
 		}
 		goto st0
 	st343:
 		if p++; p == pe {
-			goto _testEof343
+			goto _test_eof343
 		}
-	stCase343:
+	st_case_343:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st344
 		}
 		goto st0
 	st344:
 		if p++; p == pe {
-			goto _testEof344
+			goto _test_eof344
 		}
-	stCase344:
+	st_case_344:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st345
 		}
 		goto st0
 	st345:
 		if p++; p == pe {
-			goto _testEof345
+			goto _test_eof345
 		}
-	stCase345:
+	st_case_345:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st346
 		}
 		goto st0
 	st346:
 		if p++; p == pe {
-			goto _testEof346
+			goto _test_eof346
 		}
-	stCase346:
+	st_case_346:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st347
 		}
 		goto st0
 	st347:
 		if p++; p == pe {
-			goto _testEof347
+			goto _test_eof347
 		}
-	stCase347:
+	st_case_347:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st348
 		}
 		goto st0
 	st348:
 		if p++; p == pe {
-			goto _testEof348
+			goto _test_eof348
 		}
-	stCase348:
+	st_case_348:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st349
 		}
 		goto st0
 	st349:
 		if p++; p == pe {
-			goto _testEof349
+			goto _test_eof349
 		}
-	stCase349:
+	st_case_349:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st350
 		}
 		goto st0
 	st350:
 		if p++; p == pe {
-			goto _testEof350
+			goto _test_eof350
 		}
-	stCase350:
+	st_case_350:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st351
 		}
 		goto st0
 	st351:
 		if p++; p == pe {
-			goto _testEof351
+			goto _test_eof351
 		}
-	stCase351:
+	st_case_351:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st352
 		}
 		goto st0
 	st352:
 		if p++; p == pe {
-			goto _testEof352
+			goto _test_eof352
 		}
-	stCase352:
+	st_case_352:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st353
 		}
 		goto st0
 	st353:
 		if p++; p == pe {
-			goto _testEof353
+			goto _test_eof353
 		}
-	stCase353:
+	st_case_353:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st354
 		}
 		goto st0
 	st354:
 		if p++; p == pe {
-			goto _testEof354
+			goto _test_eof354
 		}
-	stCase354:
+	st_case_354:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st355
 		}
 		goto st0
 	st355:
 		if p++; p == pe {
-			goto _testEof355
+			goto _test_eof355
 		}
-	stCase355:
+	st_case_355:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st356
 		}
 		goto st0
 	st356:
 		if p++; p == pe {
-			goto _testEof356
+			goto _test_eof356
 		}
-	stCase356:
+	st_case_356:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st357
 		}
 		goto st0
 	st357:
 		if p++; p == pe {
-			goto _testEof357
+			goto _test_eof357
 		}
-	stCase357:
+	st_case_357:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st358
 		}
 		goto st0
 	st358:
 		if p++; p == pe {
-			goto _testEof358
+			goto _test_eof358
 		}
-	stCase358:
+	st_case_358:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st359
 		}
 		goto st0
 	st359:
 		if p++; p == pe {
-			goto _testEof359
+			goto _test_eof359
 		}
-	stCase359:
+	st_case_359:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st360
 		}
 		goto st0
 	st360:
 		if p++; p == pe {
-			goto _testEof360
+			goto _test_eof360
 		}
-	stCase360:
+	st_case_360:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st361
 		}
 		goto st0
 	st361:
 		if p++; p == pe {
-			goto _testEof361
+			goto _test_eof361
 		}
-	stCase361:
+	st_case_361:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st362
 		}
 		goto st0
 	st362:
 		if p++; p == pe {
-			goto _testEof362
+			goto _test_eof362
 		}
-	stCase362:
+	st_case_362:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st363
 		}
 		goto st0
 	st363:
 		if p++; p == pe {
-			goto _testEof363
+			goto _test_eof363
 		}
-	stCase363:
+	st_case_363:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st364
 		}
 		goto st0
 	st364:
 		if p++; p == pe {
-			goto _testEof364
+			goto _test_eof364
 		}
-	stCase364:
+	st_case_364:
 		goto st0
-	stCase47:
+	st_case_47:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto tr43
 		}
@@ -4599,1154 +4599,1154 @@ func (sm *SyslogMessage) set(from entrypoint, value string) *SyslogMessage {
 		goto st365
 	st365:
 		if p++; p == pe {
-			goto _testEof365
+			goto _test_eof365
 		}
-	stCase365:
+	st_case_365:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st366
 		}
 		goto st0
 	st366:
 		if p++; p == pe {
-			goto _testEof366
+			goto _test_eof366
 		}
-	stCase366:
+	st_case_366:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st367
 		}
 		goto st0
 	st367:
 		if p++; p == pe {
-			goto _testEof367
+			goto _test_eof367
 		}
-	stCase367:
+	st_case_367:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st368
 		}
 		goto st0
 	st368:
 		if p++; p == pe {
-			goto _testEof368
+			goto _test_eof368
 		}
-	stCase368:
+	st_case_368:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st369
 		}
 		goto st0
 	st369:
 		if p++; p == pe {
-			goto _testEof369
+			goto _test_eof369
 		}
-	stCase369:
+	st_case_369:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st370
 		}
 		goto st0
 	st370:
 		if p++; p == pe {
-			goto _testEof370
+			goto _test_eof370
 		}
-	stCase370:
+	st_case_370:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st371
 		}
 		goto st0
 	st371:
 		if p++; p == pe {
-			goto _testEof371
+			goto _test_eof371
 		}
-	stCase371:
+	st_case_371:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st372
 		}
 		goto st0
 	st372:
 		if p++; p == pe {
-			goto _testEof372
+			goto _test_eof372
 		}
-	stCase372:
+	st_case_372:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st373
 		}
 		goto st0
 	st373:
 		if p++; p == pe {
-			goto _testEof373
+			goto _test_eof373
 		}
-	stCase373:
+	st_case_373:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st374
 		}
 		goto st0
 	st374:
 		if p++; p == pe {
-			goto _testEof374
+			goto _test_eof374
 		}
-	stCase374:
+	st_case_374:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st375
 		}
 		goto st0
 	st375:
 		if p++; p == pe {
-			goto _testEof375
+			goto _test_eof375
 		}
-	stCase375:
+	st_case_375:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st376
 		}
 		goto st0
 	st376:
 		if p++; p == pe {
-			goto _testEof376
+			goto _test_eof376
 		}
-	stCase376:
+	st_case_376:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st377
 		}
 		goto st0
 	st377:
 		if p++; p == pe {
-			goto _testEof377
+			goto _test_eof377
 		}
-	stCase377:
+	st_case_377:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st378
 		}
 		goto st0
 	st378:
 		if p++; p == pe {
-			goto _testEof378
+			goto _test_eof378
 		}
-	stCase378:
+	st_case_378:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st379
 		}
 		goto st0
 	st379:
 		if p++; p == pe {
-			goto _testEof379
+			goto _test_eof379
 		}
-	stCase379:
+	st_case_379:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st380
 		}
 		goto st0
 	st380:
 		if p++; p == pe {
-			goto _testEof380
+			goto _test_eof380
 		}
-	stCase380:
+	st_case_380:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st381
 		}
 		goto st0
 	st381:
 		if p++; p == pe {
-			goto _testEof381
+			goto _test_eof381
 		}
-	stCase381:
+	st_case_381:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st382
 		}
 		goto st0
 	st382:
 		if p++; p == pe {
-			goto _testEof382
+			goto _test_eof382
 		}
-	stCase382:
+	st_case_382:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st383
 		}
 		goto st0
 	st383:
 		if p++; p == pe {
-			goto _testEof383
+			goto _test_eof383
 		}
-	stCase383:
+	st_case_383:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st384
 		}
 		goto st0
 	st384:
 		if p++; p == pe {
-			goto _testEof384
+			goto _test_eof384
 		}
-	stCase384:
+	st_case_384:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st385
 		}
 		goto st0
 	st385:
 		if p++; p == pe {
-			goto _testEof385
+			goto _test_eof385
 		}
-	stCase385:
+	st_case_385:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st386
 		}
 		goto st0
 	st386:
 		if p++; p == pe {
-			goto _testEof386
+			goto _test_eof386
 		}
-	stCase386:
+	st_case_386:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st387
 		}
 		goto st0
 	st387:
 		if p++; p == pe {
-			goto _testEof387
+			goto _test_eof387
 		}
-	stCase387:
+	st_case_387:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st388
 		}
 		goto st0
 	st388:
 		if p++; p == pe {
-			goto _testEof388
+			goto _test_eof388
 		}
-	stCase388:
+	st_case_388:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st389
 		}
 		goto st0
 	st389:
 		if p++; p == pe {
-			goto _testEof389
+			goto _test_eof389
 		}
-	stCase389:
+	st_case_389:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st390
 		}
 		goto st0
 	st390:
 		if p++; p == pe {
-			goto _testEof390
+			goto _test_eof390
 		}
-	stCase390:
+	st_case_390:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st391
 		}
 		goto st0
 	st391:
 		if p++; p == pe {
-			goto _testEof391
+			goto _test_eof391
 		}
-	stCase391:
+	st_case_391:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st392
 		}
 		goto st0
 	st392:
 		if p++; p == pe {
-			goto _testEof392
+			goto _test_eof392
 		}
-	stCase392:
+	st_case_392:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st393
 		}
 		goto st0
 	st393:
 		if p++; p == pe {
-			goto _testEof393
+			goto _test_eof393
 		}
-	stCase393:
+	st_case_393:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st394
 		}
 		goto st0
 	st394:
 		if p++; p == pe {
-			goto _testEof394
+			goto _test_eof394
 		}
-	stCase394:
+	st_case_394:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st395
 		}
 		goto st0
 	st395:
 		if p++; p == pe {
-			goto _testEof395
+			goto _test_eof395
 		}
-	stCase395:
+	st_case_395:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st396
 		}
 		goto st0
 	st396:
 		if p++; p == pe {
-			goto _testEof396
+			goto _test_eof396
 		}
-	stCase396:
+	st_case_396:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st397
 		}
 		goto st0
 	st397:
 		if p++; p == pe {
-			goto _testEof397
+			goto _test_eof397
 		}
-	stCase397:
+	st_case_397:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st398
 		}
 		goto st0
 	st398:
 		if p++; p == pe {
-			goto _testEof398
+			goto _test_eof398
 		}
-	stCase398:
+	st_case_398:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st399
 		}
 		goto st0
 	st399:
 		if p++; p == pe {
-			goto _testEof399
+			goto _test_eof399
 		}
-	stCase399:
+	st_case_399:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st400
 		}
 		goto st0
 	st400:
 		if p++; p == pe {
-			goto _testEof400
+			goto _test_eof400
 		}
-	stCase400:
+	st_case_400:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st401
 		}
 		goto st0
 	st401:
 		if p++; p == pe {
-			goto _testEof401
+			goto _test_eof401
 		}
-	stCase401:
+	st_case_401:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st402
 		}
 		goto st0
 	st402:
 		if p++; p == pe {
-			goto _testEof402
+			goto _test_eof402
 		}
-	stCase402:
+	st_case_402:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st403
 		}
 		goto st0
 	st403:
 		if p++; p == pe {
-			goto _testEof403
+			goto _test_eof403
 		}
-	stCase403:
+	st_case_403:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st404
 		}
 		goto st0
 	st404:
 		if p++; p == pe {
-			goto _testEof404
+			goto _test_eof404
 		}
-	stCase404:
+	st_case_404:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st405
 		}
 		goto st0
 	st405:
 		if p++; p == pe {
-			goto _testEof405
+			goto _test_eof405
 		}
-	stCase405:
+	st_case_405:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st406
 		}
 		goto st0
 	st406:
 		if p++; p == pe {
-			goto _testEof406
+			goto _test_eof406
 		}
-	stCase406:
+	st_case_406:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st407
 		}
 		goto st0
 	st407:
 		if p++; p == pe {
-			goto _testEof407
+			goto _test_eof407
 		}
-	stCase407:
+	st_case_407:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st408
 		}
 		goto st0
 	st408:
 		if p++; p == pe {
-			goto _testEof408
+			goto _test_eof408
 		}
-	stCase408:
+	st_case_408:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st409
 		}
 		goto st0
 	st409:
 		if p++; p == pe {
-			goto _testEof409
+			goto _test_eof409
 		}
-	stCase409:
+	st_case_409:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st410
 		}
 		goto st0
 	st410:
 		if p++; p == pe {
-			goto _testEof410
+			goto _test_eof410
 		}
-	stCase410:
+	st_case_410:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st411
 		}
 		goto st0
 	st411:
 		if p++; p == pe {
-			goto _testEof411
+			goto _test_eof411
 		}
-	stCase411:
+	st_case_411:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st412
 		}
 		goto st0
 	st412:
 		if p++; p == pe {
-			goto _testEof412
+			goto _test_eof412
 		}
-	stCase412:
+	st_case_412:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st413
 		}
 		goto st0
 	st413:
 		if p++; p == pe {
-			goto _testEof413
+			goto _test_eof413
 		}
-	stCase413:
+	st_case_413:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st414
 		}
 		goto st0
 	st414:
 		if p++; p == pe {
-			goto _testEof414
+			goto _test_eof414
 		}
-	stCase414:
+	st_case_414:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st415
 		}
 		goto st0
 	st415:
 		if p++; p == pe {
-			goto _testEof415
+			goto _test_eof415
 		}
-	stCase415:
+	st_case_415:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st416
 		}
 		goto st0
 	st416:
 		if p++; p == pe {
-			goto _testEof416
+			goto _test_eof416
 		}
-	stCase416:
+	st_case_416:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st417
 		}
 		goto st0
 	st417:
 		if p++; p == pe {
-			goto _testEof417
+			goto _test_eof417
 		}
-	stCase417:
+	st_case_417:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st418
 		}
 		goto st0
 	st418:
 		if p++; p == pe {
-			goto _testEof418
+			goto _test_eof418
 		}
-	stCase418:
+	st_case_418:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st419
 		}
 		goto st0
 	st419:
 		if p++; p == pe {
-			goto _testEof419
+			goto _test_eof419
 		}
-	stCase419:
+	st_case_419:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st420
 		}
 		goto st0
 	st420:
 		if p++; p == pe {
-			goto _testEof420
+			goto _test_eof420
 		}
-	stCase420:
+	st_case_420:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st421
 		}
 		goto st0
 	st421:
 		if p++; p == pe {
-			goto _testEof421
+			goto _test_eof421
 		}
-	stCase421:
+	st_case_421:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st422
 		}
 		goto st0
 	st422:
 		if p++; p == pe {
-			goto _testEof422
+			goto _test_eof422
 		}
-	stCase422:
+	st_case_422:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st423
 		}
 		goto st0
 	st423:
 		if p++; p == pe {
-			goto _testEof423
+			goto _test_eof423
 		}
-	stCase423:
+	st_case_423:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st424
 		}
 		goto st0
 	st424:
 		if p++; p == pe {
-			goto _testEof424
+			goto _test_eof424
 		}
-	stCase424:
+	st_case_424:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st425
 		}
 		goto st0
 	st425:
 		if p++; p == pe {
-			goto _testEof425
+			goto _test_eof425
 		}
-	stCase425:
+	st_case_425:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st426
 		}
 		goto st0
 	st426:
 		if p++; p == pe {
-			goto _testEof426
+			goto _test_eof426
 		}
-	stCase426:
+	st_case_426:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st427
 		}
 		goto st0
 	st427:
 		if p++; p == pe {
-			goto _testEof427
+			goto _test_eof427
 		}
-	stCase427:
+	st_case_427:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st428
 		}
 		goto st0
 	st428:
 		if p++; p == pe {
-			goto _testEof428
+			goto _test_eof428
 		}
-	stCase428:
+	st_case_428:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st429
 		}
 		goto st0
 	st429:
 		if p++; p == pe {
-			goto _testEof429
+			goto _test_eof429
 		}
-	stCase429:
+	st_case_429:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st430
 		}
 		goto st0
 	st430:
 		if p++; p == pe {
-			goto _testEof430
+			goto _test_eof430
 		}
-	stCase430:
+	st_case_430:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st431
 		}
 		goto st0
 	st431:
 		if p++; p == pe {
-			goto _testEof431
+			goto _test_eof431
 		}
-	stCase431:
+	st_case_431:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st432
 		}
 		goto st0
 	st432:
 		if p++; p == pe {
-			goto _testEof432
+			goto _test_eof432
 		}
-	stCase432:
+	st_case_432:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st433
 		}
 		goto st0
 	st433:
 		if p++; p == pe {
-			goto _testEof433
+			goto _test_eof433
 		}
-	stCase433:
+	st_case_433:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st434
 		}
 		goto st0
 	st434:
 		if p++; p == pe {
-			goto _testEof434
+			goto _test_eof434
 		}
-	stCase434:
+	st_case_434:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st435
 		}
 		goto st0
 	st435:
 		if p++; p == pe {
-			goto _testEof435
+			goto _test_eof435
 		}
-	stCase435:
+	st_case_435:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st436
 		}
 		goto st0
 	st436:
 		if p++; p == pe {
-			goto _testEof436
+			goto _test_eof436
 		}
-	stCase436:
+	st_case_436:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st437
 		}
 		goto st0
 	st437:
 		if p++; p == pe {
-			goto _testEof437
+			goto _test_eof437
 		}
-	stCase437:
+	st_case_437:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st438
 		}
 		goto st0
 	st438:
 		if p++; p == pe {
-			goto _testEof438
+			goto _test_eof438
 		}
-	stCase438:
+	st_case_438:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st439
 		}
 		goto st0
 	st439:
 		if p++; p == pe {
-			goto _testEof439
+			goto _test_eof439
 		}
-	stCase439:
+	st_case_439:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st440
 		}
 		goto st0
 	st440:
 		if p++; p == pe {
-			goto _testEof440
+			goto _test_eof440
 		}
-	stCase440:
+	st_case_440:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st441
 		}
 		goto st0
 	st441:
 		if p++; p == pe {
-			goto _testEof441
+			goto _test_eof441
 		}
-	stCase441:
+	st_case_441:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st442
 		}
 		goto st0
 	st442:
 		if p++; p == pe {
-			goto _testEof442
+			goto _test_eof442
 		}
-	stCase442:
+	st_case_442:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st443
 		}
 		goto st0
 	st443:
 		if p++; p == pe {
-			goto _testEof443
+			goto _test_eof443
 		}
-	stCase443:
+	st_case_443:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st444
 		}
 		goto st0
 	st444:
 		if p++; p == pe {
-			goto _testEof444
+			goto _test_eof444
 		}
-	stCase444:
+	st_case_444:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st445
 		}
 		goto st0
 	st445:
 		if p++; p == pe {
-			goto _testEof445
+			goto _test_eof445
 		}
-	stCase445:
+	st_case_445:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st446
 		}
 		goto st0
 	st446:
 		if p++; p == pe {
-			goto _testEof446
+			goto _test_eof446
 		}
-	stCase446:
+	st_case_446:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st447
 		}
 		goto st0
 	st447:
 		if p++; p == pe {
-			goto _testEof447
+			goto _test_eof447
 		}
-	stCase447:
+	st_case_447:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st448
 		}
 		goto st0
 	st448:
 		if p++; p == pe {
-			goto _testEof448
+			goto _test_eof448
 		}
-	stCase448:
+	st_case_448:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st449
 		}
 		goto st0
 	st449:
 		if p++; p == pe {
-			goto _testEof449
+			goto _test_eof449
 		}
-	stCase449:
+	st_case_449:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st450
 		}
 		goto st0
 	st450:
 		if p++; p == pe {
-			goto _testEof450
+			goto _test_eof450
 		}
-	stCase450:
+	st_case_450:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st451
 		}
 		goto st0
 	st451:
 		if p++; p == pe {
-			goto _testEof451
+			goto _test_eof451
 		}
-	stCase451:
+	st_case_451:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st452
 		}
 		goto st0
 	st452:
 		if p++; p == pe {
-			goto _testEof452
+			goto _test_eof452
 		}
-	stCase452:
+	st_case_452:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st453
 		}
 		goto st0
 	st453:
 		if p++; p == pe {
-			goto _testEof453
+			goto _test_eof453
 		}
-	stCase453:
+	st_case_453:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st454
 		}
 		goto st0
 	st454:
 		if p++; p == pe {
-			goto _testEof454
+			goto _test_eof454
 		}
-	stCase454:
+	st_case_454:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st455
 		}
 		goto st0
 	st455:
 		if p++; p == pe {
-			goto _testEof455
+			goto _test_eof455
 		}
-	stCase455:
+	st_case_455:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st456
 		}
 		goto st0
 	st456:
 		if p++; p == pe {
-			goto _testEof456
+			goto _test_eof456
 		}
-	stCase456:
+	st_case_456:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st457
 		}
 		goto st0
 	st457:
 		if p++; p == pe {
-			goto _testEof457
+			goto _test_eof457
 		}
-	stCase457:
+	st_case_457:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st458
 		}
 		goto st0
 	st458:
 		if p++; p == pe {
-			goto _testEof458
+			goto _test_eof458
 		}
-	stCase458:
+	st_case_458:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st459
 		}
 		goto st0
 	st459:
 		if p++; p == pe {
-			goto _testEof459
+			goto _test_eof459
 		}
-	stCase459:
+	st_case_459:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st460
 		}
 		goto st0
 	st460:
 		if p++; p == pe {
-			goto _testEof460
+			goto _test_eof460
 		}
-	stCase460:
+	st_case_460:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st461
 		}
 		goto st0
 	st461:
 		if p++; p == pe {
-			goto _testEof461
+			goto _test_eof461
 		}
-	stCase461:
+	st_case_461:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st462
 		}
 		goto st0
 	st462:
 		if p++; p == pe {
-			goto _testEof462
+			goto _test_eof462
 		}
-	stCase462:
+	st_case_462:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st463
 		}
 		goto st0
 	st463:
 		if p++; p == pe {
-			goto _testEof463
+			goto _test_eof463
 		}
-	stCase463:
+	st_case_463:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st464
 		}
 		goto st0
 	st464:
 		if p++; p == pe {
-			goto _testEof464
+			goto _test_eof464
 		}
-	stCase464:
+	st_case_464:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st465
 		}
 		goto st0
 	st465:
 		if p++; p == pe {
-			goto _testEof465
+			goto _test_eof465
 		}
-	stCase465:
+	st_case_465:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st466
 		}
 		goto st0
 	st466:
 		if p++; p == pe {
-			goto _testEof466
+			goto _test_eof466
 		}
-	stCase466:
+	st_case_466:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st467
 		}
 		goto st0
 	st467:
 		if p++; p == pe {
-			goto _testEof467
+			goto _test_eof467
 		}
-	stCase467:
+	st_case_467:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st468
 		}
 		goto st0
 	st468:
 		if p++; p == pe {
-			goto _testEof468
+			goto _test_eof468
 		}
-	stCase468:
+	st_case_468:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st469
 		}
 		goto st0
 	st469:
 		if p++; p == pe {
-			goto _testEof469
+			goto _test_eof469
 		}
-	stCase469:
+	st_case_469:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st470
 		}
 		goto st0
 	st470:
 		if p++; p == pe {
-			goto _testEof470
+			goto _test_eof470
 		}
-	stCase470:
+	st_case_470:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st471
 		}
 		goto st0
 	st471:
 		if p++; p == pe {
-			goto _testEof471
+			goto _test_eof471
 		}
-	stCase471:
+	st_case_471:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st472
 		}
 		goto st0
 	st472:
 		if p++; p == pe {
-			goto _testEof472
+			goto _test_eof472
 		}
-	stCase472:
+	st_case_472:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st473
 		}
 		goto st0
 	st473:
 		if p++; p == pe {
-			goto _testEof473
+			goto _test_eof473
 		}
-	stCase473:
+	st_case_473:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st474
 		}
 		goto st0
 	st474:
 		if p++; p == pe {
-			goto _testEof474
+			goto _test_eof474
 		}
-	stCase474:
+	st_case_474:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st475
 		}
 		goto st0
 	st475:
 		if p++; p == pe {
-			goto _testEof475
+			goto _test_eof475
 		}
-	stCase475:
+	st_case_475:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st476
 		}
 		goto st0
 	st476:
 		if p++; p == pe {
-			goto _testEof476
+			goto _test_eof476
 		}
-	stCase476:
+	st_case_476:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st477
 		}
 		goto st0
 	st477:
 		if p++; p == pe {
-			goto _testEof477
+			goto _test_eof477
 		}
-	stCase477:
+	st_case_477:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st478
 		}
 		goto st0
 	st478:
 		if p++; p == pe {
-			goto _testEof478
+			goto _test_eof478
 		}
-	stCase478:
+	st_case_478:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st479
 		}
 		goto st0
 	st479:
 		if p++; p == pe {
-			goto _testEof479
+			goto _test_eof479
 		}
-	stCase479:
+	st_case_479:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st480
 		}
 		goto st0
 	st480:
 		if p++; p == pe {
-			goto _testEof480
+			goto _test_eof480
 		}
-	stCase480:
+	st_case_480:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st481
 		}
 		goto st0
 	st481:
 		if p++; p == pe {
-			goto _testEof481
+			goto _test_eof481
 		}
-	stCase481:
+	st_case_481:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st482
 		}
 		goto st0
 	st482:
 		if p++; p == pe {
-			goto _testEof482
+			goto _test_eof482
 		}
-	stCase482:
+	st_case_482:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st483
 		}
 		goto st0
 	st483:
 		if p++; p == pe {
-			goto _testEof483
+			goto _test_eof483
 		}
-	stCase483:
+	st_case_483:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st484
 		}
 		goto st0
 	st484:
 		if p++; p == pe {
-			goto _testEof484
+			goto _test_eof484
 		}
-	stCase484:
+	st_case_484:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st485
 		}
 		goto st0
 	st485:
 		if p++; p == pe {
-			goto _testEof485
+			goto _test_eof485
 		}
-	stCase485:
+	st_case_485:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st486
 		}
 		goto st0
 	st486:
 		if p++; p == pe {
-			goto _testEof486
+			goto _test_eof486
 		}
-	stCase486:
+	st_case_486:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st487
 		}
 		goto st0
 	st487:
 		if p++; p == pe {
-			goto _testEof487
+			goto _test_eof487
 		}
-	stCase487:
+	st_case_487:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st488
 		}
 		goto st0
 	st488:
 		if p++; p == pe {
-			goto _testEof488
+			goto _test_eof488
 		}
-	stCase488:
+	st_case_488:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st489
 		}
 		goto st0
 	st489:
 		if p++; p == pe {
-			goto _testEof489
+			goto _test_eof489
 		}
-	stCase489:
+	st_case_489:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st490
 		}
 		goto st0
 	st490:
 		if p++; p == pe {
-			goto _testEof490
+			goto _test_eof490
 		}
-	stCase490:
+	st_case_490:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st491
 		}
 		goto st0
 	st491:
 		if p++; p == pe {
-			goto _testEof491
+			goto _test_eof491
 		}
-	stCase491:
+	st_case_491:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st492
 		}
 		goto st0
 	st492:
 		if p++; p == pe {
-			goto _testEof492
+			goto _test_eof492
 		}
-	stCase492:
+	st_case_492:
 		goto st0
-	stCase48:
+	st_case_48:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto tr44
 		}
@@ -5758,290 +5758,290 @@ func (sm *SyslogMessage) set(from entrypoint, value string) *SyslogMessage {
 		goto st493
 	st493:
 		if p++; p == pe {
-			goto _testEof493
+			goto _test_eof493
 		}
-	stCase493:
+	st_case_493:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st494
 		}
 		goto st0
 	st494:
 		if p++; p == pe {
-			goto _testEof494
+			goto _test_eof494
 		}
-	stCase494:
+	st_case_494:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st495
 		}
 		goto st0
 	st495:
 		if p++; p == pe {
-			goto _testEof495
+			goto _test_eof495
 		}
-	stCase495:
+	st_case_495:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st496
 		}
 		goto st0
 	st496:
 		if p++; p == pe {
-			goto _testEof496
+			goto _test_eof496
 		}
-	stCase496:
+	st_case_496:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st497
 		}
 		goto st0
 	st497:
 		if p++; p == pe {
-			goto _testEof497
+			goto _test_eof497
 		}
-	stCase497:
+	st_case_497:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st498
 		}
 		goto st0
 	st498:
 		if p++; p == pe {
-			goto _testEof498
+			goto _test_eof498
 		}
-	stCase498:
+	st_case_498:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st499
 		}
 		goto st0
 	st499:
 		if p++; p == pe {
-			goto _testEof499
+			goto _test_eof499
 		}
-	stCase499:
+	st_case_499:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st500
 		}
 		goto st0
 	st500:
 		if p++; p == pe {
-			goto _testEof500
+			goto _test_eof500
 		}
-	stCase500:
+	st_case_500:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st501
 		}
 		goto st0
 	st501:
 		if p++; p == pe {
-			goto _testEof501
+			goto _test_eof501
 		}
-	stCase501:
+	st_case_501:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st502
 		}
 		goto st0
 	st502:
 		if p++; p == pe {
-			goto _testEof502
+			goto _test_eof502
 		}
-	stCase502:
+	st_case_502:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st503
 		}
 		goto st0
 	st503:
 		if p++; p == pe {
-			goto _testEof503
+			goto _test_eof503
 		}
-	stCase503:
+	st_case_503:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st504
 		}
 		goto st0
 	st504:
 		if p++; p == pe {
-			goto _testEof504
+			goto _test_eof504
 		}
-	stCase504:
+	st_case_504:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st505
 		}
 		goto st0
 	st505:
 		if p++; p == pe {
-			goto _testEof505
+			goto _test_eof505
 		}
-	stCase505:
+	st_case_505:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st506
 		}
 		goto st0
 	st506:
 		if p++; p == pe {
-			goto _testEof506
+			goto _test_eof506
 		}
-	stCase506:
+	st_case_506:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st507
 		}
 		goto st0
 	st507:
 		if p++; p == pe {
-			goto _testEof507
+			goto _test_eof507
 		}
-	stCase507:
+	st_case_507:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st508
 		}
 		goto st0
 	st508:
 		if p++; p == pe {
-			goto _testEof508
+			goto _test_eof508
 		}
-	stCase508:
+	st_case_508:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st509
 		}
 		goto st0
 	st509:
 		if p++; p == pe {
-			goto _testEof509
+			goto _test_eof509
 		}
-	stCase509:
+	st_case_509:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st510
 		}
 		goto st0
 	st510:
 		if p++; p == pe {
-			goto _testEof510
+			goto _test_eof510
 		}
-	stCase510:
+	st_case_510:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st511
 		}
 		goto st0
 	st511:
 		if p++; p == pe {
-			goto _testEof511
+			goto _test_eof511
 		}
-	stCase511:
+	st_case_511:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st512
 		}
 		goto st0
 	st512:
 		if p++; p == pe {
-			goto _testEof512
+			goto _test_eof512
 		}
-	stCase512:
+	st_case_512:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st513
 		}
 		goto st0
 	st513:
 		if p++; p == pe {
-			goto _testEof513
+			goto _test_eof513
 		}
-	stCase513:
+	st_case_513:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st514
 		}
 		goto st0
 	st514:
 		if p++; p == pe {
-			goto _testEof514
+			goto _test_eof514
 		}
-	stCase514:
+	st_case_514:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st515
 		}
 		goto st0
 	st515:
 		if p++; p == pe {
-			goto _testEof515
+			goto _test_eof515
 		}
-	stCase515:
+	st_case_515:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st516
 		}
 		goto st0
 	st516:
 		if p++; p == pe {
-			goto _testEof516
+			goto _test_eof516
 		}
-	stCase516:
+	st_case_516:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st517
 		}
 		goto st0
 	st517:
 		if p++; p == pe {
-			goto _testEof517
+			goto _test_eof517
 		}
-	stCase517:
+	st_case_517:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st518
 		}
 		goto st0
 	st518:
 		if p++; p == pe {
-			goto _testEof518
+			goto _test_eof518
 		}
-	stCase518:
+	st_case_518:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st519
 		}
 		goto st0
 	st519:
 		if p++; p == pe {
-			goto _testEof519
+			goto _test_eof519
 		}
-	stCase519:
+	st_case_519:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st520
 		}
 		goto st0
 	st520:
 		if p++; p == pe {
-			goto _testEof520
+			goto _test_eof520
 		}
-	stCase520:
+	st_case_520:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st521
 		}
 		goto st0
 	st521:
 		if p++; p == pe {
-			goto _testEof521
+			goto _test_eof521
 		}
-	stCase521:
+	st_case_521:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st522
 		}
 		goto st0
 	st522:
 		if p++; p == pe {
-			goto _testEof522
+			goto _test_eof522
 		}
-	stCase522:
+	st_case_522:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st523
 		}
 		goto st0
 	st523:
 		if p++; p == pe {
-			goto _testEof523
+			goto _test_eof523
 		}
-	stCase523:
+	st_case_523:
 		if 33 <= data[p] && data[p] <= 126 {
 			goto st524
 		}
 		goto st0
 	st524:
 		if p++; p == pe {
-			goto _testEof524
+			goto _test_eof524
 		}
-	stCase524:
+	st_case_524:
 		goto st0
-	stCase49:
+	st_case_49:
 		if data[p] == 33 {
 			goto tr45
 		}
@@ -6065,9 +6065,9 @@ func (sm *SyslogMessage) set(from entrypoint, value string) *SyslogMessage {
 		goto st525
 	st525:
 		if p++; p == pe {
-			goto _testEof525
+			goto _test_eof525
 		}
-	stCase525:
+	st_case_525:
 		if data[p] == 33 {
 			goto st526
 		}
@@ -6086,9 +6086,9 @@ func (sm *SyslogMessage) set(from entrypoint, value string) *SyslogMessage {
 		goto st0
 	st526:
 		if p++; p == pe {
-			goto _testEof526
+			goto _test_eof526
 		}
-	stCase526:
+	st_case_526:
 		if data[p] == 33 {
 			goto st527
 		}
@@ -6107,9 +6107,9 @@ func (sm *SyslogMessage) set(from entrypoint, value string) *SyslogMessage {
 		goto st0
 	st527:
 		if p++; p == pe {
-			goto _testEof527
+			goto _test_eof527
 		}
-	stCase527:
+	st_case_527:
 		if data[p] == 33 {
 			goto st528
 		}
@@ -6128,9 +6128,9 @@ func (sm *SyslogMessage) set(from entrypoint, value string) *SyslogMessage {
 		goto st0
 	st528:
 		if p++; p == pe {
-			goto _testEof528
+			goto _test_eof528
 		}
-	stCase528:
+	st_case_528:
 		if data[p] == 33 {
 			goto st529
 		}
@@ -6149,9 +6149,9 @@ func (sm *SyslogMessage) set(from entrypoint, value string) *SyslogMessage {
 		goto st0
 	st529:
 		if p++; p == pe {
-			goto _testEof529
+			goto _test_eof529
 		}
-	stCase529:
+	st_case_529:
 		if data[p] == 33 {
 			goto st530
 		}
@@ -6170,9 +6170,9 @@ func (sm *SyslogMessage) set(from entrypoint, value string) *SyslogMessage {
 		goto st0
 	st530:
 		if p++; p == pe {
-			goto _testEof530
+			goto _test_eof530
 		}
-	stCase530:
+	st_case_530:
 		if data[p] == 33 {
 			goto st531
 		}
@@ -6191,9 +6191,9 @@ func (sm *SyslogMessage) set(from entrypoint, value string) *SyslogMessage {
 		goto st0
 	st531:
 		if p++; p == pe {
-			goto _testEof531
+			goto _test_eof531
 		}
-	stCase531:
+	st_case_531:
 		if data[p] == 33 {
 			goto st532
 		}
@@ -6212,9 +6212,9 @@ func (sm *SyslogMessage) set(from entrypoint, value string) *SyslogMessage {
 		goto st0
 	st532:
 		if p++; p == pe {
-			goto _testEof532
+			goto _test_eof532
 		}
-	stCase532:
+	st_case_532:
 		if data[p] == 33 {
 			goto st533
 		}
@@ -6233,9 +6233,9 @@ func (sm *SyslogMessage) set(from entrypoint, value string) *SyslogMessage {
 		goto st0
 	st533:
 		if p++; p == pe {
-			goto _testEof533
+			goto _test_eof533
 		}
-	stCase533:
+	st_case_533:
 		if data[p] == 33 {
 			goto st534
 		}
@@ -6254,9 +6254,9 @@ func (sm *SyslogMessage) set(from entrypoint, value string) *SyslogMessage {
 		goto st0
 	st534:
 		if p++; p == pe {
-			goto _testEof534
+			goto _test_eof534
 		}
-	stCase534:
+	st_case_534:
 		if data[p] == 33 {
 			goto st535
 		}
@@ -6275,9 +6275,9 @@ func (sm *SyslogMessage) set(from entrypoint, value string) *SyslogMessage {
 		goto st0
 	st535:
 		if p++; p == pe {
-			goto _testEof535
+			goto _test_eof535
 		}
-	stCase535:
+	st_case_535:
 		if data[p] == 33 {
 			goto st536
 		}
@@ -6296,9 +6296,9 @@ func (sm *SyslogMessage) set(from entrypoint, value string) *SyslogMessage {
 		goto st0
 	st536:
 		if p++; p == pe {
-			goto _testEof536
+			goto _test_eof536
 		}
-	stCase536:
+	st_case_536:
 		if data[p] == 33 {
 			goto st537
 		}
@@ -6317,9 +6317,9 @@ func (sm *SyslogMessage) set(from entrypoint, value string) *SyslogMessage {
 		goto st0
 	st537:
 		if p++; p == pe {
-			goto _testEof537
+			goto _test_eof537
 		}
-	stCase537:
+	st_case_537:
 		if data[p] == 33 {
 			goto st538
 		}
@@ -6338,9 +6338,9 @@ func (sm *SyslogMessage) set(from entrypoint, value string) *SyslogMessage {
 		goto st0
 	st538:
 		if p++; p == pe {
-			goto _testEof538
+			goto _test_eof538
 		}
-	stCase538:
+	st_case_538:
 		if data[p] == 33 {
 			goto st539
 		}
@@ -6359,9 +6359,9 @@ func (sm *SyslogMessage) set(from entrypoint, value string) *SyslogMessage {
 		goto st0
 	st539:
 		if p++; p == pe {
-			goto _testEof539
+			goto _test_eof539
 		}
-	stCase539:
+	st_case_539:
 		if data[p] == 33 {
 			goto st540
 		}
@@ -6380,9 +6380,9 @@ func (sm *SyslogMessage) set(from entrypoint, value string) *SyslogMessage {
 		goto st0
 	st540:
 		if p++; p == pe {
-			goto _testEof540
+			goto _test_eof540
 		}
-	stCase540:
+	st_case_540:
 		if data[p] == 33 {
 			goto st541
 		}
@@ -6401,9 +6401,9 @@ func (sm *SyslogMessage) set(from entrypoint, value string) *SyslogMessage {
 		goto st0
 	st541:
 		if p++; p == pe {
-			goto _testEof541
+			goto _test_eof541
 		}
-	stCase541:
+	st_case_541:
 		if data[p] == 33 {
 			goto st542
 		}
@@ -6422,9 +6422,9 @@ func (sm *SyslogMessage) set(from entrypoint, value string) *SyslogMessage {
 		goto st0
 	st542:
 		if p++; p == pe {
-			goto _testEof542
+			goto _test_eof542
 		}
-	stCase542:
+	st_case_542:
 		if data[p] == 33 {
 			goto st543
 		}
@@ -6443,9 +6443,9 @@ func (sm *SyslogMessage) set(from entrypoint, value string) *SyslogMessage {
 		goto st0
 	st543:
 		if p++; p == pe {
-			goto _testEof543
+			goto _test_eof543
 		}
-	stCase543:
+	st_case_543:
 		if data[p] == 33 {
 			goto st544
 		}
@@ -6464,9 +6464,9 @@ func (sm *SyslogMessage) set(from entrypoint, value string) *SyslogMessage {
 		goto st0
 	st544:
 		if p++; p == pe {
-			goto _testEof544
+			goto _test_eof544
 		}
-	stCase544:
+	st_case_544:
 		if data[p] == 33 {
 			goto st545
 		}
@@ -6485,9 +6485,9 @@ func (sm *SyslogMessage) set(from entrypoint, value string) *SyslogMessage {
 		goto st0
 	st545:
 		if p++; p == pe {
-			goto _testEof545
+			goto _test_eof545
 		}
-	stCase545:
+	st_case_545:
 		if data[p] == 33 {
 			goto st546
 		}
@@ -6506,9 +6506,9 @@ func (sm *SyslogMessage) set(from entrypoint, value string) *SyslogMessage {
 		goto st0
 	st546:
 		if p++; p == pe {
-			goto _testEof546
+			goto _test_eof546
 		}
-	stCase546:
+	st_case_546:
 		if data[p] == 33 {
 			goto st547
 		}
@@ -6527,9 +6527,9 @@ func (sm *SyslogMessage) set(from entrypoint, value string) *SyslogMessage {
 		goto st0
 	st547:
 		if p++; p == pe {
-			goto _testEof547
+			goto _test_eof547
 		}
-	stCase547:
+	st_case_547:
 		if data[p] == 33 {
 			goto st548
 		}
@@ -6548,9 +6548,9 @@ func (sm *SyslogMessage) set(from entrypoint, value string) *SyslogMessage {
 		goto st0
 	st548:
 		if p++; p == pe {
-			goto _testEof548
+			goto _test_eof548
 		}
-	stCase548:
+	st_case_548:
 		if data[p] == 33 {
 			goto st549
 		}
@@ -6569,9 +6569,9 @@ func (sm *SyslogMessage) set(from entrypoint, value string) *SyslogMessage {
 		goto st0
 	st549:
 		if p++; p == pe {
-			goto _testEof549
+			goto _test_eof549
 		}
-	stCase549:
+	st_case_549:
 		if data[p] == 33 {
 			goto st550
 		}
@@ -6590,9 +6590,9 @@ func (sm *SyslogMessage) set(from entrypoint, value string) *SyslogMessage {
 		goto st0
 	st550:
 		if p++; p == pe {
-			goto _testEof550
+			goto _test_eof550
 		}
-	stCase550:
+	st_case_550:
 		if data[p] == 33 {
 			goto st551
 		}
@@ -6611,9 +6611,9 @@ func (sm *SyslogMessage) set(from entrypoint, value string) *SyslogMessage {
 		goto st0
 	st551:
 		if p++; p == pe {
-			goto _testEof551
+			goto _test_eof551
 		}
-	stCase551:
+	st_case_551:
 		if data[p] == 33 {
 			goto st552
 		}
@@ -6632,9 +6632,9 @@ func (sm *SyslogMessage) set(from entrypoint, value string) *SyslogMessage {
 		goto st0
 	st552:
 		if p++; p == pe {
-			goto _testEof552
+			goto _test_eof552
 		}
-	stCase552:
+	st_case_552:
 		if data[p] == 33 {
 			goto st553
 		}
@@ -6653,9 +6653,9 @@ func (sm *SyslogMessage) set(from entrypoint, value string) *SyslogMessage {
 		goto st0
 	st553:
 		if p++; p == pe {
-			goto _testEof553
+			goto _test_eof553
 		}
-	stCase553:
+	st_case_553:
 		if data[p] == 33 {
 			goto st554
 		}
@@ -6674,9 +6674,9 @@ func (sm *SyslogMessage) set(from entrypoint, value string) *SyslogMessage {
 		goto st0
 	st554:
 		if p++; p == pe {
-			goto _testEof554
+			goto _test_eof554
 		}
-	stCase554:
+	st_case_554:
 		if data[p] == 33 {
 			goto st555
 		}
@@ -6695,9 +6695,9 @@ func (sm *SyslogMessage) set(from entrypoint, value string) *SyslogMessage {
 		goto st0
 	st555:
 		if p++; p == pe {
-			goto _testEof555
+			goto _test_eof555
 		}
-	stCase555:
+	st_case_555:
 		if data[p] == 33 {
 			goto st556
 		}
@@ -6716,11 +6716,11 @@ func (sm *SyslogMessage) set(from entrypoint, value string) *SyslogMessage {
 		goto st0
 	st556:
 		if p++; p == pe {
-			goto _testEof556
+			goto _test_eof556
 		}
-	stCase556:
+	st_case_556:
 		goto st0
-	stCase50:
+	st_case_50:
 		if data[p] == 33 {
 			goto tr46
 		}
@@ -6744,9 +6744,9 @@ func (sm *SyslogMessage) set(from entrypoint, value string) *SyslogMessage {
 		goto st557
 	st557:
 		if p++; p == pe {
-			goto _testEof557
+			goto _test_eof557
 		}
-	stCase557:
+	st_case_557:
 		if data[p] == 33 {
 			goto st558
 		}
@@ -6765,9 +6765,9 @@ func (sm *SyslogMessage) set(from entrypoint, value string) *SyslogMessage {
 		goto st0
 	st558:
 		if p++; p == pe {
-			goto _testEof558
+			goto _test_eof558
 		}
-	stCase558:
+	st_case_558:
 		if data[p] == 33 {
 			goto st559
 		}
@@ -6786,9 +6786,9 @@ func (sm *SyslogMessage) set(from entrypoint, value string) *SyslogMessage {
 		goto st0
 	st559:
 		if p++; p == pe {
-			goto _testEof559
+			goto _test_eof559
 		}
-	stCase559:
+	st_case_559:
 		if data[p] == 33 {
 			goto st560
 		}
@@ -6807,9 +6807,9 @@ func (sm *SyslogMessage) set(from entrypoint, value string) *SyslogMessage {
 		goto st0
 	st560:
 		if p++; p == pe {
-			goto _testEof560
+			goto _test_eof560
 		}
-	stCase560:
+	st_case_560:
 		if data[p] == 33 {
 			goto st561
 		}
@@ -6828,9 +6828,9 @@ func (sm *SyslogMessage) set(from entrypoint, value string) *SyslogMessage {
 		goto st0
 	st561:
 		if p++; p == pe {
-			goto _testEof561
+			goto _test_eof561
 		}
-	stCase561:
+	st_case_561:
 		if data[p] == 33 {
 			goto st562
 		}
@@ -6849,9 +6849,9 @@ func (sm *SyslogMessage) set(from entrypoint, value string) *SyslogMessage {
 		goto st0
 	st562:
 		if p++; p == pe {
-			goto _testEof562
+			goto _test_eof562
 		}
-	stCase562:
+	st_case_562:
 		if data[p] == 33 {
 			goto st563
 		}
@@ -6870,9 +6870,9 @@ func (sm *SyslogMessage) set(from entrypoint, value string) *SyslogMessage {
 		goto st0
 	st563:
 		if p++; p == pe {
-			goto _testEof563
+			goto _test_eof563
 		}
-	stCase563:
+	st_case_563:
 		if data[p] == 33 {
 			goto st564
 		}
@@ -6891,9 +6891,9 @@ func (sm *SyslogMessage) set(from entrypoint, value string) *SyslogMessage {
 		goto st0
 	st564:
 		if p++; p == pe {
-			goto _testEof564
+			goto _test_eof564
 		}
-	stCase564:
+	st_case_564:
 		if data[p] == 33 {
 			goto st565
 		}
@@ -6912,9 +6912,9 @@ func (sm *SyslogMessage) set(from entrypoint, value string) *SyslogMessage {
 		goto st0
 	st565:
 		if p++; p == pe {
-			goto _testEof565
+			goto _test_eof565
 		}
-	stCase565:
+	st_case_565:
 		if data[p] == 33 {
 			goto st566
 		}
@@ -6933,9 +6933,9 @@ func (sm *SyslogMessage) set(from entrypoint, value string) *SyslogMessage {
 		goto st0
 	st566:
 		if p++; p == pe {
-			goto _testEof566
+			goto _test_eof566
 		}
-	stCase566:
+	st_case_566:
 		if data[p] == 33 {
 			goto st567
 		}
@@ -6954,9 +6954,9 @@ func (sm *SyslogMessage) set(from entrypoint, value string) *SyslogMessage {
 		goto st0
 	st567:
 		if p++; p == pe {
-			goto _testEof567
+			goto _test_eof567
 		}
-	stCase567:
+	st_case_567:
 		if data[p] == 33 {
 			goto st568
 		}
@@ -6975,9 +6975,9 @@ func (sm *SyslogMessage) set(from entrypoint, value string) *SyslogMessage {
 		goto st0
 	st568:
 		if p++; p == pe {
-			goto _testEof568
+			goto _test_eof568
 		}
-	stCase568:
+	st_case_568:
 		if data[p] == 33 {
 			goto st569
 		}
@@ -6996,9 +6996,9 @@ func (sm *SyslogMessage) set(from entrypoint, value string) *SyslogMessage {
 		goto st0
 	st569:
 		if p++; p == pe {
-			goto _testEof569
+			goto _test_eof569
 		}
-	stCase569:
+	st_case_569:
 		if data[p] == 33 {
 			goto st570
 		}
@@ -7017,9 +7017,9 @@ func (sm *SyslogMessage) set(from entrypoint, value string) *SyslogMessage {
 		goto st0
 	st570:
 		if p++; p == pe {
-			goto _testEof570
+			goto _test_eof570
 		}
-	stCase570:
+	st_case_570:
 		if data[p] == 33 {
 			goto st571
 		}
@@ -7038,9 +7038,9 @@ func (sm *SyslogMessage) set(from entrypoint, value string) *SyslogMessage {
 		goto st0
 	st571:
 		if p++; p == pe {
-			goto _testEof571
+			goto _test_eof571
 		}
-	stCase571:
+	st_case_571:
 		if data[p] == 33 {
 			goto st572
 		}
@@ -7059,9 +7059,9 @@ func (sm *SyslogMessage) set(from entrypoint, value string) *SyslogMessage {
 		goto st0
 	st572:
 		if p++; p == pe {
-			goto _testEof572
+			goto _test_eof572
 		}
-	stCase572:
+	st_case_572:
 		if data[p] == 33 {
 			goto st573
 		}
@@ -7080,9 +7080,9 @@ func (sm *SyslogMessage) set(from entrypoint, value string) *SyslogMessage {
 		goto st0
 	st573:
 		if p++; p == pe {
-			goto _testEof573
+			goto _test_eof573
 		}
-	stCase573:
+	st_case_573:
 		if data[p] == 33 {
 			goto st574
 		}
@@ -7101,9 +7101,9 @@ func (sm *SyslogMessage) set(from entrypoint, value string) *SyslogMessage {
 		goto st0
 	st574:
 		if p++; p == pe {
-			goto _testEof574
+			goto _test_eof574
 		}
-	stCase574:
+	st_case_574:
 		if data[p] == 33 {
 			goto st575
 		}
@@ -7122,9 +7122,9 @@ func (sm *SyslogMessage) set(from entrypoint, value string) *SyslogMessage {
 		goto st0
 	st575:
 		if p++; p == pe {
-			goto _testEof575
+			goto _test_eof575
 		}
-	stCase575:
+	st_case_575:
 		if data[p] == 33 {
 			goto st576
 		}
@@ -7143,9 +7143,9 @@ func (sm *SyslogMessage) set(from entrypoint, value string) *SyslogMessage {
 		goto st0
 	st576:
 		if p++; p == pe {
-			goto _testEof576
+			goto _test_eof576
 		}
-	stCase576:
+	st_case_576:
 		if data[p] == 33 {
 			goto st577
 		}
@@ -7164,9 +7164,9 @@ func (sm *SyslogMessage) set(from entrypoint, value string) *SyslogMessage {
 		goto st0
 	st577:
 		if p++; p == pe {
-			goto _testEof577
+			goto _test_eof577
 		}
-	stCase577:
+	st_case_577:
 		if data[p] == 33 {
 			goto st578
 		}
@@ -7185,9 +7185,9 @@ func (sm *SyslogMessage) set(from entrypoint, value string) *SyslogMessage {
 		goto st0
 	st578:
 		if p++; p == pe {
-			goto _testEof578
+			goto _test_eof578
 		}
-	stCase578:
+	st_case_578:
 		if data[p] == 33 {
 			goto st579
 		}
@@ -7206,9 +7206,9 @@ func (sm *SyslogMessage) set(from entrypoint, value string) *SyslogMessage {
 		goto st0
 	st579:
 		if p++; p == pe {
-			goto _testEof579
+			goto _test_eof579
 		}
-	stCase579:
+	st_case_579:
 		if data[p] == 33 {
 			goto st580
 		}
@@ -7227,9 +7227,9 @@ func (sm *SyslogMessage) set(from entrypoint, value string) *SyslogMessage {
 		goto st0
 	st580:
 		if p++; p == pe {
-			goto _testEof580
+			goto _test_eof580
 		}
-	stCase580:
+	st_case_580:
 		if data[p] == 33 {
 			goto st581
 		}
@@ -7248,9 +7248,9 @@ func (sm *SyslogMessage) set(from entrypoint, value string) *SyslogMessage {
 		goto st0
 	st581:
 		if p++; p == pe {
-			goto _testEof581
+			goto _test_eof581
 		}
-	stCase581:
+	st_case_581:
 		if data[p] == 33 {
 			goto st582
 		}
@@ -7269,9 +7269,9 @@ func (sm *SyslogMessage) set(from entrypoint, value string) *SyslogMessage {
 		goto st0
 	st582:
 		if p++; p == pe {
-			goto _testEof582
+			goto _test_eof582
 		}
-	stCase582:
+	st_case_582:
 		if data[p] == 33 {
 			goto st583
 		}
@@ -7290,9 +7290,9 @@ func (sm *SyslogMessage) set(from entrypoint, value string) *SyslogMessage {
 		goto st0
 	st583:
 		if p++; p == pe {
-			goto _testEof583
+			goto _test_eof583
 		}
-	stCase583:
+	st_case_583:
 		if data[p] == 33 {
 			goto st584
 		}
@@ -7311,9 +7311,9 @@ func (sm *SyslogMessage) set(from entrypoint, value string) *SyslogMessage {
 		goto st0
 	st584:
 		if p++; p == pe {
-			goto _testEof584
+			goto _test_eof584
 		}
-	stCase584:
+	st_case_584:
 		if data[p] == 33 {
 			goto st585
 		}
@@ -7332,9 +7332,9 @@ func (sm *SyslogMessage) set(from entrypoint, value string) *SyslogMessage {
 		goto st0
 	st585:
 		if p++; p == pe {
-			goto _testEof585
+			goto _test_eof585
 		}
-	stCase585:
+	st_case_585:
 		if data[p] == 33 {
 			goto st586
 		}
@@ -7353,9 +7353,9 @@ func (sm *SyslogMessage) set(from entrypoint, value string) *SyslogMessage {
 		goto st0
 	st586:
 		if p++; p == pe {
-			goto _testEof586
+			goto _test_eof586
 		}
-	stCase586:
+	st_case_586:
 		if data[p] == 33 {
 			goto st587
 		}
@@ -7374,9 +7374,9 @@ func (sm *SyslogMessage) set(from entrypoint, value string) *SyslogMessage {
 		goto st0
 	st587:
 		if p++; p == pe {
-			goto _testEof587
+			goto _test_eof587
 		}
-	stCase587:
+	st_case_587:
 		if data[p] == 33 {
 			goto st588
 		}
@@ -7395,11 +7395,11 @@ func (sm *SyslogMessage) set(from entrypoint, value string) *SyslogMessage {
 		goto st0
 	st588:
 		if p++; p == pe {
-			goto _testEof588
+			goto _test_eof588
 		}
-	stCase588:
+	st_case_588:
 		goto st0
-	stCase589:
+	st_case_589:
 		switch data[p] {
 		case 34:
 			goto st0
@@ -7446,9 +7446,9 @@ func (sm *SyslogMessage) set(from entrypoint, value string) *SyslogMessage {
 		goto st590
 	st590:
 		if p++; p == pe {
-			goto _testEof590
+			goto _test_eof590
 		}
-	stCase590:
+	st_case_590:
 		switch data[p] {
 		case 34:
 			goto st0
@@ -7502,9 +7502,9 @@ func (sm *SyslogMessage) set(from entrypoint, value string) *SyslogMessage {
 		goto st51
 	st51:
 		if p++; p == pe {
-			goto _testEof51
+			goto _test_eof51
 		}
-	stCase51:
+	st_case_51:
 		if data[p] == 34 {
 			goto st590
 		}
@@ -7519,9 +7519,9 @@ func (sm *SyslogMessage) set(from entrypoint, value string) *SyslogMessage {
 		goto st52
 	st52:
 		if p++; p == pe {
-			goto _testEof52
+			goto _test_eof52
 		}
-	stCase52:
+	st_case_52:
 		if 128 <= data[p] && data[p] <= 191 {
 			goto st590
 		}
@@ -7533,9 +7533,9 @@ func (sm *SyslogMessage) set(from entrypoint, value string) *SyslogMessage {
 		goto st53
 	st53:
 		if p++; p == pe {
-			goto _testEof53
+			goto _test_eof53
 		}
-	stCase53:
+	st_case_53:
 		if 160 <= data[p] && data[p] <= 191 {
 			goto st52
 		}
@@ -7547,9 +7547,9 @@ func (sm *SyslogMessage) set(from entrypoint, value string) *SyslogMessage {
 		goto st54
 	st54:
 		if p++; p == pe {
-			goto _testEof54
+			goto _test_eof54
 		}
-	stCase54:
+	st_case_54:
 		if 128 <= data[p] && data[p] <= 191 {
 			goto st52
 		}
@@ -7561,9 +7561,9 @@ func (sm *SyslogMessage) set(from entrypoint, value string) *SyslogMessage {
 		goto st55
 	st55:
 		if p++; p == pe {
-			goto _testEof55
+			goto _test_eof55
 		}
-	stCase55:
+	st_case_55:
 		if 128 <= data[p] && data[p] <= 159 {
 			goto st52
 		}
@@ -7575,9 +7575,9 @@ func (sm *SyslogMessage) set(from entrypoint, value string) *SyslogMessage {
 		goto st56
 	st56:
 		if p++; p == pe {
-			goto _testEof56
+			goto _test_eof56
 		}
-	stCase56:
+	st_case_56:
 		if 144 <= data[p] && data[p] <= 191 {
 			goto st54
 		}
@@ -7589,9 +7589,9 @@ func (sm *SyslogMessage) set(from entrypoint, value string) *SyslogMessage {
 		goto st57
 	st57:
 		if p++; p == pe {
-			goto _testEof57
+			goto _test_eof57
 		}
-	stCase57:
+	st_case_57:
 		if 128 <= data[p] && data[p] <= 191 {
 			goto st54
 		}
@@ -7603,1759 +7603,1759 @@ func (sm *SyslogMessage) set(from entrypoint, value string) *SyslogMessage {
 		goto st58
 	st58:
 		if p++; p == pe {
-			goto _testEof58
+			goto _test_eof58
 		}
-	stCase58:
+	st_case_58:
 		if 128 <= data[p] && data[p] <= 143 {
 			goto st54
 		}
 		goto st0
-	stOut:
-	_testEof60:
+	st_out:
+	_test_eof60:
 		cs = 60
-		goto _testEof
-	_testEof1:
+		goto _test_eof
+	_test_eof1:
 		cs = 1
-		goto _testEof
-	_testEof2:
+		goto _test_eof
+	_test_eof2:
 		cs = 2
-		goto _testEof
-	_testEof3:
+		goto _test_eof
+	_test_eof3:
 		cs = 3
-		goto _testEof
-	_testEof4:
+		goto _test_eof
+	_test_eof4:
 		cs = 4
-		goto _testEof
-	_testEof5:
+		goto _test_eof
+	_test_eof5:
 		cs = 5
-		goto _testEof
-	_testEof6:
+		goto _test_eof
+	_test_eof6:
 		cs = 6
-		goto _testEof
-	_testEof7:
+		goto _test_eof
+	_test_eof7:
 		cs = 7
-		goto _testEof
-	_testEof9:
+		goto _test_eof
+	_test_eof9:
 		cs = 9
-		goto _testEof
-	_testEof10:
+		goto _test_eof
+	_test_eof10:
 		cs = 10
-		goto _testEof
-	_testEof11:
+		goto _test_eof
+	_test_eof11:
 		cs = 11
-		goto _testEof
-	_testEof12:
+		goto _test_eof
+	_test_eof12:
 		cs = 12
-		goto _testEof
-	_testEof13:
+		goto _test_eof
+	_test_eof13:
 		cs = 13
-		goto _testEof
-	_testEof14:
+		goto _test_eof
+	_test_eof14:
 		cs = 14
-		goto _testEof
-	_testEof15:
+		goto _test_eof
+	_test_eof15:
 		cs = 15
-		goto _testEof
-	_testEof16:
+		goto _test_eof
+	_test_eof16:
 		cs = 16
-		goto _testEof
-	_testEof17:
+		goto _test_eof
+	_test_eof17:
 		cs = 17
-		goto _testEof
-	_testEof18:
+		goto _test_eof
+	_test_eof18:
 		cs = 18
-		goto _testEof
-	_testEof19:
+		goto _test_eof
+	_test_eof19:
 		cs = 19
-		goto _testEof
-	_testEof20:
+		goto _test_eof
+	_test_eof20:
 		cs = 20
-		goto _testEof
-	_testEof21:
+		goto _test_eof
+	_test_eof21:
 		cs = 21
-		goto _testEof
-	_testEof22:
+		goto _test_eof
+	_test_eof22:
 		cs = 22
-		goto _testEof
-	_testEof23:
+		goto _test_eof
+	_test_eof23:
 		cs = 23
-		goto _testEof
-	_testEof24:
+		goto _test_eof
+	_test_eof24:
 		cs = 24
-		goto _testEof
-	_testEof25:
+		goto _test_eof
+	_test_eof25:
 		cs = 25
-		goto _testEof
-	_testEof26:
+		goto _test_eof
+	_test_eof26:
 		cs = 26
-		goto _testEof
-	_testEof27:
+		goto _test_eof
+	_test_eof27:
 		cs = 27
-		goto _testEof
-	_testEof28:
+		goto _test_eof
+	_test_eof28:
 		cs = 28
-		goto _testEof
-	_testEof29:
+		goto _test_eof
+	_test_eof29:
 		cs = 29
-		goto _testEof
-	_testEof30:
+		goto _test_eof
+	_test_eof30:
 		cs = 30
-		goto _testEof
-	_testEof31:
+		goto _test_eof
+	_test_eof31:
 		cs = 31
-		goto _testEof
-	_testEof32:
+		goto _test_eof
+	_test_eof32:
 		cs = 32
-		goto _testEof
-	_testEof61:
+		goto _test_eof
+	_test_eof61:
 		cs = 61
-		goto _testEof
-	_testEof33:
+		goto _test_eof
+	_test_eof33:
 		cs = 33
-		goto _testEof
-	_testEof34:
+		goto _test_eof
+	_test_eof34:
 		cs = 34
-		goto _testEof
-	_testEof35:
+		goto _test_eof
+	_test_eof35:
 		cs = 35
-		goto _testEof
-	_testEof36:
+		goto _test_eof
+	_test_eof36:
 		cs = 36
-		goto _testEof
-	_testEof37:
+		goto _test_eof
+	_test_eof37:
 		cs = 37
-		goto _testEof
-	_testEof38:
+		goto _test_eof
+	_test_eof38:
 		cs = 38
-		goto _testEof
-	_testEof39:
+		goto _test_eof
+	_test_eof39:
 		cs = 39
-		goto _testEof
-	_testEof40:
+		goto _test_eof
+	_test_eof40:
 		cs = 40
-		goto _testEof
-	_testEof41:
+		goto _test_eof
+	_test_eof41:
 		cs = 41
-		goto _testEof
-	_testEof42:
+		goto _test_eof
+	_test_eof42:
 		cs = 42
-		goto _testEof
-	_testEof43:
+		goto _test_eof
+	_test_eof43:
 		cs = 43
-		goto _testEof
-	_testEof44:
+		goto _test_eof
+	_test_eof44:
 		cs = 44
-		goto _testEof
-	_testEof62:
+		goto _test_eof
+	_test_eof62:
 		cs = 62
-		goto _testEof
-	_testEof63:
+		goto _test_eof
+	_test_eof63:
 		cs = 63
-		goto _testEof
-	_testEof64:
+		goto _test_eof
+	_test_eof64:
 		cs = 64
-		goto _testEof
-	_testEof65:
+		goto _test_eof
+	_test_eof65:
 		cs = 65
-		goto _testEof
-	_testEof66:
+		goto _test_eof
+	_test_eof66:
 		cs = 66
-		goto _testEof
-	_testEof67:
+		goto _test_eof
+	_test_eof67:
 		cs = 67
-		goto _testEof
-	_testEof68:
+		goto _test_eof
+	_test_eof68:
 		cs = 68
-		goto _testEof
-	_testEof69:
+		goto _test_eof
+	_test_eof69:
 		cs = 69
-		goto _testEof
-	_testEof70:
+		goto _test_eof
+	_test_eof70:
 		cs = 70
-		goto _testEof
-	_testEof71:
+		goto _test_eof
+	_test_eof71:
 		cs = 71
-		goto _testEof
-	_testEof72:
+		goto _test_eof
+	_test_eof72:
 		cs = 72
-		goto _testEof
-	_testEof73:
+		goto _test_eof
+	_test_eof73:
 		cs = 73
-		goto _testEof
-	_testEof74:
+		goto _test_eof
+	_test_eof74:
 		cs = 74
-		goto _testEof
-	_testEof75:
+		goto _test_eof
+	_test_eof75:
 		cs = 75
-		goto _testEof
-	_testEof76:
+		goto _test_eof
+	_test_eof76:
 		cs = 76
-		goto _testEof
-	_testEof77:
+		goto _test_eof
+	_test_eof77:
 		cs = 77
-		goto _testEof
-	_testEof78:
+		goto _test_eof
+	_test_eof78:
 		cs = 78
-		goto _testEof
-	_testEof79:
+		goto _test_eof
+	_test_eof79:
 		cs = 79
-		goto _testEof
-	_testEof80:
+		goto _test_eof
+	_test_eof80:
 		cs = 80
-		goto _testEof
-	_testEof81:
+		goto _test_eof
+	_test_eof81:
 		cs = 81
-		goto _testEof
-	_testEof82:
+		goto _test_eof
+	_test_eof82:
 		cs = 82
-		goto _testEof
-	_testEof83:
+		goto _test_eof
+	_test_eof83:
 		cs = 83
-		goto _testEof
-	_testEof84:
+		goto _test_eof
+	_test_eof84:
 		cs = 84
-		goto _testEof
-	_testEof85:
+		goto _test_eof
+	_test_eof85:
 		cs = 85
-		goto _testEof
-	_testEof86:
+		goto _test_eof
+	_test_eof86:
 		cs = 86
-		goto _testEof
-	_testEof87:
+		goto _test_eof
+	_test_eof87:
 		cs = 87
-		goto _testEof
-	_testEof88:
+		goto _test_eof
+	_test_eof88:
 		cs = 88
-		goto _testEof
-	_testEof89:
+		goto _test_eof
+	_test_eof89:
 		cs = 89
-		goto _testEof
-	_testEof90:
+		goto _test_eof
+	_test_eof90:
 		cs = 90
-		goto _testEof
-	_testEof91:
+		goto _test_eof
+	_test_eof91:
 		cs = 91
-		goto _testEof
-	_testEof92:
+		goto _test_eof
+	_test_eof92:
 		cs = 92
-		goto _testEof
-	_testEof93:
+		goto _test_eof
+	_test_eof93:
 		cs = 93
-		goto _testEof
-	_testEof94:
+		goto _test_eof
+	_test_eof94:
 		cs = 94
-		goto _testEof
-	_testEof95:
+		goto _test_eof
+	_test_eof95:
 		cs = 95
-		goto _testEof
-	_testEof96:
+		goto _test_eof
+	_test_eof96:
 		cs = 96
-		goto _testEof
-	_testEof97:
+		goto _test_eof
+	_test_eof97:
 		cs = 97
-		goto _testEof
-	_testEof98:
+		goto _test_eof
+	_test_eof98:
 		cs = 98
-		goto _testEof
-	_testEof99:
+		goto _test_eof
+	_test_eof99:
 		cs = 99
-		goto _testEof
-	_testEof100:
+		goto _test_eof
+	_test_eof100:
 		cs = 100
-		goto _testEof
-	_testEof101:
+		goto _test_eof
+	_test_eof101:
 		cs = 101
-		goto _testEof
-	_testEof102:
+		goto _test_eof
+	_test_eof102:
 		cs = 102
-		goto _testEof
-	_testEof103:
+		goto _test_eof
+	_test_eof103:
 		cs = 103
-		goto _testEof
-	_testEof104:
+		goto _test_eof
+	_test_eof104:
 		cs = 104
-		goto _testEof
-	_testEof105:
+		goto _test_eof
+	_test_eof105:
 		cs = 105
-		goto _testEof
-	_testEof106:
+		goto _test_eof
+	_test_eof106:
 		cs = 106
-		goto _testEof
-	_testEof107:
+		goto _test_eof
+	_test_eof107:
 		cs = 107
-		goto _testEof
-	_testEof108:
+		goto _test_eof
+	_test_eof108:
 		cs = 108
-		goto _testEof
-	_testEof109:
+		goto _test_eof
+	_test_eof109:
 		cs = 109
-		goto _testEof
-	_testEof110:
+		goto _test_eof
+	_test_eof110:
 		cs = 110
-		goto _testEof
-	_testEof111:
+		goto _test_eof
+	_test_eof111:
 		cs = 111
-		goto _testEof
-	_testEof112:
+		goto _test_eof
+	_test_eof112:
 		cs = 112
-		goto _testEof
-	_testEof113:
+		goto _test_eof
+	_test_eof113:
 		cs = 113
-		goto _testEof
-	_testEof114:
+		goto _test_eof
+	_test_eof114:
 		cs = 114
-		goto _testEof
-	_testEof115:
+		goto _test_eof
+	_test_eof115:
 		cs = 115
-		goto _testEof
-	_testEof116:
+		goto _test_eof
+	_test_eof116:
 		cs = 116
-		goto _testEof
-	_testEof117:
+		goto _test_eof
+	_test_eof117:
 		cs = 117
-		goto _testEof
-	_testEof118:
+		goto _test_eof
+	_test_eof118:
 		cs = 118
-		goto _testEof
-	_testEof119:
+		goto _test_eof
+	_test_eof119:
 		cs = 119
-		goto _testEof
-	_testEof120:
+		goto _test_eof
+	_test_eof120:
 		cs = 120
-		goto _testEof
-	_testEof121:
+		goto _test_eof
+	_test_eof121:
 		cs = 121
-		goto _testEof
-	_testEof122:
+		goto _test_eof
+	_test_eof122:
 		cs = 122
-		goto _testEof
-	_testEof123:
+		goto _test_eof
+	_test_eof123:
 		cs = 123
-		goto _testEof
-	_testEof124:
+		goto _test_eof
+	_test_eof124:
 		cs = 124
-		goto _testEof
-	_testEof125:
+		goto _test_eof
+	_test_eof125:
 		cs = 125
-		goto _testEof
-	_testEof126:
+		goto _test_eof
+	_test_eof126:
 		cs = 126
-		goto _testEof
-	_testEof127:
+		goto _test_eof
+	_test_eof127:
 		cs = 127
-		goto _testEof
-	_testEof128:
+		goto _test_eof
+	_test_eof128:
 		cs = 128
-		goto _testEof
-	_testEof129:
+		goto _test_eof
+	_test_eof129:
 		cs = 129
-		goto _testEof
-	_testEof130:
+		goto _test_eof
+	_test_eof130:
 		cs = 130
-		goto _testEof
-	_testEof131:
+		goto _test_eof
+	_test_eof131:
 		cs = 131
-		goto _testEof
-	_testEof132:
+		goto _test_eof
+	_test_eof132:
 		cs = 132
-		goto _testEof
-	_testEof133:
+		goto _test_eof
+	_test_eof133:
 		cs = 133
-		goto _testEof
-	_testEof134:
+		goto _test_eof
+	_test_eof134:
 		cs = 134
-		goto _testEof
-	_testEof135:
+		goto _test_eof
+	_test_eof135:
 		cs = 135
-		goto _testEof
-	_testEof136:
+		goto _test_eof
+	_test_eof136:
 		cs = 136
-		goto _testEof
-	_testEof137:
+		goto _test_eof
+	_test_eof137:
 		cs = 137
-		goto _testEof
-	_testEof138:
+		goto _test_eof
+	_test_eof138:
 		cs = 138
-		goto _testEof
-	_testEof139:
+		goto _test_eof
+	_test_eof139:
 		cs = 139
-		goto _testEof
-	_testEof140:
+		goto _test_eof
+	_test_eof140:
 		cs = 140
-		goto _testEof
-	_testEof141:
+		goto _test_eof
+	_test_eof141:
 		cs = 141
-		goto _testEof
-	_testEof142:
+		goto _test_eof
+	_test_eof142:
 		cs = 142
-		goto _testEof
-	_testEof143:
+		goto _test_eof
+	_test_eof143:
 		cs = 143
-		goto _testEof
-	_testEof144:
+		goto _test_eof
+	_test_eof144:
 		cs = 144
-		goto _testEof
-	_testEof145:
+		goto _test_eof
+	_test_eof145:
 		cs = 145
-		goto _testEof
-	_testEof146:
+		goto _test_eof
+	_test_eof146:
 		cs = 146
-		goto _testEof
-	_testEof147:
+		goto _test_eof
+	_test_eof147:
 		cs = 147
-		goto _testEof
-	_testEof148:
+		goto _test_eof
+	_test_eof148:
 		cs = 148
-		goto _testEof
-	_testEof149:
+		goto _test_eof
+	_test_eof149:
 		cs = 149
-		goto _testEof
-	_testEof150:
+		goto _test_eof
+	_test_eof150:
 		cs = 150
-		goto _testEof
-	_testEof151:
+		goto _test_eof
+	_test_eof151:
 		cs = 151
-		goto _testEof
-	_testEof152:
+		goto _test_eof
+	_test_eof152:
 		cs = 152
-		goto _testEof
-	_testEof153:
+		goto _test_eof
+	_test_eof153:
 		cs = 153
-		goto _testEof
-	_testEof154:
+		goto _test_eof
+	_test_eof154:
 		cs = 154
-		goto _testEof
-	_testEof155:
+		goto _test_eof
+	_test_eof155:
 		cs = 155
-		goto _testEof
-	_testEof156:
+		goto _test_eof
+	_test_eof156:
 		cs = 156
-		goto _testEof
-	_testEof157:
+		goto _test_eof
+	_test_eof157:
 		cs = 157
-		goto _testEof
-	_testEof158:
+		goto _test_eof
+	_test_eof158:
 		cs = 158
-		goto _testEof
-	_testEof159:
+		goto _test_eof
+	_test_eof159:
 		cs = 159
-		goto _testEof
-	_testEof160:
+		goto _test_eof
+	_test_eof160:
 		cs = 160
-		goto _testEof
-	_testEof161:
+		goto _test_eof
+	_test_eof161:
 		cs = 161
-		goto _testEof
-	_testEof162:
+		goto _test_eof
+	_test_eof162:
 		cs = 162
-		goto _testEof
-	_testEof163:
+		goto _test_eof
+	_test_eof163:
 		cs = 163
-		goto _testEof
-	_testEof164:
+		goto _test_eof
+	_test_eof164:
 		cs = 164
-		goto _testEof
-	_testEof165:
+		goto _test_eof
+	_test_eof165:
 		cs = 165
-		goto _testEof
-	_testEof166:
+		goto _test_eof
+	_test_eof166:
 		cs = 166
-		goto _testEof
-	_testEof167:
+		goto _test_eof
+	_test_eof167:
 		cs = 167
-		goto _testEof
-	_testEof168:
+		goto _test_eof
+	_test_eof168:
 		cs = 168
-		goto _testEof
-	_testEof169:
+		goto _test_eof
+	_test_eof169:
 		cs = 169
-		goto _testEof
-	_testEof170:
+		goto _test_eof
+	_test_eof170:
 		cs = 170
-		goto _testEof
-	_testEof171:
+		goto _test_eof
+	_test_eof171:
 		cs = 171
-		goto _testEof
-	_testEof172:
+		goto _test_eof
+	_test_eof172:
 		cs = 172
-		goto _testEof
-	_testEof173:
+		goto _test_eof
+	_test_eof173:
 		cs = 173
-		goto _testEof
-	_testEof174:
+		goto _test_eof
+	_test_eof174:
 		cs = 174
-		goto _testEof
-	_testEof175:
+		goto _test_eof
+	_test_eof175:
 		cs = 175
-		goto _testEof
-	_testEof176:
+		goto _test_eof
+	_test_eof176:
 		cs = 176
-		goto _testEof
-	_testEof177:
+		goto _test_eof
+	_test_eof177:
 		cs = 177
-		goto _testEof
-	_testEof178:
+		goto _test_eof
+	_test_eof178:
 		cs = 178
-		goto _testEof
-	_testEof179:
+		goto _test_eof
+	_test_eof179:
 		cs = 179
-		goto _testEof
-	_testEof180:
+		goto _test_eof
+	_test_eof180:
 		cs = 180
-		goto _testEof
-	_testEof181:
+		goto _test_eof
+	_test_eof181:
 		cs = 181
-		goto _testEof
-	_testEof182:
+		goto _test_eof
+	_test_eof182:
 		cs = 182
-		goto _testEof
-	_testEof183:
+		goto _test_eof
+	_test_eof183:
 		cs = 183
-		goto _testEof
-	_testEof184:
+		goto _test_eof
+	_test_eof184:
 		cs = 184
-		goto _testEof
-	_testEof185:
+		goto _test_eof
+	_test_eof185:
 		cs = 185
-		goto _testEof
-	_testEof186:
+		goto _test_eof
+	_test_eof186:
 		cs = 186
-		goto _testEof
-	_testEof187:
+		goto _test_eof
+	_test_eof187:
 		cs = 187
-		goto _testEof
-	_testEof188:
+		goto _test_eof
+	_test_eof188:
 		cs = 188
-		goto _testEof
-	_testEof189:
+		goto _test_eof
+	_test_eof189:
 		cs = 189
-		goto _testEof
-	_testEof190:
+		goto _test_eof
+	_test_eof190:
 		cs = 190
-		goto _testEof
-	_testEof191:
+		goto _test_eof
+	_test_eof191:
 		cs = 191
-		goto _testEof
-	_testEof192:
+		goto _test_eof
+	_test_eof192:
 		cs = 192
-		goto _testEof
-	_testEof193:
+		goto _test_eof
+	_test_eof193:
 		cs = 193
-		goto _testEof
-	_testEof194:
+		goto _test_eof
+	_test_eof194:
 		cs = 194
-		goto _testEof
-	_testEof195:
+		goto _test_eof
+	_test_eof195:
 		cs = 195
-		goto _testEof
-	_testEof196:
+		goto _test_eof
+	_test_eof196:
 		cs = 196
-		goto _testEof
-	_testEof197:
+		goto _test_eof
+	_test_eof197:
 		cs = 197
-		goto _testEof
-	_testEof198:
+		goto _test_eof
+	_test_eof198:
 		cs = 198
-		goto _testEof
-	_testEof199:
+		goto _test_eof
+	_test_eof199:
 		cs = 199
-		goto _testEof
-	_testEof200:
+		goto _test_eof
+	_test_eof200:
 		cs = 200
-		goto _testEof
-	_testEof201:
+		goto _test_eof
+	_test_eof201:
 		cs = 201
-		goto _testEof
-	_testEof202:
+		goto _test_eof
+	_test_eof202:
 		cs = 202
-		goto _testEof
-	_testEof203:
+		goto _test_eof
+	_test_eof203:
 		cs = 203
-		goto _testEof
-	_testEof204:
+		goto _test_eof
+	_test_eof204:
 		cs = 204
-		goto _testEof
-	_testEof205:
+		goto _test_eof
+	_test_eof205:
 		cs = 205
-		goto _testEof
-	_testEof206:
+		goto _test_eof
+	_test_eof206:
 		cs = 206
-		goto _testEof
-	_testEof207:
+		goto _test_eof
+	_test_eof207:
 		cs = 207
-		goto _testEof
-	_testEof208:
+		goto _test_eof
+	_test_eof208:
 		cs = 208
-		goto _testEof
-	_testEof209:
+		goto _test_eof
+	_test_eof209:
 		cs = 209
-		goto _testEof
-	_testEof210:
+		goto _test_eof
+	_test_eof210:
 		cs = 210
-		goto _testEof
-	_testEof211:
+		goto _test_eof
+	_test_eof211:
 		cs = 211
-		goto _testEof
-	_testEof212:
+		goto _test_eof
+	_test_eof212:
 		cs = 212
-		goto _testEof
-	_testEof213:
+		goto _test_eof
+	_test_eof213:
 		cs = 213
-		goto _testEof
-	_testEof214:
+		goto _test_eof
+	_test_eof214:
 		cs = 214
-		goto _testEof
-	_testEof215:
+		goto _test_eof
+	_test_eof215:
 		cs = 215
-		goto _testEof
-	_testEof216:
+		goto _test_eof
+	_test_eof216:
 		cs = 216
-		goto _testEof
-	_testEof217:
+		goto _test_eof
+	_test_eof217:
 		cs = 217
-		goto _testEof
-	_testEof218:
+		goto _test_eof
+	_test_eof218:
 		cs = 218
-		goto _testEof
-	_testEof219:
+		goto _test_eof
+	_test_eof219:
 		cs = 219
-		goto _testEof
-	_testEof220:
+		goto _test_eof
+	_test_eof220:
 		cs = 220
-		goto _testEof
-	_testEof221:
+		goto _test_eof
+	_test_eof221:
 		cs = 221
-		goto _testEof
-	_testEof222:
+		goto _test_eof
+	_test_eof222:
 		cs = 222
-		goto _testEof
-	_testEof223:
+		goto _test_eof
+	_test_eof223:
 		cs = 223
-		goto _testEof
-	_testEof224:
+		goto _test_eof
+	_test_eof224:
 		cs = 224
-		goto _testEof
-	_testEof225:
+		goto _test_eof
+	_test_eof225:
 		cs = 225
-		goto _testEof
-	_testEof226:
+		goto _test_eof
+	_test_eof226:
 		cs = 226
-		goto _testEof
-	_testEof227:
+		goto _test_eof
+	_test_eof227:
 		cs = 227
-		goto _testEof
-	_testEof228:
+		goto _test_eof
+	_test_eof228:
 		cs = 228
-		goto _testEof
-	_testEof229:
+		goto _test_eof
+	_test_eof229:
 		cs = 229
-		goto _testEof
-	_testEof230:
+		goto _test_eof
+	_test_eof230:
 		cs = 230
-		goto _testEof
-	_testEof231:
+		goto _test_eof
+	_test_eof231:
 		cs = 231
-		goto _testEof
-	_testEof232:
+		goto _test_eof
+	_test_eof232:
 		cs = 232
-		goto _testEof
-	_testEof233:
+		goto _test_eof
+	_test_eof233:
 		cs = 233
-		goto _testEof
-	_testEof234:
+		goto _test_eof
+	_test_eof234:
 		cs = 234
-		goto _testEof
-	_testEof235:
+		goto _test_eof
+	_test_eof235:
 		cs = 235
-		goto _testEof
-	_testEof236:
+		goto _test_eof
+	_test_eof236:
 		cs = 236
-		goto _testEof
-	_testEof237:
+		goto _test_eof
+	_test_eof237:
 		cs = 237
-		goto _testEof
-	_testEof238:
+		goto _test_eof
+	_test_eof238:
 		cs = 238
-		goto _testEof
-	_testEof239:
+		goto _test_eof
+	_test_eof239:
 		cs = 239
-		goto _testEof
-	_testEof240:
+		goto _test_eof
+	_test_eof240:
 		cs = 240
-		goto _testEof
-	_testEof241:
+		goto _test_eof
+	_test_eof241:
 		cs = 241
-		goto _testEof
-	_testEof242:
+		goto _test_eof
+	_test_eof242:
 		cs = 242
-		goto _testEof
-	_testEof243:
+		goto _test_eof
+	_test_eof243:
 		cs = 243
-		goto _testEof
-	_testEof244:
+		goto _test_eof
+	_test_eof244:
 		cs = 244
-		goto _testEof
-	_testEof245:
+		goto _test_eof
+	_test_eof245:
 		cs = 245
-		goto _testEof
-	_testEof246:
+		goto _test_eof
+	_test_eof246:
 		cs = 246
-		goto _testEof
-	_testEof247:
+		goto _test_eof
+	_test_eof247:
 		cs = 247
-		goto _testEof
-	_testEof248:
+		goto _test_eof
+	_test_eof248:
 		cs = 248
-		goto _testEof
-	_testEof249:
+		goto _test_eof
+	_test_eof249:
 		cs = 249
-		goto _testEof
-	_testEof250:
+		goto _test_eof
+	_test_eof250:
 		cs = 250
-		goto _testEof
-	_testEof251:
+		goto _test_eof
+	_test_eof251:
 		cs = 251
-		goto _testEof
-	_testEof252:
+		goto _test_eof
+	_test_eof252:
 		cs = 252
-		goto _testEof
-	_testEof253:
+		goto _test_eof
+	_test_eof253:
 		cs = 253
-		goto _testEof
-	_testEof254:
+		goto _test_eof
+	_test_eof254:
 		cs = 254
-		goto _testEof
-	_testEof255:
+		goto _test_eof
+	_test_eof255:
 		cs = 255
-		goto _testEof
-	_testEof256:
+		goto _test_eof
+	_test_eof256:
 		cs = 256
-		goto _testEof
-	_testEof257:
+		goto _test_eof
+	_test_eof257:
 		cs = 257
-		goto _testEof
-	_testEof258:
+		goto _test_eof
+	_test_eof258:
 		cs = 258
-		goto _testEof
-	_testEof259:
+		goto _test_eof
+	_test_eof259:
 		cs = 259
-		goto _testEof
-	_testEof260:
+		goto _test_eof
+	_test_eof260:
 		cs = 260
-		goto _testEof
-	_testEof261:
+		goto _test_eof
+	_test_eof261:
 		cs = 261
-		goto _testEof
-	_testEof262:
+		goto _test_eof
+	_test_eof262:
 		cs = 262
-		goto _testEof
-	_testEof263:
+		goto _test_eof
+	_test_eof263:
 		cs = 263
-		goto _testEof
-	_testEof264:
+		goto _test_eof
+	_test_eof264:
 		cs = 264
-		goto _testEof
-	_testEof265:
+		goto _test_eof
+	_test_eof265:
 		cs = 265
-		goto _testEof
-	_testEof266:
+		goto _test_eof
+	_test_eof266:
 		cs = 266
-		goto _testEof
-	_testEof267:
+		goto _test_eof
+	_test_eof267:
 		cs = 267
-		goto _testEof
-	_testEof268:
+		goto _test_eof
+	_test_eof268:
 		cs = 268
-		goto _testEof
-	_testEof269:
+		goto _test_eof
+	_test_eof269:
 		cs = 269
-		goto _testEof
-	_testEof270:
+		goto _test_eof
+	_test_eof270:
 		cs = 270
-		goto _testEof
-	_testEof271:
+		goto _test_eof
+	_test_eof271:
 		cs = 271
-		goto _testEof
-	_testEof272:
+		goto _test_eof
+	_test_eof272:
 		cs = 272
-		goto _testEof
-	_testEof273:
+		goto _test_eof
+	_test_eof273:
 		cs = 273
-		goto _testEof
-	_testEof274:
+		goto _test_eof
+	_test_eof274:
 		cs = 274
-		goto _testEof
-	_testEof275:
+		goto _test_eof
+	_test_eof275:
 		cs = 275
-		goto _testEof
-	_testEof276:
+		goto _test_eof
+	_test_eof276:
 		cs = 276
-		goto _testEof
-	_testEof277:
+		goto _test_eof
+	_test_eof277:
 		cs = 277
-		goto _testEof
-	_testEof278:
+		goto _test_eof
+	_test_eof278:
 		cs = 278
-		goto _testEof
-	_testEof279:
+		goto _test_eof
+	_test_eof279:
 		cs = 279
-		goto _testEof
-	_testEof280:
+		goto _test_eof
+	_test_eof280:
 		cs = 280
-		goto _testEof
-	_testEof281:
+		goto _test_eof
+	_test_eof281:
 		cs = 281
-		goto _testEof
-	_testEof282:
+		goto _test_eof
+	_test_eof282:
 		cs = 282
-		goto _testEof
-	_testEof283:
+		goto _test_eof
+	_test_eof283:
 		cs = 283
-		goto _testEof
-	_testEof284:
+		goto _test_eof
+	_test_eof284:
 		cs = 284
-		goto _testEof
-	_testEof285:
+		goto _test_eof
+	_test_eof285:
 		cs = 285
-		goto _testEof
-	_testEof286:
+		goto _test_eof
+	_test_eof286:
 		cs = 286
-		goto _testEof
-	_testEof287:
+		goto _test_eof
+	_test_eof287:
 		cs = 287
-		goto _testEof
-	_testEof288:
+		goto _test_eof
+	_test_eof288:
 		cs = 288
-		goto _testEof
-	_testEof289:
+		goto _test_eof
+	_test_eof289:
 		cs = 289
-		goto _testEof
-	_testEof290:
+		goto _test_eof
+	_test_eof290:
 		cs = 290
-		goto _testEof
-	_testEof291:
+		goto _test_eof
+	_test_eof291:
 		cs = 291
-		goto _testEof
-	_testEof292:
+		goto _test_eof
+	_test_eof292:
 		cs = 292
-		goto _testEof
-	_testEof293:
+		goto _test_eof
+	_test_eof293:
 		cs = 293
-		goto _testEof
-	_testEof294:
+		goto _test_eof
+	_test_eof294:
 		cs = 294
-		goto _testEof
-	_testEof295:
+		goto _test_eof
+	_test_eof295:
 		cs = 295
-		goto _testEof
-	_testEof296:
+		goto _test_eof
+	_test_eof296:
 		cs = 296
-		goto _testEof
-	_testEof297:
+		goto _test_eof
+	_test_eof297:
 		cs = 297
-		goto _testEof
-	_testEof298:
+		goto _test_eof
+	_test_eof298:
 		cs = 298
-		goto _testEof
-	_testEof299:
+		goto _test_eof
+	_test_eof299:
 		cs = 299
-		goto _testEof
-	_testEof300:
+		goto _test_eof
+	_test_eof300:
 		cs = 300
-		goto _testEof
-	_testEof301:
+		goto _test_eof
+	_test_eof301:
 		cs = 301
-		goto _testEof
-	_testEof302:
+		goto _test_eof
+	_test_eof302:
 		cs = 302
-		goto _testEof
-	_testEof303:
+		goto _test_eof
+	_test_eof303:
 		cs = 303
-		goto _testEof
-	_testEof304:
+		goto _test_eof
+	_test_eof304:
 		cs = 304
-		goto _testEof
-	_testEof305:
+		goto _test_eof
+	_test_eof305:
 		cs = 305
-		goto _testEof
-	_testEof306:
+		goto _test_eof
+	_test_eof306:
 		cs = 306
-		goto _testEof
-	_testEof307:
+		goto _test_eof
+	_test_eof307:
 		cs = 307
-		goto _testEof
-	_testEof308:
+		goto _test_eof
+	_test_eof308:
 		cs = 308
-		goto _testEof
-	_testEof309:
+		goto _test_eof
+	_test_eof309:
 		cs = 309
-		goto _testEof
-	_testEof310:
+		goto _test_eof
+	_test_eof310:
 		cs = 310
-		goto _testEof
-	_testEof311:
+		goto _test_eof
+	_test_eof311:
 		cs = 311
-		goto _testEof
-	_testEof312:
+		goto _test_eof
+	_test_eof312:
 		cs = 312
-		goto _testEof
-	_testEof313:
+		goto _test_eof
+	_test_eof313:
 		cs = 313
-		goto _testEof
-	_testEof314:
+		goto _test_eof
+	_test_eof314:
 		cs = 314
-		goto _testEof
-	_testEof315:
+		goto _test_eof
+	_test_eof315:
 		cs = 315
-		goto _testEof
-	_testEof316:
+		goto _test_eof
+	_test_eof316:
 		cs = 316
-		goto _testEof
-	_testEof317:
+		goto _test_eof
+	_test_eof317:
 		cs = 317
-		goto _testEof
-	_testEof318:
+		goto _test_eof
+	_test_eof318:
 		cs = 318
-		goto _testEof
-	_testEof319:
+		goto _test_eof
+	_test_eof319:
 		cs = 319
-		goto _testEof
-	_testEof320:
+		goto _test_eof
+	_test_eof320:
 		cs = 320
-		goto _testEof
-	_testEof321:
+		goto _test_eof
+	_test_eof321:
 		cs = 321
-		goto _testEof
-	_testEof322:
+		goto _test_eof
+	_test_eof322:
 		cs = 322
-		goto _testEof
-	_testEof323:
+		goto _test_eof
+	_test_eof323:
 		cs = 323
-		goto _testEof
-	_testEof324:
+		goto _test_eof
+	_test_eof324:
 		cs = 324
-		goto _testEof
-	_testEof325:
+		goto _test_eof
+	_test_eof325:
 		cs = 325
-		goto _testEof
-	_testEof326:
+		goto _test_eof
+	_test_eof326:
 		cs = 326
-		goto _testEof
-	_testEof327:
+		goto _test_eof
+	_test_eof327:
 		cs = 327
-		goto _testEof
-	_testEof328:
+		goto _test_eof
+	_test_eof328:
 		cs = 328
-		goto _testEof
-	_testEof329:
+		goto _test_eof
+	_test_eof329:
 		cs = 329
-		goto _testEof
-	_testEof330:
+		goto _test_eof
+	_test_eof330:
 		cs = 330
-		goto _testEof
-	_testEof331:
+		goto _test_eof
+	_test_eof331:
 		cs = 331
-		goto _testEof
-	_testEof332:
+		goto _test_eof
+	_test_eof332:
 		cs = 332
-		goto _testEof
-	_testEof333:
+		goto _test_eof
+	_test_eof333:
 		cs = 333
-		goto _testEof
-	_testEof334:
+		goto _test_eof
+	_test_eof334:
 		cs = 334
-		goto _testEof
-	_testEof335:
+		goto _test_eof
+	_test_eof335:
 		cs = 335
-		goto _testEof
-	_testEof336:
+		goto _test_eof
+	_test_eof336:
 		cs = 336
-		goto _testEof
-	_testEof337:
+		goto _test_eof
+	_test_eof337:
 		cs = 337
-		goto _testEof
-	_testEof338:
+		goto _test_eof
+	_test_eof338:
 		cs = 338
-		goto _testEof
-	_testEof339:
+		goto _test_eof
+	_test_eof339:
 		cs = 339
-		goto _testEof
-	_testEof340:
+		goto _test_eof
+	_test_eof340:
 		cs = 340
-		goto _testEof
-	_testEof341:
+		goto _test_eof
+	_test_eof341:
 		cs = 341
-		goto _testEof
-	_testEof342:
+		goto _test_eof
+	_test_eof342:
 		cs = 342
-		goto _testEof
-	_testEof343:
+		goto _test_eof
+	_test_eof343:
 		cs = 343
-		goto _testEof
-	_testEof344:
+		goto _test_eof
+	_test_eof344:
 		cs = 344
-		goto _testEof
-	_testEof345:
+		goto _test_eof
+	_test_eof345:
 		cs = 345
-		goto _testEof
-	_testEof346:
+		goto _test_eof
+	_test_eof346:
 		cs = 346
-		goto _testEof
-	_testEof347:
+		goto _test_eof
+	_test_eof347:
 		cs = 347
-		goto _testEof
-	_testEof348:
+		goto _test_eof
+	_test_eof348:
 		cs = 348
-		goto _testEof
-	_testEof349:
+		goto _test_eof
+	_test_eof349:
 		cs = 349
-		goto _testEof
-	_testEof350:
+		goto _test_eof
+	_test_eof350:
 		cs = 350
-		goto _testEof
-	_testEof351:
+		goto _test_eof
+	_test_eof351:
 		cs = 351
-		goto _testEof
-	_testEof352:
+		goto _test_eof
+	_test_eof352:
 		cs = 352
-		goto _testEof
-	_testEof353:
+		goto _test_eof
+	_test_eof353:
 		cs = 353
-		goto _testEof
-	_testEof354:
+		goto _test_eof
+	_test_eof354:
 		cs = 354
-		goto _testEof
-	_testEof355:
+		goto _test_eof
+	_test_eof355:
 		cs = 355
-		goto _testEof
-	_testEof356:
+		goto _test_eof
+	_test_eof356:
 		cs = 356
-		goto _testEof
-	_testEof357:
+		goto _test_eof
+	_test_eof357:
 		cs = 357
-		goto _testEof
-	_testEof358:
+		goto _test_eof
+	_test_eof358:
 		cs = 358
-		goto _testEof
-	_testEof359:
+		goto _test_eof
+	_test_eof359:
 		cs = 359
-		goto _testEof
-	_testEof360:
+		goto _test_eof
+	_test_eof360:
 		cs = 360
-		goto _testEof
-	_testEof361:
+		goto _test_eof
+	_test_eof361:
 		cs = 361
-		goto _testEof
-	_testEof362:
+		goto _test_eof
+	_test_eof362:
 		cs = 362
-		goto _testEof
-	_testEof363:
+		goto _test_eof
+	_test_eof363:
 		cs = 363
-		goto _testEof
-	_testEof364:
+		goto _test_eof
+	_test_eof364:
 		cs = 364
-		goto _testEof
-	_testEof365:
+		goto _test_eof
+	_test_eof365:
 		cs = 365
-		goto _testEof
-	_testEof366:
+		goto _test_eof
+	_test_eof366:
 		cs = 366
-		goto _testEof
-	_testEof367:
+		goto _test_eof
+	_test_eof367:
 		cs = 367
-		goto _testEof
-	_testEof368:
+		goto _test_eof
+	_test_eof368:
 		cs = 368
-		goto _testEof
-	_testEof369:
+		goto _test_eof
+	_test_eof369:
 		cs = 369
-		goto _testEof
-	_testEof370:
+		goto _test_eof
+	_test_eof370:
 		cs = 370
-		goto _testEof
-	_testEof371:
+		goto _test_eof
+	_test_eof371:
 		cs = 371
-		goto _testEof
-	_testEof372:
+		goto _test_eof
+	_test_eof372:
 		cs = 372
-		goto _testEof
-	_testEof373:
+		goto _test_eof
+	_test_eof373:
 		cs = 373
-		goto _testEof
-	_testEof374:
+		goto _test_eof
+	_test_eof374:
 		cs = 374
-		goto _testEof
-	_testEof375:
+		goto _test_eof
+	_test_eof375:
 		cs = 375
-		goto _testEof
-	_testEof376:
+		goto _test_eof
+	_test_eof376:
 		cs = 376
-		goto _testEof
-	_testEof377:
+		goto _test_eof
+	_test_eof377:
 		cs = 377
-		goto _testEof
-	_testEof378:
+		goto _test_eof
+	_test_eof378:
 		cs = 378
-		goto _testEof
-	_testEof379:
+		goto _test_eof
+	_test_eof379:
 		cs = 379
-		goto _testEof
-	_testEof380:
+		goto _test_eof
+	_test_eof380:
 		cs = 380
-		goto _testEof
-	_testEof381:
+		goto _test_eof
+	_test_eof381:
 		cs = 381
-		goto _testEof
-	_testEof382:
+		goto _test_eof
+	_test_eof382:
 		cs = 382
-		goto _testEof
-	_testEof383:
+		goto _test_eof
+	_test_eof383:
 		cs = 383
-		goto _testEof
-	_testEof384:
+		goto _test_eof
+	_test_eof384:
 		cs = 384
-		goto _testEof
-	_testEof385:
+		goto _test_eof
+	_test_eof385:
 		cs = 385
-		goto _testEof
-	_testEof386:
+		goto _test_eof
+	_test_eof386:
 		cs = 386
-		goto _testEof
-	_testEof387:
+		goto _test_eof
+	_test_eof387:
 		cs = 387
-		goto _testEof
-	_testEof388:
+		goto _test_eof
+	_test_eof388:
 		cs = 388
-		goto _testEof
-	_testEof389:
+		goto _test_eof
+	_test_eof389:
 		cs = 389
-		goto _testEof
-	_testEof390:
+		goto _test_eof
+	_test_eof390:
 		cs = 390
-		goto _testEof
-	_testEof391:
+		goto _test_eof
+	_test_eof391:
 		cs = 391
-		goto _testEof
-	_testEof392:
+		goto _test_eof
+	_test_eof392:
 		cs = 392
-		goto _testEof
-	_testEof393:
+		goto _test_eof
+	_test_eof393:
 		cs = 393
-		goto _testEof
-	_testEof394:
+		goto _test_eof
+	_test_eof394:
 		cs = 394
-		goto _testEof
-	_testEof395:
+		goto _test_eof
+	_test_eof395:
 		cs = 395
-		goto _testEof
-	_testEof396:
+		goto _test_eof
+	_test_eof396:
 		cs = 396
-		goto _testEof
-	_testEof397:
+		goto _test_eof
+	_test_eof397:
 		cs = 397
-		goto _testEof
-	_testEof398:
+		goto _test_eof
+	_test_eof398:
 		cs = 398
-		goto _testEof
-	_testEof399:
+		goto _test_eof
+	_test_eof399:
 		cs = 399
-		goto _testEof
-	_testEof400:
+		goto _test_eof
+	_test_eof400:
 		cs = 400
-		goto _testEof
-	_testEof401:
+		goto _test_eof
+	_test_eof401:
 		cs = 401
-		goto _testEof
-	_testEof402:
+		goto _test_eof
+	_test_eof402:
 		cs = 402
-		goto _testEof
-	_testEof403:
+		goto _test_eof
+	_test_eof403:
 		cs = 403
-		goto _testEof
-	_testEof404:
+		goto _test_eof
+	_test_eof404:
 		cs = 404
-		goto _testEof
-	_testEof405:
+		goto _test_eof
+	_test_eof405:
 		cs = 405
-		goto _testEof
-	_testEof406:
+		goto _test_eof
+	_test_eof406:
 		cs = 406
-		goto _testEof
-	_testEof407:
+		goto _test_eof
+	_test_eof407:
 		cs = 407
-		goto _testEof
-	_testEof408:
+		goto _test_eof
+	_test_eof408:
 		cs = 408
-		goto _testEof
-	_testEof409:
+		goto _test_eof
+	_test_eof409:
 		cs = 409
-		goto _testEof
-	_testEof410:
+		goto _test_eof
+	_test_eof410:
 		cs = 410
-		goto _testEof
-	_testEof411:
+		goto _test_eof
+	_test_eof411:
 		cs = 411
-		goto _testEof
-	_testEof412:
+		goto _test_eof
+	_test_eof412:
 		cs = 412
-		goto _testEof
-	_testEof413:
+		goto _test_eof
+	_test_eof413:
 		cs = 413
-		goto _testEof
-	_testEof414:
+		goto _test_eof
+	_test_eof414:
 		cs = 414
-		goto _testEof
-	_testEof415:
+		goto _test_eof
+	_test_eof415:
 		cs = 415
-		goto _testEof
-	_testEof416:
+		goto _test_eof
+	_test_eof416:
 		cs = 416
-		goto _testEof
-	_testEof417:
+		goto _test_eof
+	_test_eof417:
 		cs = 417
-		goto _testEof
-	_testEof418:
+		goto _test_eof
+	_test_eof418:
 		cs = 418
-		goto _testEof
-	_testEof419:
+		goto _test_eof
+	_test_eof419:
 		cs = 419
-		goto _testEof
-	_testEof420:
+		goto _test_eof
+	_test_eof420:
 		cs = 420
-		goto _testEof
-	_testEof421:
+		goto _test_eof
+	_test_eof421:
 		cs = 421
-		goto _testEof
-	_testEof422:
+		goto _test_eof
+	_test_eof422:
 		cs = 422
-		goto _testEof
-	_testEof423:
+		goto _test_eof
+	_test_eof423:
 		cs = 423
-		goto _testEof
-	_testEof424:
+		goto _test_eof
+	_test_eof424:
 		cs = 424
-		goto _testEof
-	_testEof425:
+		goto _test_eof
+	_test_eof425:
 		cs = 425
-		goto _testEof
-	_testEof426:
+		goto _test_eof
+	_test_eof426:
 		cs = 426
-		goto _testEof
-	_testEof427:
+		goto _test_eof
+	_test_eof427:
 		cs = 427
-		goto _testEof
-	_testEof428:
+		goto _test_eof
+	_test_eof428:
 		cs = 428
-		goto _testEof
-	_testEof429:
+		goto _test_eof
+	_test_eof429:
 		cs = 429
-		goto _testEof
-	_testEof430:
+		goto _test_eof
+	_test_eof430:
 		cs = 430
-		goto _testEof
-	_testEof431:
+		goto _test_eof
+	_test_eof431:
 		cs = 431
-		goto _testEof
-	_testEof432:
+		goto _test_eof
+	_test_eof432:
 		cs = 432
-		goto _testEof
-	_testEof433:
+		goto _test_eof
+	_test_eof433:
 		cs = 433
-		goto _testEof
-	_testEof434:
+		goto _test_eof
+	_test_eof434:
 		cs = 434
-		goto _testEof
-	_testEof435:
+		goto _test_eof
+	_test_eof435:
 		cs = 435
-		goto _testEof
-	_testEof436:
+		goto _test_eof
+	_test_eof436:
 		cs = 436
-		goto _testEof
-	_testEof437:
+		goto _test_eof
+	_test_eof437:
 		cs = 437
-		goto _testEof
-	_testEof438:
+		goto _test_eof
+	_test_eof438:
 		cs = 438
-		goto _testEof
-	_testEof439:
+		goto _test_eof
+	_test_eof439:
 		cs = 439
-		goto _testEof
-	_testEof440:
+		goto _test_eof
+	_test_eof440:
 		cs = 440
-		goto _testEof
-	_testEof441:
+		goto _test_eof
+	_test_eof441:
 		cs = 441
-		goto _testEof
-	_testEof442:
+		goto _test_eof
+	_test_eof442:
 		cs = 442
-		goto _testEof
-	_testEof443:
+		goto _test_eof
+	_test_eof443:
 		cs = 443
-		goto _testEof
-	_testEof444:
+		goto _test_eof
+	_test_eof444:
 		cs = 444
-		goto _testEof
-	_testEof445:
+		goto _test_eof
+	_test_eof445:
 		cs = 445
-		goto _testEof
-	_testEof446:
+		goto _test_eof
+	_test_eof446:
 		cs = 446
-		goto _testEof
-	_testEof447:
+		goto _test_eof
+	_test_eof447:
 		cs = 447
-		goto _testEof
-	_testEof448:
+		goto _test_eof
+	_test_eof448:
 		cs = 448
-		goto _testEof
-	_testEof449:
+		goto _test_eof
+	_test_eof449:
 		cs = 449
-		goto _testEof
-	_testEof450:
+		goto _test_eof
+	_test_eof450:
 		cs = 450
-		goto _testEof
-	_testEof451:
+		goto _test_eof
+	_test_eof451:
 		cs = 451
-		goto _testEof
-	_testEof452:
+		goto _test_eof
+	_test_eof452:
 		cs = 452
-		goto _testEof
-	_testEof453:
+		goto _test_eof
+	_test_eof453:
 		cs = 453
-		goto _testEof
-	_testEof454:
+		goto _test_eof
+	_test_eof454:
 		cs = 454
-		goto _testEof
-	_testEof455:
+		goto _test_eof
+	_test_eof455:
 		cs = 455
-		goto _testEof
-	_testEof456:
+		goto _test_eof
+	_test_eof456:
 		cs = 456
-		goto _testEof
-	_testEof457:
+		goto _test_eof
+	_test_eof457:
 		cs = 457
-		goto _testEof
-	_testEof458:
+		goto _test_eof
+	_test_eof458:
 		cs = 458
-		goto _testEof
-	_testEof459:
+		goto _test_eof
+	_test_eof459:
 		cs = 459
-		goto _testEof
-	_testEof460:
+		goto _test_eof
+	_test_eof460:
 		cs = 460
-		goto _testEof
-	_testEof461:
+		goto _test_eof
+	_test_eof461:
 		cs = 461
-		goto _testEof
-	_testEof462:
+		goto _test_eof
+	_test_eof462:
 		cs = 462
-		goto _testEof
-	_testEof463:
+		goto _test_eof
+	_test_eof463:
 		cs = 463
-		goto _testEof
-	_testEof464:
+		goto _test_eof
+	_test_eof464:
 		cs = 464
-		goto _testEof
-	_testEof465:
+		goto _test_eof
+	_test_eof465:
 		cs = 465
-		goto _testEof
-	_testEof466:
+		goto _test_eof
+	_test_eof466:
 		cs = 466
-		goto _testEof
-	_testEof467:
+		goto _test_eof
+	_test_eof467:
 		cs = 467
-		goto _testEof
-	_testEof468:
+		goto _test_eof
+	_test_eof468:
 		cs = 468
-		goto _testEof
-	_testEof469:
+		goto _test_eof
+	_test_eof469:
 		cs = 469
-		goto _testEof
-	_testEof470:
+		goto _test_eof
+	_test_eof470:
 		cs = 470
-		goto _testEof
-	_testEof471:
+		goto _test_eof
+	_test_eof471:
 		cs = 471
-		goto _testEof
-	_testEof472:
+		goto _test_eof
+	_test_eof472:
 		cs = 472
-		goto _testEof
-	_testEof473:
+		goto _test_eof
+	_test_eof473:
 		cs = 473
-		goto _testEof
-	_testEof474:
+		goto _test_eof
+	_test_eof474:
 		cs = 474
-		goto _testEof
-	_testEof475:
+		goto _test_eof
+	_test_eof475:
 		cs = 475
-		goto _testEof
-	_testEof476:
+		goto _test_eof
+	_test_eof476:
 		cs = 476
-		goto _testEof
-	_testEof477:
+		goto _test_eof
+	_test_eof477:
 		cs = 477
-		goto _testEof
-	_testEof478:
+		goto _test_eof
+	_test_eof478:
 		cs = 478
-		goto _testEof
-	_testEof479:
+		goto _test_eof
+	_test_eof479:
 		cs = 479
-		goto _testEof
-	_testEof480:
+		goto _test_eof
+	_test_eof480:
 		cs = 480
-		goto _testEof
-	_testEof481:
+		goto _test_eof
+	_test_eof481:
 		cs = 481
-		goto _testEof
-	_testEof482:
+		goto _test_eof
+	_test_eof482:
 		cs = 482
-		goto _testEof
-	_testEof483:
+		goto _test_eof
+	_test_eof483:
 		cs = 483
-		goto _testEof
-	_testEof484:
+		goto _test_eof
+	_test_eof484:
 		cs = 484
-		goto _testEof
-	_testEof485:
+		goto _test_eof
+	_test_eof485:
 		cs = 485
-		goto _testEof
-	_testEof486:
+		goto _test_eof
+	_test_eof486:
 		cs = 486
-		goto _testEof
-	_testEof487:
+		goto _test_eof
+	_test_eof487:
 		cs = 487
-		goto _testEof
-	_testEof488:
+		goto _test_eof
+	_test_eof488:
 		cs = 488
-		goto _testEof
-	_testEof489:
+		goto _test_eof
+	_test_eof489:
 		cs = 489
-		goto _testEof
-	_testEof490:
+		goto _test_eof
+	_test_eof490:
 		cs = 490
-		goto _testEof
-	_testEof491:
+		goto _test_eof
+	_test_eof491:
 		cs = 491
-		goto _testEof
-	_testEof492:
+		goto _test_eof
+	_test_eof492:
 		cs = 492
-		goto _testEof
-	_testEof493:
+		goto _test_eof
+	_test_eof493:
 		cs = 493
-		goto _testEof
-	_testEof494:
+		goto _test_eof
+	_test_eof494:
 		cs = 494
-		goto _testEof
-	_testEof495:
+		goto _test_eof
+	_test_eof495:
 		cs = 495
-		goto _testEof
-	_testEof496:
+		goto _test_eof
+	_test_eof496:
 		cs = 496
-		goto _testEof
-	_testEof497:
+		goto _test_eof
+	_test_eof497:
 		cs = 497
-		goto _testEof
-	_testEof498:
+		goto _test_eof
+	_test_eof498:
 		cs = 498
-		goto _testEof
-	_testEof499:
+		goto _test_eof
+	_test_eof499:
 		cs = 499
-		goto _testEof
-	_testEof500:
+		goto _test_eof
+	_test_eof500:
 		cs = 500
-		goto _testEof
-	_testEof501:
+		goto _test_eof
+	_test_eof501:
 		cs = 501
-		goto _testEof
-	_testEof502:
+		goto _test_eof
+	_test_eof502:
 		cs = 502
-		goto _testEof
-	_testEof503:
+		goto _test_eof
+	_test_eof503:
 		cs = 503
-		goto _testEof
-	_testEof504:
+		goto _test_eof
+	_test_eof504:
 		cs = 504
-		goto _testEof
-	_testEof505:
+		goto _test_eof
+	_test_eof505:
 		cs = 505
-		goto _testEof
-	_testEof506:
+		goto _test_eof
+	_test_eof506:
 		cs = 506
-		goto _testEof
-	_testEof507:
+		goto _test_eof
+	_test_eof507:
 		cs = 507
-		goto _testEof
-	_testEof508:
+		goto _test_eof
+	_test_eof508:
 		cs = 508
-		goto _testEof
-	_testEof509:
+		goto _test_eof
+	_test_eof509:
 		cs = 509
-		goto _testEof
-	_testEof510:
+		goto _test_eof
+	_test_eof510:
 		cs = 510
-		goto _testEof
-	_testEof511:
+		goto _test_eof
+	_test_eof511:
 		cs = 511
-		goto _testEof
-	_testEof512:
+		goto _test_eof
+	_test_eof512:
 		cs = 512
-		goto _testEof
-	_testEof513:
+		goto _test_eof
+	_test_eof513:
 		cs = 513
-		goto _testEof
-	_testEof514:
+		goto _test_eof
+	_test_eof514:
 		cs = 514
-		goto _testEof
-	_testEof515:
+		goto _test_eof
+	_test_eof515:
 		cs = 515
-		goto _testEof
-	_testEof516:
+		goto _test_eof
+	_test_eof516:
 		cs = 516
-		goto _testEof
-	_testEof517:
+		goto _test_eof
+	_test_eof517:
 		cs = 517
-		goto _testEof
-	_testEof518:
+		goto _test_eof
+	_test_eof518:
 		cs = 518
-		goto _testEof
-	_testEof519:
+		goto _test_eof
+	_test_eof519:
 		cs = 519
-		goto _testEof
-	_testEof520:
+		goto _test_eof
+	_test_eof520:
 		cs = 520
-		goto _testEof
-	_testEof521:
+		goto _test_eof
+	_test_eof521:
 		cs = 521
-		goto _testEof
-	_testEof522:
+		goto _test_eof
+	_test_eof522:
 		cs = 522
-		goto _testEof
-	_testEof523:
+		goto _test_eof
+	_test_eof523:
 		cs = 523
-		goto _testEof
-	_testEof524:
+		goto _test_eof
+	_test_eof524:
 		cs = 524
-		goto _testEof
-	_testEof525:
+		goto _test_eof
+	_test_eof525:
 		cs = 525
-		goto _testEof
-	_testEof526:
+		goto _test_eof
+	_test_eof526:
 		cs = 526
-		goto _testEof
-	_testEof527:
+		goto _test_eof
+	_test_eof527:
 		cs = 527
-		goto _testEof
-	_testEof528:
+		goto _test_eof
+	_test_eof528:
 		cs = 528
-		goto _testEof
-	_testEof529:
+		goto _test_eof
+	_test_eof529:
 		cs = 529
-		goto _testEof
-	_testEof530:
+		goto _test_eof
+	_test_eof530:
 		cs = 530
-		goto _testEof
-	_testEof531:
+		goto _test_eof
+	_test_eof531:
 		cs = 531
-		goto _testEof
-	_testEof532:
+		goto _test_eof
+	_test_eof532:
 		cs = 532
-		goto _testEof
-	_testEof533:
+		goto _test_eof
+	_test_eof533:
 		cs = 533
-		goto _testEof
-	_testEof534:
+		goto _test_eof
+	_test_eof534:
 		cs = 534
-		goto _testEof
-	_testEof535:
+		goto _test_eof
+	_test_eof535:
 		cs = 535
-		goto _testEof
-	_testEof536:
+		goto _test_eof
+	_test_eof536:
 		cs = 536
-		goto _testEof
-	_testEof537:
+		goto _test_eof
+	_test_eof537:
 		cs = 537
-		goto _testEof
-	_testEof538:
+		goto _test_eof
+	_test_eof538:
 		cs = 538
-		goto _testEof
-	_testEof539:
+		goto _test_eof
+	_test_eof539:
 		cs = 539
-		goto _testEof
-	_testEof540:
+		goto _test_eof
+	_test_eof540:
 		cs = 540
-		goto _testEof
-	_testEof541:
+		goto _test_eof
+	_test_eof541:
 		cs = 541
-		goto _testEof
-	_testEof542:
+		goto _test_eof
+	_test_eof542:
 		cs = 542
-		goto _testEof
-	_testEof543:
+		goto _test_eof
+	_test_eof543:
 		cs = 543
-		goto _testEof
-	_testEof544:
+		goto _test_eof
+	_test_eof544:
 		cs = 544
-		goto _testEof
-	_testEof545:
+		goto _test_eof
+	_test_eof545:
 		cs = 545
-		goto _testEof
-	_testEof546:
+		goto _test_eof
+	_test_eof546:
 		cs = 546
-		goto _testEof
-	_testEof547:
+		goto _test_eof
+	_test_eof547:
 		cs = 547
-		goto _testEof
-	_testEof548:
+		goto _test_eof
+	_test_eof548:
 		cs = 548
-		goto _testEof
-	_testEof549:
+		goto _test_eof
+	_test_eof549:
 		cs = 549
-		goto _testEof
-	_testEof550:
+		goto _test_eof
+	_test_eof550:
 		cs = 550
-		goto _testEof
-	_testEof551:
+		goto _test_eof
+	_test_eof551:
 		cs = 551
-		goto _testEof
-	_testEof552:
+		goto _test_eof
+	_test_eof552:
 		cs = 552
-		goto _testEof
-	_testEof553:
+		goto _test_eof
+	_test_eof553:
 		cs = 553
-		goto _testEof
-	_testEof554:
+		goto _test_eof
+	_test_eof554:
 		cs = 554
-		goto _testEof
-	_testEof555:
+		goto _test_eof
+	_test_eof555:
 		cs = 555
-		goto _testEof
-	_testEof556:
+		goto _test_eof
+	_test_eof556:
 		cs = 556
-		goto _testEof
-	_testEof557:
+		goto _test_eof
+	_test_eof557:
 		cs = 557
-		goto _testEof
-	_testEof558:
+		goto _test_eof
+	_test_eof558:
 		cs = 558
-		goto _testEof
-	_testEof559:
+		goto _test_eof
+	_test_eof559:
 		cs = 559
-		goto _testEof
-	_testEof560:
+		goto _test_eof
+	_test_eof560:
 		cs = 560
-		goto _testEof
-	_testEof561:
+		goto _test_eof
+	_test_eof561:
 		cs = 561
-		goto _testEof
-	_testEof562:
+		goto _test_eof
+	_test_eof562:
 		cs = 562
-		goto _testEof
-	_testEof563:
+		goto _test_eof
+	_test_eof563:
 		cs = 563
-		goto _testEof
-	_testEof564:
+		goto _test_eof
+	_test_eof564:
 		cs = 564
-		goto _testEof
-	_testEof565:
+		goto _test_eof
+	_test_eof565:
 		cs = 565
-		goto _testEof
-	_testEof566:
+		goto _test_eof
+	_test_eof566:
 		cs = 566
-		goto _testEof
-	_testEof567:
+		goto _test_eof
+	_test_eof567:
 		cs = 567
-		goto _testEof
-	_testEof568:
+		goto _test_eof
+	_test_eof568:
 		cs = 568
-		goto _testEof
-	_testEof569:
+		goto _test_eof
+	_test_eof569:
 		cs = 569
-		goto _testEof
-	_testEof570:
+		goto _test_eof
+	_test_eof570:
 		cs = 570
-		goto _testEof
-	_testEof571:
+		goto _test_eof
+	_test_eof571:
 		cs = 571
-		goto _testEof
-	_testEof572:
+		goto _test_eof
+	_test_eof572:
 		cs = 572
-		goto _testEof
-	_testEof573:
+		goto _test_eof
+	_test_eof573:
 		cs = 573
-		goto _testEof
-	_testEof574:
+		goto _test_eof
+	_test_eof574:
 		cs = 574
-		goto _testEof
-	_testEof575:
+		goto _test_eof
+	_test_eof575:
 		cs = 575
-		goto _testEof
-	_testEof576:
+		goto _test_eof
+	_test_eof576:
 		cs = 576
-		goto _testEof
-	_testEof577:
+		goto _test_eof
+	_test_eof577:
 		cs = 577
-		goto _testEof
-	_testEof578:
+		goto _test_eof
+	_test_eof578:
 		cs = 578
-		goto _testEof
-	_testEof579:
+		goto _test_eof
+	_test_eof579:
 		cs = 579
-		goto _testEof
-	_testEof580:
+		goto _test_eof
+	_test_eof580:
 		cs = 580
-		goto _testEof
-	_testEof581:
+		goto _test_eof
+	_test_eof581:
 		cs = 581
-		goto _testEof
-	_testEof582:
+		goto _test_eof
+	_test_eof582:
 		cs = 582
-		goto _testEof
-	_testEof583:
+		goto _test_eof
+	_test_eof583:
 		cs = 583
-		goto _testEof
-	_testEof584:
+		goto _test_eof
+	_test_eof584:
 		cs = 584
-		goto _testEof
-	_testEof585:
+		goto _test_eof
+	_test_eof585:
 		cs = 585
-		goto _testEof
-	_testEof586:
+		goto _test_eof
+	_test_eof586:
 		cs = 586
-		goto _testEof
-	_testEof587:
+		goto _test_eof
+	_test_eof587:
 		cs = 587
-		goto _testEof
-	_testEof588:
+		goto _test_eof
+	_test_eof588:
 		cs = 588
-		goto _testEof
-	_testEof590:
+		goto _test_eof
+	_test_eof590:
 		cs = 590
-		goto _testEof
-	_testEof51:
+		goto _test_eof
+	_test_eof51:
 		cs = 51
-		goto _testEof
-	_testEof52:
+		goto _test_eof
+	_test_eof52:
 		cs = 52
-		goto _testEof
-	_testEof53:
+		goto _test_eof
+	_test_eof53:
 		cs = 53
-		goto _testEof
-	_testEof54:
+		goto _test_eof
+	_test_eof54:
 		cs = 54
-		goto _testEof
-	_testEof55:
+		goto _test_eof
+	_test_eof55:
 		cs = 55
-		goto _testEof
-	_testEof56:
+		goto _test_eof
+	_test_eof56:
 		cs = 56
-		goto _testEof
-	_testEof57:
+		goto _test_eof
+	_test_eof57:
 		cs = 57
-		goto _testEof
-	_testEof58:
+		goto _test_eof
+	_test_eof58:
 		cs = 58
-		goto _testEof
+		goto _test_eof
 
-	_testEof:
+	_test_eof:
 		{
 		}
 		if p == eof {

--- a/rfc5424/builder.go.rl
+++ b/rfc5424/builder.go.rl
@@ -5,7 +5,7 @@ import (
     "sort"
     "fmt"
 
-    "github.com/influxdata/go-syslog/v2/common"
+    "github.com/influxdata/go-syslog/common"
 )
 
 %%{

--- a/rfc5424/builder_test.go
+++ b/rfc5424/builder_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/influxdata/go-syslog/v2"
+	"github.com/influxdata/go-syslog"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/rfc5424/machine.go
+++ b/rfc5424/machine.go
@@ -1,4 +1,3 @@
-//line rfc5424/machine.go.rl:1
 package rfc5424
 
 import (
@@ -48,16 +47,11 @@ const (
 // RFC3339MICRO represents the timestamp format that RFC5424 mandates.
 const RFC3339MICRO = "2006-01-02T15:04:05.999999Z07:00"
 
-//line rfc5424/machine.go.rl:299
-
-//line rfc5424/machine.go:58
 const start int = 1
-const first_final int = 603
+const firstFinal int = 603
 
-const en_fail int = 607
-const en_main int = 1
-
-//line rfc5424/machine.go.rl:302
+const enFail int = 607
+const enMain int = 1
 
 type machine struct {
 	data         []byte
@@ -79,16 +73,6 @@ func NewMachine(options ...syslog.MachineOption) syslog.Machine {
 	for _, opt := range options {
 		opt(m)
 	}
-
-//line rfc5424/machine.go.rl:325
-
-//line rfc5424/machine.go.rl:326
-
-//line rfc5424/machine.go.rl:327
-
-//line rfc5424/machine.go.rl:328
-
-//line rfc5424/machine.go.rl:329
 
 	return m
 }
@@ -131,1244 +115,1239 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 	m.err = nil
 	output := &syslogMessage{}
 
-//line rfc5424/machine.go:142
 	{
 		m.cs = start
 	}
 
-//line rfc5424/machine.go.rl:372
-
-//line rfc5424/machine.go:149
 	{
 		if (m.p) == (m.pe) {
-			goto _test_eof
+			goto _testEof
 		}
 		switch m.cs {
 		case 1:
-			goto st_case_1
+			goto stCase1
 		case 0:
-			goto st_case_0
+			goto stCase0
 		case 2:
-			goto st_case_2
+			goto stCase2
 		case 3:
-			goto st_case_3
+			goto stCase3
 		case 4:
-			goto st_case_4
+			goto stCase4
 		case 5:
-			goto st_case_5
+			goto stCase5
 		case 6:
-			goto st_case_6
+			goto stCase6
 		case 7:
-			goto st_case_7
+			goto stCase7
 		case 8:
-			goto st_case_8
+			goto stCase8
 		case 9:
-			goto st_case_9
+			goto stCase9
 		case 10:
-			goto st_case_10
+			goto stCase10
 		case 11:
-			goto st_case_11
+			goto stCase11
 		case 12:
-			goto st_case_12
+			goto stCase12
 		case 13:
-			goto st_case_13
+			goto stCase13
 		case 14:
-			goto st_case_14
+			goto stCase14
 		case 15:
-			goto st_case_15
+			goto stCase15
 		case 16:
-			goto st_case_16
+			goto stCase16
 		case 603:
-			goto st_case_603
+			goto stCase603
 		case 604:
-			goto st_case_604
+			goto stCase604
 		case 605:
-			goto st_case_605
+			goto stCase605
 		case 17:
-			goto st_case_17
+			goto stCase17
 		case 18:
-			goto st_case_18
+			goto stCase18
 		case 19:
-			goto st_case_19
+			goto stCase19
 		case 20:
-			goto st_case_20
+			goto stCase20
 		case 21:
-			goto st_case_21
+			goto stCase21
 		case 22:
-			goto st_case_22
+			goto stCase22
 		case 23:
-			goto st_case_23
+			goto stCase23
 		case 24:
-			goto st_case_24
+			goto stCase24
 		case 25:
-			goto st_case_25
+			goto stCase25
 		case 26:
-			goto st_case_26
+			goto stCase26
 		case 27:
-			goto st_case_27
+			goto stCase27
 		case 28:
-			goto st_case_28
+			goto stCase28
 		case 29:
-			goto st_case_29
+			goto stCase29
 		case 30:
-			goto st_case_30
+			goto stCase30
 		case 31:
-			goto st_case_31
+			goto stCase31
 		case 32:
-			goto st_case_32
+			goto stCase32
 		case 33:
-			goto st_case_33
+			goto stCase33
 		case 34:
-			goto st_case_34
+			goto stCase34
 		case 35:
-			goto st_case_35
+			goto stCase35
 		case 36:
-			goto st_case_36
+			goto stCase36
 		case 37:
-			goto st_case_37
+			goto stCase37
 		case 38:
-			goto st_case_38
+			goto stCase38
 		case 39:
-			goto st_case_39
+			goto stCase39
 		case 40:
-			goto st_case_40
+			goto stCase40
 		case 41:
-			goto st_case_41
+			goto stCase41
 		case 42:
-			goto st_case_42
+			goto stCase42
 		case 43:
-			goto st_case_43
+			goto stCase43
 		case 44:
-			goto st_case_44
+			goto stCase44
 		case 45:
-			goto st_case_45
+			goto stCase45
 		case 46:
-			goto st_case_46
+			goto stCase46
 		case 47:
-			goto st_case_47
+			goto stCase47
 		case 48:
-			goto st_case_48
+			goto stCase48
 		case 49:
-			goto st_case_49
+			goto stCase49
 		case 50:
-			goto st_case_50
+			goto stCase50
 		case 51:
-			goto st_case_51
+			goto stCase51
 		case 52:
-			goto st_case_52
+			goto stCase52
 		case 53:
-			goto st_case_53
+			goto stCase53
 		case 54:
-			goto st_case_54
+			goto stCase54
 		case 55:
-			goto st_case_55
+			goto stCase55
 		case 56:
-			goto st_case_56
+			goto stCase56
 		case 57:
-			goto st_case_57
+			goto stCase57
 		case 58:
-			goto st_case_58
+			goto stCase58
 		case 59:
-			goto st_case_59
+			goto stCase59
 		case 60:
-			goto st_case_60
+			goto stCase60
 		case 61:
-			goto st_case_61
+			goto stCase61
 		case 62:
-			goto st_case_62
+			goto stCase62
 		case 606:
-			goto st_case_606
+			goto stCase606
 		case 63:
-			goto st_case_63
+			goto stCase63
 		case 64:
-			goto st_case_64
+			goto stCase64
 		case 65:
-			goto st_case_65
+			goto stCase65
 		case 66:
-			goto st_case_66
+			goto stCase66
 		case 67:
-			goto st_case_67
+			goto stCase67
 		case 68:
-			goto st_case_68
+			goto stCase68
 		case 69:
-			goto st_case_69
+			goto stCase69
 		case 70:
-			goto st_case_70
+			goto stCase70
 		case 71:
-			goto st_case_71
+			goto stCase71
 		case 72:
-			goto st_case_72
+			goto stCase72
 		case 73:
-			goto st_case_73
+			goto stCase73
 		case 74:
-			goto st_case_74
+			goto stCase74
 		case 75:
-			goto st_case_75
+			goto stCase75
 		case 76:
-			goto st_case_76
+			goto stCase76
 		case 77:
-			goto st_case_77
+			goto stCase77
 		case 78:
-			goto st_case_78
+			goto stCase78
 		case 79:
-			goto st_case_79
+			goto stCase79
 		case 80:
-			goto st_case_80
+			goto stCase80
 		case 81:
-			goto st_case_81
+			goto stCase81
 		case 82:
-			goto st_case_82
+			goto stCase82
 		case 83:
-			goto st_case_83
+			goto stCase83
 		case 84:
-			goto st_case_84
+			goto stCase84
 		case 85:
-			goto st_case_85
+			goto stCase85
 		case 86:
-			goto st_case_86
+			goto stCase86
 		case 87:
-			goto st_case_87
+			goto stCase87
 		case 88:
-			goto st_case_88
+			goto stCase88
 		case 89:
-			goto st_case_89
+			goto stCase89
 		case 90:
-			goto st_case_90
+			goto stCase90
 		case 91:
-			goto st_case_91
+			goto stCase91
 		case 92:
-			goto st_case_92
+			goto stCase92
 		case 93:
-			goto st_case_93
+			goto stCase93
 		case 94:
-			goto st_case_94
+			goto stCase94
 		case 95:
-			goto st_case_95
+			goto stCase95
 		case 96:
-			goto st_case_96
+			goto stCase96
 		case 97:
-			goto st_case_97
+			goto stCase97
 		case 98:
-			goto st_case_98
+			goto stCase98
 		case 99:
-			goto st_case_99
+			goto stCase99
 		case 100:
-			goto st_case_100
+			goto stCase100
 		case 101:
-			goto st_case_101
+			goto stCase101
 		case 102:
-			goto st_case_102
+			goto stCase102
 		case 103:
-			goto st_case_103
+			goto stCase103
 		case 104:
-			goto st_case_104
+			goto stCase104
 		case 105:
-			goto st_case_105
+			goto stCase105
 		case 106:
-			goto st_case_106
+			goto stCase106
 		case 107:
-			goto st_case_107
+			goto stCase107
 		case 108:
-			goto st_case_108
+			goto stCase108
 		case 109:
-			goto st_case_109
+			goto stCase109
 		case 110:
-			goto st_case_110
+			goto stCase110
 		case 111:
-			goto st_case_111
+			goto stCase111
 		case 112:
-			goto st_case_112
+			goto stCase112
 		case 113:
-			goto st_case_113
+			goto stCase113
 		case 114:
-			goto st_case_114
+			goto stCase114
 		case 115:
-			goto st_case_115
+			goto stCase115
 		case 116:
-			goto st_case_116
+			goto stCase116
 		case 117:
-			goto st_case_117
+			goto stCase117
 		case 118:
-			goto st_case_118
+			goto stCase118
 		case 119:
-			goto st_case_119
+			goto stCase119
 		case 120:
-			goto st_case_120
+			goto stCase120
 		case 121:
-			goto st_case_121
+			goto stCase121
 		case 122:
-			goto st_case_122
+			goto stCase122
 		case 123:
-			goto st_case_123
+			goto stCase123
 		case 124:
-			goto st_case_124
+			goto stCase124
 		case 125:
-			goto st_case_125
+			goto stCase125
 		case 126:
-			goto st_case_126
+			goto stCase126
 		case 127:
-			goto st_case_127
+			goto stCase127
 		case 128:
-			goto st_case_128
+			goto stCase128
 		case 129:
-			goto st_case_129
+			goto stCase129
 		case 130:
-			goto st_case_130
+			goto stCase130
 		case 131:
-			goto st_case_131
+			goto stCase131
 		case 132:
-			goto st_case_132
+			goto stCase132
 		case 133:
-			goto st_case_133
+			goto stCase133
 		case 134:
-			goto st_case_134
+			goto stCase134
 		case 135:
-			goto st_case_135
+			goto stCase135
 		case 136:
-			goto st_case_136
+			goto stCase136
 		case 137:
-			goto st_case_137
+			goto stCase137
 		case 138:
-			goto st_case_138
+			goto stCase138
 		case 139:
-			goto st_case_139
+			goto stCase139
 		case 140:
-			goto st_case_140
+			goto stCase140
 		case 141:
-			goto st_case_141
+			goto stCase141
 		case 142:
-			goto st_case_142
+			goto stCase142
 		case 143:
-			goto st_case_143
+			goto stCase143
 		case 144:
-			goto st_case_144
+			goto stCase144
 		case 145:
-			goto st_case_145
+			goto stCase145
 		case 146:
-			goto st_case_146
+			goto stCase146
 		case 147:
-			goto st_case_147
+			goto stCase147
 		case 148:
-			goto st_case_148
+			goto stCase148
 		case 149:
-			goto st_case_149
+			goto stCase149
 		case 150:
-			goto st_case_150
+			goto stCase150
 		case 151:
-			goto st_case_151
+			goto stCase151
 		case 152:
-			goto st_case_152
+			goto stCase152
 		case 153:
-			goto st_case_153
+			goto stCase153
 		case 154:
-			goto st_case_154
+			goto stCase154
 		case 155:
-			goto st_case_155
+			goto stCase155
 		case 156:
-			goto st_case_156
+			goto stCase156
 		case 157:
-			goto st_case_157
+			goto stCase157
 		case 158:
-			goto st_case_158
+			goto stCase158
 		case 159:
-			goto st_case_159
+			goto stCase159
 		case 160:
-			goto st_case_160
+			goto stCase160
 		case 161:
-			goto st_case_161
+			goto stCase161
 		case 162:
-			goto st_case_162
+			goto stCase162
 		case 163:
-			goto st_case_163
+			goto stCase163
 		case 164:
-			goto st_case_164
+			goto stCase164
 		case 165:
-			goto st_case_165
+			goto stCase165
 		case 166:
-			goto st_case_166
+			goto stCase166
 		case 167:
-			goto st_case_167
+			goto stCase167
 		case 168:
-			goto st_case_168
+			goto stCase168
 		case 169:
-			goto st_case_169
+			goto stCase169
 		case 170:
-			goto st_case_170
+			goto stCase170
 		case 171:
-			goto st_case_171
+			goto stCase171
 		case 172:
-			goto st_case_172
+			goto stCase172
 		case 173:
-			goto st_case_173
+			goto stCase173
 		case 174:
-			goto st_case_174
+			goto stCase174
 		case 175:
-			goto st_case_175
+			goto stCase175
 		case 176:
-			goto st_case_176
+			goto stCase176
 		case 177:
-			goto st_case_177
+			goto stCase177
 		case 178:
-			goto st_case_178
+			goto stCase178
 		case 179:
-			goto st_case_179
+			goto stCase179
 		case 180:
-			goto st_case_180
+			goto stCase180
 		case 181:
-			goto st_case_181
+			goto stCase181
 		case 182:
-			goto st_case_182
+			goto stCase182
 		case 183:
-			goto st_case_183
+			goto stCase183
 		case 184:
-			goto st_case_184
+			goto stCase184
 		case 185:
-			goto st_case_185
+			goto stCase185
 		case 186:
-			goto st_case_186
+			goto stCase186
 		case 187:
-			goto st_case_187
+			goto stCase187
 		case 188:
-			goto st_case_188
+			goto stCase188
 		case 189:
-			goto st_case_189
+			goto stCase189
 		case 190:
-			goto st_case_190
+			goto stCase190
 		case 191:
-			goto st_case_191
+			goto stCase191
 		case 192:
-			goto st_case_192
+			goto stCase192
 		case 193:
-			goto st_case_193
+			goto stCase193
 		case 194:
-			goto st_case_194
+			goto stCase194
 		case 195:
-			goto st_case_195
+			goto stCase195
 		case 196:
-			goto st_case_196
+			goto stCase196
 		case 197:
-			goto st_case_197
+			goto stCase197
 		case 198:
-			goto st_case_198
+			goto stCase198
 		case 199:
-			goto st_case_199
+			goto stCase199
 		case 200:
-			goto st_case_200
+			goto stCase200
 		case 201:
-			goto st_case_201
+			goto stCase201
 		case 202:
-			goto st_case_202
+			goto stCase202
 		case 203:
-			goto st_case_203
+			goto stCase203
 		case 204:
-			goto st_case_204
+			goto stCase204
 		case 205:
-			goto st_case_205
+			goto stCase205
 		case 206:
-			goto st_case_206
+			goto stCase206
 		case 207:
-			goto st_case_207
+			goto stCase207
 		case 208:
-			goto st_case_208
+			goto stCase208
 		case 209:
-			goto st_case_209
+			goto stCase209
 		case 210:
-			goto st_case_210
+			goto stCase210
 		case 211:
-			goto st_case_211
+			goto stCase211
 		case 212:
-			goto st_case_212
+			goto stCase212
 		case 213:
-			goto st_case_213
+			goto stCase213
 		case 214:
-			goto st_case_214
+			goto stCase214
 		case 215:
-			goto st_case_215
+			goto stCase215
 		case 216:
-			goto st_case_216
+			goto stCase216
 		case 217:
-			goto st_case_217
+			goto stCase217
 		case 218:
-			goto st_case_218
+			goto stCase218
 		case 219:
-			goto st_case_219
+			goto stCase219
 		case 220:
-			goto st_case_220
+			goto stCase220
 		case 221:
-			goto st_case_221
+			goto stCase221
 		case 222:
-			goto st_case_222
+			goto stCase222
 		case 223:
-			goto st_case_223
+			goto stCase223
 		case 224:
-			goto st_case_224
+			goto stCase224
 		case 225:
-			goto st_case_225
+			goto stCase225
 		case 226:
-			goto st_case_226
+			goto stCase226
 		case 227:
-			goto st_case_227
+			goto stCase227
 		case 228:
-			goto st_case_228
+			goto stCase228
 		case 229:
-			goto st_case_229
+			goto stCase229
 		case 230:
-			goto st_case_230
+			goto stCase230
 		case 231:
-			goto st_case_231
+			goto stCase231
 		case 232:
-			goto st_case_232
+			goto stCase232
 		case 233:
-			goto st_case_233
+			goto stCase233
 		case 234:
-			goto st_case_234
+			goto stCase234
 		case 235:
-			goto st_case_235
+			goto stCase235
 		case 236:
-			goto st_case_236
+			goto stCase236
 		case 237:
-			goto st_case_237
+			goto stCase237
 		case 238:
-			goto st_case_238
+			goto stCase238
 		case 239:
-			goto st_case_239
+			goto stCase239
 		case 240:
-			goto st_case_240
+			goto stCase240
 		case 241:
-			goto st_case_241
+			goto stCase241
 		case 242:
-			goto st_case_242
+			goto stCase242
 		case 243:
-			goto st_case_243
+			goto stCase243
 		case 244:
-			goto st_case_244
+			goto stCase244
 		case 245:
-			goto st_case_245
+			goto stCase245
 		case 246:
-			goto st_case_246
+			goto stCase246
 		case 247:
-			goto st_case_247
+			goto stCase247
 		case 248:
-			goto st_case_248
+			goto stCase248
 		case 249:
-			goto st_case_249
+			goto stCase249
 		case 250:
-			goto st_case_250
+			goto stCase250
 		case 251:
-			goto st_case_251
+			goto stCase251
 		case 252:
-			goto st_case_252
+			goto stCase252
 		case 253:
-			goto st_case_253
+			goto stCase253
 		case 254:
-			goto st_case_254
+			goto stCase254
 		case 255:
-			goto st_case_255
+			goto stCase255
 		case 256:
-			goto st_case_256
+			goto stCase256
 		case 257:
-			goto st_case_257
+			goto stCase257
 		case 258:
-			goto st_case_258
+			goto stCase258
 		case 259:
-			goto st_case_259
+			goto stCase259
 		case 260:
-			goto st_case_260
+			goto stCase260
 		case 261:
-			goto st_case_261
+			goto stCase261
 		case 262:
-			goto st_case_262
+			goto stCase262
 		case 263:
-			goto st_case_263
+			goto stCase263
 		case 264:
-			goto st_case_264
+			goto stCase264
 		case 265:
-			goto st_case_265
+			goto stCase265
 		case 266:
-			goto st_case_266
+			goto stCase266
 		case 267:
-			goto st_case_267
+			goto stCase267
 		case 268:
-			goto st_case_268
+			goto stCase268
 		case 269:
-			goto st_case_269
+			goto stCase269
 		case 270:
-			goto st_case_270
+			goto stCase270
 		case 271:
-			goto st_case_271
+			goto stCase271
 		case 272:
-			goto st_case_272
+			goto stCase272
 		case 273:
-			goto st_case_273
+			goto stCase273
 		case 274:
-			goto st_case_274
+			goto stCase274
 		case 275:
-			goto st_case_275
+			goto stCase275
 		case 276:
-			goto st_case_276
+			goto stCase276
 		case 277:
-			goto st_case_277
+			goto stCase277
 		case 278:
-			goto st_case_278
+			goto stCase278
 		case 279:
-			goto st_case_279
+			goto stCase279
 		case 280:
-			goto st_case_280
+			goto stCase280
 		case 281:
-			goto st_case_281
+			goto stCase281
 		case 282:
-			goto st_case_282
+			goto stCase282
 		case 283:
-			goto st_case_283
+			goto stCase283
 		case 284:
-			goto st_case_284
+			goto stCase284
 		case 285:
-			goto st_case_285
+			goto stCase285
 		case 286:
-			goto st_case_286
+			goto stCase286
 		case 287:
-			goto st_case_287
+			goto stCase287
 		case 288:
-			goto st_case_288
+			goto stCase288
 		case 289:
-			goto st_case_289
+			goto stCase289
 		case 290:
-			goto st_case_290
+			goto stCase290
 		case 291:
-			goto st_case_291
+			goto stCase291
 		case 292:
-			goto st_case_292
+			goto stCase292
 		case 293:
-			goto st_case_293
+			goto stCase293
 		case 294:
-			goto st_case_294
+			goto stCase294
 		case 295:
-			goto st_case_295
+			goto stCase295
 		case 296:
-			goto st_case_296
+			goto stCase296
 		case 297:
-			goto st_case_297
+			goto stCase297
 		case 298:
-			goto st_case_298
+			goto stCase298
 		case 299:
-			goto st_case_299
+			goto stCase299
 		case 300:
-			goto st_case_300
+			goto stCase300
 		case 301:
-			goto st_case_301
+			goto stCase301
 		case 302:
-			goto st_case_302
+			goto stCase302
 		case 303:
-			goto st_case_303
+			goto stCase303
 		case 304:
-			goto st_case_304
+			goto stCase304
 		case 305:
-			goto st_case_305
+			goto stCase305
 		case 306:
-			goto st_case_306
+			goto stCase306
 		case 307:
-			goto st_case_307
+			goto stCase307
 		case 308:
-			goto st_case_308
+			goto stCase308
 		case 309:
-			goto st_case_309
+			goto stCase309
 		case 310:
-			goto st_case_310
+			goto stCase310
 		case 311:
-			goto st_case_311
+			goto stCase311
 		case 312:
-			goto st_case_312
+			goto stCase312
 		case 313:
-			goto st_case_313
+			goto stCase313
 		case 314:
-			goto st_case_314
+			goto stCase314
 		case 315:
-			goto st_case_315
+			goto stCase315
 		case 316:
-			goto st_case_316
+			goto stCase316
 		case 317:
-			goto st_case_317
+			goto stCase317
 		case 318:
-			goto st_case_318
+			goto stCase318
 		case 319:
-			goto st_case_319
+			goto stCase319
 		case 320:
-			goto st_case_320
+			goto stCase320
 		case 321:
-			goto st_case_321
+			goto stCase321
 		case 322:
-			goto st_case_322
+			goto stCase322
 		case 323:
-			goto st_case_323
+			goto stCase323
 		case 324:
-			goto st_case_324
+			goto stCase324
 		case 325:
-			goto st_case_325
+			goto stCase325
 		case 326:
-			goto st_case_326
+			goto stCase326
 		case 327:
-			goto st_case_327
+			goto stCase327
 		case 328:
-			goto st_case_328
+			goto stCase328
 		case 329:
-			goto st_case_329
+			goto stCase329
 		case 330:
-			goto st_case_330
+			goto stCase330
 		case 331:
-			goto st_case_331
+			goto stCase331
 		case 332:
-			goto st_case_332
+			goto stCase332
 		case 333:
-			goto st_case_333
+			goto stCase333
 		case 334:
-			goto st_case_334
+			goto stCase334
 		case 335:
-			goto st_case_335
+			goto stCase335
 		case 336:
-			goto st_case_336
+			goto stCase336
 		case 337:
-			goto st_case_337
+			goto stCase337
 		case 338:
-			goto st_case_338
+			goto stCase338
 		case 339:
-			goto st_case_339
+			goto stCase339
 		case 340:
-			goto st_case_340
+			goto stCase340
 		case 341:
-			goto st_case_341
+			goto stCase341
 		case 342:
-			goto st_case_342
+			goto stCase342
 		case 343:
-			goto st_case_343
+			goto stCase343
 		case 344:
-			goto st_case_344
+			goto stCase344
 		case 345:
-			goto st_case_345
+			goto stCase345
 		case 346:
-			goto st_case_346
+			goto stCase346
 		case 347:
-			goto st_case_347
+			goto stCase347
 		case 348:
-			goto st_case_348
+			goto stCase348
 		case 349:
-			goto st_case_349
+			goto stCase349
 		case 350:
-			goto st_case_350
+			goto stCase350
 		case 351:
-			goto st_case_351
+			goto stCase351
 		case 352:
-			goto st_case_352
+			goto stCase352
 		case 353:
-			goto st_case_353
+			goto stCase353
 		case 354:
-			goto st_case_354
+			goto stCase354
 		case 355:
-			goto st_case_355
+			goto stCase355
 		case 356:
-			goto st_case_356
+			goto stCase356
 		case 357:
-			goto st_case_357
+			goto stCase357
 		case 358:
-			goto st_case_358
+			goto stCase358
 		case 359:
-			goto st_case_359
+			goto stCase359
 		case 360:
-			goto st_case_360
+			goto stCase360
 		case 361:
-			goto st_case_361
+			goto stCase361
 		case 362:
-			goto st_case_362
+			goto stCase362
 		case 363:
-			goto st_case_363
+			goto stCase363
 		case 364:
-			goto st_case_364
+			goto stCase364
 		case 365:
-			goto st_case_365
+			goto stCase365
 		case 366:
-			goto st_case_366
+			goto stCase366
 		case 367:
-			goto st_case_367
+			goto stCase367
 		case 368:
-			goto st_case_368
+			goto stCase368
 		case 369:
-			goto st_case_369
+			goto stCase369
 		case 370:
-			goto st_case_370
+			goto stCase370
 		case 371:
-			goto st_case_371
+			goto stCase371
 		case 372:
-			goto st_case_372
+			goto stCase372
 		case 373:
-			goto st_case_373
+			goto stCase373
 		case 374:
-			goto st_case_374
+			goto stCase374
 		case 375:
-			goto st_case_375
+			goto stCase375
 		case 376:
-			goto st_case_376
+			goto stCase376
 		case 377:
-			goto st_case_377
+			goto stCase377
 		case 378:
-			goto st_case_378
+			goto stCase378
 		case 379:
-			goto st_case_379
+			goto stCase379
 		case 380:
-			goto st_case_380
+			goto stCase380
 		case 381:
-			goto st_case_381
+			goto stCase381
 		case 382:
-			goto st_case_382
+			goto stCase382
 		case 383:
-			goto st_case_383
+			goto stCase383
 		case 384:
-			goto st_case_384
+			goto stCase384
 		case 385:
-			goto st_case_385
+			goto stCase385
 		case 386:
-			goto st_case_386
+			goto stCase386
 		case 387:
-			goto st_case_387
+			goto stCase387
 		case 388:
-			goto st_case_388
+			goto stCase388
 		case 389:
-			goto st_case_389
+			goto stCase389
 		case 390:
-			goto st_case_390
+			goto stCase390
 		case 391:
-			goto st_case_391
+			goto stCase391
 		case 392:
-			goto st_case_392
+			goto stCase392
 		case 393:
-			goto st_case_393
+			goto stCase393
 		case 394:
-			goto st_case_394
+			goto stCase394
 		case 395:
-			goto st_case_395
+			goto stCase395
 		case 396:
-			goto st_case_396
+			goto stCase396
 		case 397:
-			goto st_case_397
+			goto stCase397
 		case 398:
-			goto st_case_398
+			goto stCase398
 		case 399:
-			goto st_case_399
+			goto stCase399
 		case 400:
-			goto st_case_400
+			goto stCase400
 		case 401:
-			goto st_case_401
+			goto stCase401
 		case 402:
-			goto st_case_402
+			goto stCase402
 		case 403:
-			goto st_case_403
+			goto stCase403
 		case 404:
-			goto st_case_404
+			goto stCase404
 		case 405:
-			goto st_case_405
+			goto stCase405
 		case 406:
-			goto st_case_406
+			goto stCase406
 		case 407:
-			goto st_case_407
+			goto stCase407
 		case 408:
-			goto st_case_408
+			goto stCase408
 		case 409:
-			goto st_case_409
+			goto stCase409
 		case 410:
-			goto st_case_410
+			goto stCase410
 		case 411:
-			goto st_case_411
+			goto stCase411
 		case 412:
-			goto st_case_412
+			goto stCase412
 		case 413:
-			goto st_case_413
+			goto stCase413
 		case 414:
-			goto st_case_414
+			goto stCase414
 		case 415:
-			goto st_case_415
+			goto stCase415
 		case 416:
-			goto st_case_416
+			goto stCase416
 		case 417:
-			goto st_case_417
+			goto stCase417
 		case 418:
-			goto st_case_418
+			goto stCase418
 		case 419:
-			goto st_case_419
+			goto stCase419
 		case 420:
-			goto st_case_420
+			goto stCase420
 		case 421:
-			goto st_case_421
+			goto stCase421
 		case 422:
-			goto st_case_422
+			goto stCase422
 		case 423:
-			goto st_case_423
+			goto stCase423
 		case 424:
-			goto st_case_424
+			goto stCase424
 		case 425:
-			goto st_case_425
+			goto stCase425
 		case 426:
-			goto st_case_426
+			goto stCase426
 		case 427:
-			goto st_case_427
+			goto stCase427
 		case 428:
-			goto st_case_428
+			goto stCase428
 		case 429:
-			goto st_case_429
+			goto stCase429
 		case 430:
-			goto st_case_430
+			goto stCase430
 		case 431:
-			goto st_case_431
+			goto stCase431
 		case 432:
-			goto st_case_432
+			goto stCase432
 		case 433:
-			goto st_case_433
+			goto stCase433
 		case 434:
-			goto st_case_434
+			goto stCase434
 		case 435:
-			goto st_case_435
+			goto stCase435
 		case 436:
-			goto st_case_436
+			goto stCase436
 		case 437:
-			goto st_case_437
+			goto stCase437
 		case 438:
-			goto st_case_438
+			goto stCase438
 		case 439:
-			goto st_case_439
+			goto stCase439
 		case 440:
-			goto st_case_440
+			goto stCase440
 		case 441:
-			goto st_case_441
+			goto stCase441
 		case 442:
-			goto st_case_442
+			goto stCase442
 		case 443:
-			goto st_case_443
+			goto stCase443
 		case 444:
-			goto st_case_444
+			goto stCase444
 		case 445:
-			goto st_case_445
+			goto stCase445
 		case 446:
-			goto st_case_446
+			goto stCase446
 		case 447:
-			goto st_case_447
+			goto stCase447
 		case 448:
-			goto st_case_448
+			goto stCase448
 		case 449:
-			goto st_case_449
+			goto stCase449
 		case 450:
-			goto st_case_450
+			goto stCase450
 		case 451:
-			goto st_case_451
+			goto stCase451
 		case 452:
-			goto st_case_452
+			goto stCase452
 		case 453:
-			goto st_case_453
+			goto stCase453
 		case 454:
-			goto st_case_454
+			goto stCase454
 		case 455:
-			goto st_case_455
+			goto stCase455
 		case 456:
-			goto st_case_456
+			goto stCase456
 		case 457:
-			goto st_case_457
+			goto stCase457
 		case 458:
-			goto st_case_458
+			goto stCase458
 		case 459:
-			goto st_case_459
+			goto stCase459
 		case 460:
-			goto st_case_460
+			goto stCase460
 		case 461:
-			goto st_case_461
+			goto stCase461
 		case 462:
-			goto st_case_462
+			goto stCase462
 		case 463:
-			goto st_case_463
+			goto stCase463
 		case 464:
-			goto st_case_464
+			goto stCase464
 		case 465:
-			goto st_case_465
+			goto stCase465
 		case 466:
-			goto st_case_466
+			goto stCase466
 		case 467:
-			goto st_case_467
+			goto stCase467
 		case 468:
-			goto st_case_468
+			goto stCase468
 		case 469:
-			goto st_case_469
+			goto stCase469
 		case 470:
-			goto st_case_470
+			goto stCase470
 		case 471:
-			goto st_case_471
+			goto stCase471
 		case 472:
-			goto st_case_472
+			goto stCase472
 		case 473:
-			goto st_case_473
+			goto stCase473
 		case 474:
-			goto st_case_474
+			goto stCase474
 		case 475:
-			goto st_case_475
+			goto stCase475
 		case 476:
-			goto st_case_476
+			goto stCase476
 		case 477:
-			goto st_case_477
+			goto stCase477
 		case 478:
-			goto st_case_478
+			goto stCase478
 		case 479:
-			goto st_case_479
+			goto stCase479
 		case 480:
-			goto st_case_480
+			goto stCase480
 		case 481:
-			goto st_case_481
+			goto stCase481
 		case 482:
-			goto st_case_482
+			goto stCase482
 		case 483:
-			goto st_case_483
+			goto stCase483
 		case 484:
-			goto st_case_484
+			goto stCase484
 		case 485:
-			goto st_case_485
+			goto stCase485
 		case 486:
-			goto st_case_486
+			goto stCase486
 		case 487:
-			goto st_case_487
+			goto stCase487
 		case 488:
-			goto st_case_488
+			goto stCase488
 		case 489:
-			goto st_case_489
+			goto stCase489
 		case 490:
-			goto st_case_490
+			goto stCase490
 		case 491:
-			goto st_case_491
+			goto stCase491
 		case 492:
-			goto st_case_492
+			goto stCase492
 		case 493:
-			goto st_case_493
+			goto stCase493
 		case 494:
-			goto st_case_494
+			goto stCase494
 		case 495:
-			goto st_case_495
+			goto stCase495
 		case 496:
-			goto st_case_496
+			goto stCase496
 		case 497:
-			goto st_case_497
+			goto stCase497
 		case 498:
-			goto st_case_498
+			goto stCase498
 		case 499:
-			goto st_case_499
+			goto stCase499
 		case 500:
-			goto st_case_500
+			goto stCase500
 		case 501:
-			goto st_case_501
+			goto stCase501
 		case 502:
-			goto st_case_502
+			goto stCase502
 		case 503:
-			goto st_case_503
+			goto stCase503
 		case 504:
-			goto st_case_504
+			goto stCase504
 		case 505:
-			goto st_case_505
+			goto stCase505
 		case 506:
-			goto st_case_506
+			goto stCase506
 		case 507:
-			goto st_case_507
+			goto stCase507
 		case 508:
-			goto st_case_508
+			goto stCase508
 		case 509:
-			goto st_case_509
+			goto stCase509
 		case 510:
-			goto st_case_510
+			goto stCase510
 		case 511:
-			goto st_case_511
+			goto stCase511
 		case 512:
-			goto st_case_512
+			goto stCase512
 		case 513:
-			goto st_case_513
+			goto stCase513
 		case 514:
-			goto st_case_514
+			goto stCase514
 		case 515:
-			goto st_case_515
+			goto stCase515
 		case 516:
-			goto st_case_516
+			goto stCase516
 		case 517:
-			goto st_case_517
+			goto stCase517
 		case 518:
-			goto st_case_518
+			goto stCase518
 		case 519:
-			goto st_case_519
+			goto stCase519
 		case 520:
-			goto st_case_520
+			goto stCase520
 		case 521:
-			goto st_case_521
+			goto stCase521
 		case 522:
-			goto st_case_522
+			goto stCase522
 		case 523:
-			goto st_case_523
+			goto stCase523
 		case 524:
-			goto st_case_524
+			goto stCase524
 		case 525:
-			goto st_case_525
+			goto stCase525
 		case 526:
-			goto st_case_526
+			goto stCase526
 		case 527:
-			goto st_case_527
+			goto stCase527
 		case 528:
-			goto st_case_528
+			goto stCase528
 		case 529:
-			goto st_case_529
+			goto stCase529
 		case 530:
-			goto st_case_530
+			goto stCase530
 		case 531:
-			goto st_case_531
+			goto stCase531
 		case 532:
-			goto st_case_532
+			goto stCase532
 		case 533:
-			goto st_case_533
+			goto stCase533
 		case 534:
-			goto st_case_534
+			goto stCase534
 		case 535:
-			goto st_case_535
+			goto stCase535
 		case 536:
-			goto st_case_536
+			goto stCase536
 		case 537:
-			goto st_case_537
+			goto stCase537
 		case 538:
-			goto st_case_538
+			goto stCase538
 		case 539:
-			goto st_case_539
+			goto stCase539
 		case 540:
-			goto st_case_540
+			goto stCase540
 		case 541:
-			goto st_case_541
+			goto stCase541
 		case 542:
-			goto st_case_542
+			goto stCase542
 		case 543:
-			goto st_case_543
+			goto stCase543
 		case 544:
-			goto st_case_544
+			goto stCase544
 		case 545:
-			goto st_case_545
+			goto stCase545
 		case 546:
-			goto st_case_546
+			goto stCase546
 		case 547:
-			goto st_case_547
+			goto stCase547
 		case 548:
-			goto st_case_548
+			goto stCase548
 		case 549:
-			goto st_case_549
+			goto stCase549
 		case 550:
-			goto st_case_550
+			goto stCase550
 		case 551:
-			goto st_case_551
+			goto stCase551
 		case 552:
-			goto st_case_552
+			goto stCase552
 		case 553:
-			goto st_case_553
+			goto stCase553
 		case 554:
-			goto st_case_554
+			goto stCase554
 		case 555:
-			goto st_case_555
+			goto stCase555
 		case 556:
-			goto st_case_556
+			goto stCase556
 		case 557:
-			goto st_case_557
+			goto stCase557
 		case 558:
-			goto st_case_558
+			goto stCase558
 		case 559:
-			goto st_case_559
+			goto stCase559
 		case 560:
-			goto st_case_560
+			goto stCase560
 		case 561:
-			goto st_case_561
+			goto stCase561
 		case 562:
-			goto st_case_562
+			goto stCase562
 		case 563:
-			goto st_case_563
+			goto stCase563
 		case 564:
-			goto st_case_564
+			goto stCase564
 		case 565:
-			goto st_case_565
+			goto stCase565
 		case 566:
-			goto st_case_566
+			goto stCase566
 		case 567:
-			goto st_case_567
+			goto stCase567
 		case 568:
-			goto st_case_568
+			goto stCase568
 		case 569:
-			goto st_case_569
+			goto stCase569
 		case 570:
-			goto st_case_570
+			goto stCase570
 		case 571:
-			goto st_case_571
+			goto stCase571
 		case 572:
-			goto st_case_572
+			goto stCase572
 		case 573:
-			goto st_case_573
+			goto stCase573
 		case 574:
-			goto st_case_574
+			goto stCase574
 		case 575:
-			goto st_case_575
+			goto stCase575
 		case 576:
-			goto st_case_576
+			goto stCase576
 		case 577:
-			goto st_case_577
+			goto stCase577
 		case 578:
-			goto st_case_578
+			goto stCase578
 		case 579:
-			goto st_case_579
+			goto stCase579
 		case 580:
-			goto st_case_580
+			goto stCase580
 		case 581:
-			goto st_case_581
+			goto stCase581
 		case 582:
-			goto st_case_582
+			goto stCase582
 		case 583:
-			goto st_case_583
+			goto stCase583
 		case 584:
-			goto st_case_584
+			goto stCase584
 		case 585:
-			goto st_case_585
+			goto stCase585
 		case 586:
-			goto st_case_586
+			goto stCase586
 		case 587:
-			goto st_case_587
+			goto stCase587
 		case 588:
-			goto st_case_588
+			goto stCase588
 		case 589:
-			goto st_case_589
+			goto stCase589
 		case 590:
-			goto st_case_590
+			goto stCase590
 		case 591:
-			goto st_case_591
+			goto stCase591
 		case 592:
-			goto st_case_592
+			goto stCase592
 		case 593:
-			goto st_case_593
+			goto stCase593
 		case 594:
-			goto st_case_594
+			goto stCase594
 		case 595:
-			goto st_case_595
+			goto stCase595
 		case 596:
-			goto st_case_596
+			goto stCase596
 		case 597:
-			goto st_case_597
+			goto stCase597
 		case 598:
-			goto st_case_598
+			goto stCase598
 		case 599:
-			goto st_case_599
+			goto stCase599
 		case 600:
-			goto st_case_600
+			goto stCase600
 		case 601:
-			goto st_case_601
+			goto stCase601
 		case 602:
-			goto st_case_602
+			goto stCase602
 		case 607:
-			goto st_case_607
+			goto stCase607
 		}
-		goto st_out
-	st_case_1:
+		goto stOut
+	stCase1:
 		if (m.data)[(m.p)] == 60 {
 			goto st2
 		}
 		goto tr0
 	tr0:
-//line rfc5424/machine.go.rl:157
 
 		m.err = fmt.Errorf(ErrPri+ColumnPositionTemplate, m.p)
 		(m.p)--
@@ -1379,7 +1358,6 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 
 		goto st0
 	tr2:
-//line rfc5424/machine.go.rl:151
 
 		m.err = fmt.Errorf(ErrPrival+ColumnPositionTemplate, m.p)
 		(m.p)--
@@ -1388,16 +1366,12 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 			goto st607
 		}
 
-//line rfc5424/machine.go.rl:157
-
 		m.err = fmt.Errorf(ErrPri+ColumnPositionTemplate, m.p)
 		(m.p)--
 
 		{
 			goto st607
 		}
-
-//line rfc5424/machine.go.rl:242
 
 		m.err = fmt.Errorf(ErrParse+ColumnPositionTemplate, m.p)
 		(m.p)--
@@ -1408,7 +1382,6 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 
 		goto st0
 	tr7:
-//line rfc5424/machine.go.rl:163
 
 		m.err = fmt.Errorf(ErrVersion+ColumnPositionTemplate, m.p)
 		(m.p)--
@@ -1416,8 +1389,6 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		{
 			goto st607
 		}
-
-//line rfc5424/machine.go.rl:242
 
 		m.err = fmt.Errorf(ErrParse+ColumnPositionTemplate, m.p)
 		(m.p)--
@@ -1428,7 +1399,6 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 
 		goto st0
 	tr9:
-//line rfc5424/machine.go.rl:242
 
 		m.err = fmt.Errorf(ErrParse+ColumnPositionTemplate, m.p)
 		(m.p)--
@@ -1439,7 +1409,6 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 
 		goto st0
 	tr12:
-//line rfc5424/machine.go.rl:169
 
 		m.err = fmt.Errorf(ErrTimestamp+ColumnPositionTemplate, m.p)
 		(m.p)--
@@ -1447,8 +1416,6 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		{
 			goto st607
 		}
-
-//line rfc5424/machine.go.rl:242
 
 		m.err = fmt.Errorf(ErrParse+ColumnPositionTemplate, m.p)
 		(m.p)--
@@ -1459,7 +1426,6 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 
 		goto st0
 	tr16:
-//line rfc5424/machine.go.rl:175
 
 		m.err = fmt.Errorf(ErrHostname+ColumnPositionTemplate, m.p)
 		(m.p)--
@@ -1467,8 +1433,6 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		{
 			goto st607
 		}
-
-//line rfc5424/machine.go.rl:242
 
 		m.err = fmt.Errorf(ErrParse+ColumnPositionTemplate, m.p)
 		(m.p)--
@@ -1479,7 +1443,6 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 
 		goto st0
 	tr20:
-//line rfc5424/machine.go.rl:181
 
 		m.err = fmt.Errorf(ErrAppname+ColumnPositionTemplate, m.p)
 		(m.p)--
@@ -1487,8 +1450,6 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		{
 			goto st607
 		}
-
-//line rfc5424/machine.go.rl:242
 
 		m.err = fmt.Errorf(ErrParse+ColumnPositionTemplate, m.p)
 		(m.p)--
@@ -1499,7 +1460,6 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 
 		goto st0
 	tr24:
-//line rfc5424/machine.go.rl:187
 
 		m.err = fmt.Errorf(ErrProcID+ColumnPositionTemplate, m.p)
 		(m.p)--
@@ -1507,8 +1467,6 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		{
 			goto st607
 		}
-
-//line rfc5424/machine.go.rl:242
 
 		m.err = fmt.Errorf(ErrParse+ColumnPositionTemplate, m.p)
 		(m.p)--
@@ -1519,7 +1477,6 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 
 		goto st0
 	tr28:
-//line rfc5424/machine.go.rl:193
 
 		m.err = fmt.Errorf(ErrMsgID+ColumnPositionTemplate, m.p)
 		(m.p)--
@@ -1527,8 +1484,6 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		{
 			goto st607
 		}
-
-//line rfc5424/machine.go.rl:242
 
 		m.err = fmt.Errorf(ErrParse+ColumnPositionTemplate, m.p)
 		(m.p)--
@@ -1539,7 +1494,6 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 
 		goto st0
 	tr30:
-//line rfc5424/machine.go.rl:193
 
 		m.err = fmt.Errorf(ErrMsgID+ColumnPositionTemplate, m.p)
 		(m.p)--
@@ -1550,7 +1504,6 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 
 		goto st0
 	tr33:
-//line rfc5424/machine.go.rl:199
 
 		m.err = fmt.Errorf(ErrStructuredData+ColumnPositionTemplate, m.p)
 		(m.p)--
@@ -1561,7 +1514,6 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 
 		goto st0
 	tr36:
-//line rfc5424/machine.go.rl:224
 
 		// If error encountered within the message rule ...
 		if m.msgat > 0 {
@@ -1576,8 +1528,6 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 			goto st607
 		}
 
-//line rfc5424/machine.go.rl:242
-
 		m.err = fmt.Errorf(ErrParse+ColumnPositionTemplate, m.p)
 		(m.p)--
 
@@ -1587,7 +1537,6 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 
 		goto st0
 	tr40:
-//line rfc5424/machine.go.rl:205
 
 		delete(output.structuredData, m.currentelem)
 		if len(output.structuredData) == 0 {
@@ -1600,8 +1549,6 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 			goto st607
 		}
 
-//line rfc5424/machine.go.rl:199
-
 		m.err = fmt.Errorf(ErrStructuredData+ColumnPositionTemplate, m.p)
 		(m.p)--
 
@@ -1611,7 +1558,6 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 
 		goto st0
 	tr42:
-//line rfc5424/machine.go.rl:106
 
 		if _, ok := output.structuredData[string(m.text())]; ok {
 			// As per RFC5424 section 6.3.2 SD-ID MUST NOT exist more than once in a message
@@ -1628,8 +1574,6 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 			m.currentelem = id
 		}
 
-//line rfc5424/machine.go.rl:205
-
 		delete(output.structuredData, m.currentelem)
 		if len(output.structuredData) == 0 {
 			output.hasElements = false
@@ -1641,8 +1585,6 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 			goto st607
 		}
 
-//line rfc5424/machine.go.rl:199
-
 		m.err = fmt.Errorf(ErrStructuredData+ColumnPositionTemplate, m.p)
 		(m.p)--
 
@@ -1652,7 +1594,6 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 
 		goto st0
 	tr46:
-//line rfc5424/machine.go.rl:215
 
 		if len(output.structuredData) > 0 {
 			delete(output.structuredData[m.currentelem], m.currentparam)
@@ -1663,8 +1604,6 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		{
 			goto st607
 		}
-
-//line rfc5424/machine.go.rl:199
 
 		m.err = fmt.Errorf(ErrStructuredData+ColumnPositionTemplate, m.p)
 		(m.p)--
@@ -1675,7 +1614,6 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 
 		goto st0
 	tr84:
-//line rfc5424/machine.go.rl:236
 
 		m.err = fmt.Errorf(ErrEscape+ColumnPositionTemplate, m.p)
 		(m.p)--
@@ -1683,8 +1621,6 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		{
 			goto st607
 		}
-
-//line rfc5424/machine.go.rl:215
 
 		if len(output.structuredData) > 0 {
 			delete(output.structuredData[m.currentelem], m.currentparam)
@@ -1696,8 +1632,6 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 			goto st607
 		}
 
-//line rfc5424/machine.go.rl:199
-
 		m.err = fmt.Errorf(ErrStructuredData+ColumnPositionTemplate, m.p)
 		(m.p)--
 
@@ -1707,7 +1641,6 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 
 		goto st0
 	tr619:
-//line rfc5424/machine.go.rl:75
 
 		if t, e := time.Parse(RFC3339MICRO, string(m.text())); e != nil {
 			m.err = fmt.Errorf("%s [col %d]", e, m.p)
@@ -1721,8 +1654,6 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 			output.timestampSet = true
 		}
 
-//line rfc5424/machine.go.rl:242
-
 		m.err = fmt.Errorf(ErrParse+ColumnPositionTemplate, m.p)
 		(m.p)--
 
@@ -1732,7 +1663,6 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 
 		goto st0
 	tr645:
-//line rfc5424/machine.go.rl:199
 
 		m.err = fmt.Errorf(ErrStructuredData+ColumnPositionTemplate, m.p)
 		(m.p)--
@@ -1740,8 +1670,6 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		{
 			goto st607
 		}
-
-//line rfc5424/machine.go.rl:242
 
 		m.err = fmt.Errorf(ErrParse+ColumnPositionTemplate, m.p)
 		(m.p)--
@@ -1751,16 +1679,15 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		}
 
 		goto st0
-//line rfc5424/machine.go:1692
-	st_case_0:
+	stCase0:
 	st0:
 		m.cs = 0
 		goto _out
 	st2:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof2
+			goto _testEof2
 		}
-	st_case_2:
+	stCase2:
 		switch (m.data)[(m.p)] {
 		case 48:
 			goto tr3
@@ -1772,51 +1699,45 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		}
 		goto tr2
 	tr3:
-//line rfc5424/machine.go.rl:58
 
 		m.pb = m.p
 
 		goto st3
 	st3:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof3
+			goto _testEof3
 		}
-	st_case_3:
-//line rfc5424/machine.go.rl:66
+	stCase3:
 
 		output.priority = uint8(common.UnsafeUTF8DecimalCodePointsToInt(m.text()))
 		output.prioritySet = true
 
-//line rfc5424/machine.go:1728
 		if (m.data)[(m.p)] == 62 {
 			goto st4
 		}
 		goto tr2
 	st4:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof4
+			goto _testEof4
 		}
-	st_case_4:
+	stCase4:
 		if 49 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 57 {
 			goto tr8
 		}
 		goto tr7
 	tr8:
-//line rfc5424/machine.go.rl:58
 
 		m.pb = m.p
 
 		goto st5
 	st5:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof5
+			goto _testEof5
 		}
-	st_case_5:
-//line rfc5424/machine.go.rl:71
+	stCase5:
 
 		output.version = uint16(common.UnsafeUTF8DecimalCodePointsToInt(m.text()))
 
-//line rfc5424/machine.go:1757
 		if (m.data)[(m.p)] == 32 {
 			goto st6
 		}
@@ -1826,9 +1747,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr9
 	st6:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof6
+			goto _testEof6
 		}
-	st_case_6:
+	stCase6:
 		if (m.data)[(m.p)] == 45 {
 			goto st7
 		}
@@ -1838,15 +1759,14 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr12
 	st7:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof7
+			goto _testEof7
 		}
-	st_case_7:
+	stCase7:
 		if (m.data)[(m.p)] == 32 {
 			goto st8
 		}
 		goto tr9
 	tr620:
-//line rfc5424/machine.go.rl:75
 
 		if t, e := time.Parse(RFC3339MICRO, string(m.text())); e != nil {
 			m.err = fmt.Errorf("%s [col %d]", e, m.p)
@@ -1863,26 +1783,23 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto st8
 	st8:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof8
+			goto _testEof8
 		}
-	st_case_8:
-//line rfc5424/machine.go:1805
+	stCase8:
 		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto tr17
 		}
 		goto tr16
 	tr17:
-//line rfc5424/machine.go.rl:58
 
 		m.pb = m.p
 
 		goto st9
 	st9:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof9
+			goto _testEof9
 		}
-	st_case_9:
-//line rfc5424/machine.go:1821
+	stCase9:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -1891,33 +1808,29 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		}
 		goto tr16
 	tr18:
-//line rfc5424/machine.go.rl:86
 
 		output.hostname = string(m.text())
 
 		goto st10
 	st10:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof10
+			goto _testEof10
 		}
-	st_case_10:
-//line rfc5424/machine.go:1840
+	stCase10:
 		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto tr21
 		}
 		goto tr20
 	tr21:
-//line rfc5424/machine.go.rl:58
 
 		m.pb = m.p
 
 		goto st11
 	st11:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof11
+			goto _testEof11
 		}
-	st_case_11:
-//line rfc5424/machine.go:1856
+	stCase11:
 		if (m.data)[(m.p)] == 32 {
 			goto tr22
 		}
@@ -1926,33 +1839,29 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		}
 		goto tr20
 	tr22:
-//line rfc5424/machine.go.rl:90
 
 		output.appname = string(m.text())
 
 		goto st12
 	st12:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof12
+			goto _testEof12
 		}
-	st_case_12:
-//line rfc5424/machine.go:1875
+	stCase12:
 		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto tr25
 		}
 		goto tr24
 	tr25:
-//line rfc5424/machine.go.rl:58
 
 		m.pb = m.p
 
 		goto st13
 	st13:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof13
+			goto _testEof13
 		}
-	st_case_13:
-//line rfc5424/machine.go:1891
+	stCase13:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -1961,33 +1870,29 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		}
 		goto tr24
 	tr26:
-//line rfc5424/machine.go.rl:94
 
 		output.procID = string(m.text())
 
 		goto st14
 	st14:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof14
+			goto _testEof14
 		}
-	st_case_14:
-//line rfc5424/machine.go:1910
+	stCase14:
 		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto tr29
 		}
 		goto tr28
 	tr29:
-//line rfc5424/machine.go.rl:58
 
 		m.pb = m.p
 
 		goto st15
 	st15:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof15
+			goto _testEof15
 		}
-	st_case_15:
-//line rfc5424/machine.go:1926
+	stCase15:
 		if (m.data)[(m.p)] == 32 {
 			goto tr31
 		}
@@ -1996,17 +1901,15 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		}
 		goto tr30
 	tr31:
-//line rfc5424/machine.go.rl:98
 
 		output.msgID = string(m.text())
 
 		goto st16
 	st16:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof16
+			goto _testEof16
 		}
-	st_case_16:
-//line rfc5424/machine.go:1945
+	stCase16:
 		switch (m.data)[(m.p)] {
 		case 45:
 			goto st603
@@ -2016,18 +1919,18 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr33
 	st603:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof603
+			goto _testEof603
 		}
-	st_case_603:
+	stCase603:
 		if (m.data)[(m.p)] == 32 {
 			goto st604
 		}
 		goto tr9
 	st604:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof604
+			goto _testEof604
 		}
-	st_case_604:
+	stCase604:
 		switch (m.data)[(m.p)] {
 		case 224:
 			goto tr634
@@ -2062,21 +1965,17 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		}
 		goto tr632
 	tr632:
-//line rfc5424/machine.go.rl:58
 
 		m.pb = m.p
-
-//line rfc5424/machine.go.rl:62
 
 		m.msgat = m.p
 
 		goto st605
 	st605:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof605
+			goto _testEof605
 		}
-	st_case_605:
-//line rfc5424/machine.go:2015
+	stCase605:
 		switch (m.data)[(m.p)] {
 		case 224:
 			goto st18
@@ -2111,157 +2010,127 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		}
 		goto st605
 	tr633:
-//line rfc5424/machine.go.rl:58
 
 		m.pb = m.p
-
-//line rfc5424/machine.go.rl:62
 
 		m.msgat = m.p
 
 		goto st17
 	st17:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof17
+			goto _testEof17
 		}
-	st_case_17:
-//line rfc5424/machine.go:2064
+	stCase17:
 		if 128 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 191 {
 			goto st605
 		}
 		goto tr36
 	tr634:
-//line rfc5424/machine.go.rl:58
 
 		m.pb = m.p
-
-//line rfc5424/machine.go.rl:62
 
 		m.msgat = m.p
 
 		goto st18
 	st18:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof18
+			goto _testEof18
 		}
-	st_case_18:
-//line rfc5424/machine.go:2084
+	stCase18:
 		if 160 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 191 {
 			goto st17
 		}
 		goto tr36
 	tr635:
-//line rfc5424/machine.go.rl:58
 
 		m.pb = m.p
-
-//line rfc5424/machine.go.rl:62
 
 		m.msgat = m.p
 
 		goto st19
 	st19:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof19
+			goto _testEof19
 		}
-	st_case_19:
-//line rfc5424/machine.go:2104
+	stCase19:
 		if 128 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 191 {
 			goto st17
 		}
 		goto tr36
 	tr636:
-//line rfc5424/machine.go.rl:58
 
 		m.pb = m.p
-
-//line rfc5424/machine.go.rl:62
 
 		m.msgat = m.p
 
 		goto st20
 	st20:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof20
+			goto _testEof20
 		}
-	st_case_20:
-//line rfc5424/machine.go:2124
+	stCase20:
 		if 128 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 159 {
 			goto st17
 		}
 		goto tr36
 	tr637:
-//line rfc5424/machine.go.rl:58
 
 		m.pb = m.p
-
-//line rfc5424/machine.go.rl:62
 
 		m.msgat = m.p
 
 		goto st21
 	st21:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof21
+			goto _testEof21
 		}
-	st_case_21:
-//line rfc5424/machine.go:2144
+	stCase21:
 		if 144 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 191 {
 			goto st19
 		}
 		goto tr36
 	tr638:
-//line rfc5424/machine.go.rl:58
 
 		m.pb = m.p
-
-//line rfc5424/machine.go.rl:62
 
 		m.msgat = m.p
 
 		goto st22
 	st22:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof22
+			goto _testEof22
 		}
-	st_case_22:
-//line rfc5424/machine.go:2164
+	stCase22:
 		if 128 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 191 {
 			goto st19
 		}
 		goto tr36
 	tr639:
-//line rfc5424/machine.go.rl:58
 
 		m.pb = m.p
-
-//line rfc5424/machine.go.rl:62
 
 		m.msgat = m.p
 
 		goto st23
 	st23:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof23
+			goto _testEof23
 		}
-	st_case_23:
-//line rfc5424/machine.go:2184
+	stCase23:
 		if 128 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 143 {
 			goto st19
 		}
 		goto tr36
 	tr35:
-//line rfc5424/machine.go.rl:102
 
 		output.structuredData = map[string]map[string]string{}
 
 		goto st24
 	st24:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof24
+			goto _testEof24
 		}
-	st_case_24:
-//line rfc5424/machine.go:2200
+	stCase24:
 		if (m.data)[(m.p)] == 33 {
 			goto tr41
 		}
@@ -2279,17 +2148,15 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		}
 		goto tr40
 	tr41:
-//line rfc5424/machine.go.rl:58
 
 		m.pb = m.p
 
 		goto st25
 	st25:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof25
+			goto _testEof25
 		}
-	st_case_25:
-//line rfc5424/machine.go:2228
+	stCase25:
 		switch (m.data)[(m.p)] {
 		case 32:
 			goto tr43
@@ -2308,7 +2175,6 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		}
 		goto tr42
 	tr43:
-//line rfc5424/machine.go.rl:106
 
 		if _, ok := output.structuredData[string(m.text())]; ok {
 			// As per RFC5424 section 6.3.2 SD-ID MUST NOT exist more than once in a message
@@ -2328,10 +2194,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto st26
 	st26:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof26
+			goto _testEof26
 		}
-	st_case_26:
-//line rfc5424/machine.go:2268
+	stCase26:
 		if (m.data)[(m.p)] == 33 {
 			goto tr47
 		}
@@ -2349,21 +2214,17 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		}
 		goto tr46
 	tr47:
-//line rfc5424/machine.go.rl:120
 
 		m.backslashat = []int{}
-
-//line rfc5424/machine.go.rl:58
 
 		m.pb = m.p
 
 		goto st27
 	st27:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof27
+			goto _testEof27
 		}
-	st_case_27:
-//line rfc5424/machine.go:2300
+	stCase27:
 		switch (m.data)[(m.p)] {
 		case 33:
 			goto st28
@@ -2381,9 +2242,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr46
 	st28:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof28
+			goto _testEof28
 		}
-	st_case_28:
+	stCase28:
 		switch (m.data)[(m.p)] {
 		case 33:
 			goto st29
@@ -2401,9 +2262,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr46
 	st29:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof29
+			goto _testEof29
 		}
-	st_case_29:
+	stCase29:
 		switch (m.data)[(m.p)] {
 		case 33:
 			goto st30
@@ -2421,9 +2282,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr46
 	st30:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof30
+			goto _testEof30
 		}
-	st_case_30:
+	stCase30:
 		switch (m.data)[(m.p)] {
 		case 33:
 			goto st31
@@ -2441,9 +2302,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr46
 	st31:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof31
+			goto _testEof31
 		}
-	st_case_31:
+	stCase31:
 		switch (m.data)[(m.p)] {
 		case 33:
 			goto st32
@@ -2461,9 +2322,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr46
 	st32:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof32
+			goto _testEof32
 		}
-	st_case_32:
+	stCase32:
 		switch (m.data)[(m.p)] {
 		case 33:
 			goto st33
@@ -2481,9 +2342,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr46
 	st33:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof33
+			goto _testEof33
 		}
-	st_case_33:
+	stCase33:
 		switch (m.data)[(m.p)] {
 		case 33:
 			goto st34
@@ -2501,9 +2362,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr46
 	st34:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof34
+			goto _testEof34
 		}
-	st_case_34:
+	stCase34:
 		switch (m.data)[(m.p)] {
 		case 33:
 			goto st35
@@ -2521,9 +2382,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr46
 	st35:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof35
+			goto _testEof35
 		}
-	st_case_35:
+	stCase35:
 		switch (m.data)[(m.p)] {
 		case 33:
 			goto st36
@@ -2541,9 +2402,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr46
 	st36:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof36
+			goto _testEof36
 		}
-	st_case_36:
+	stCase36:
 		switch (m.data)[(m.p)] {
 		case 33:
 			goto st37
@@ -2561,9 +2422,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr46
 	st37:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof37
+			goto _testEof37
 		}
-	st_case_37:
+	stCase37:
 		switch (m.data)[(m.p)] {
 		case 33:
 			goto st38
@@ -2581,9 +2442,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr46
 	st38:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof38
+			goto _testEof38
 		}
-	st_case_38:
+	stCase38:
 		switch (m.data)[(m.p)] {
 		case 33:
 			goto st39
@@ -2601,9 +2462,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr46
 	st39:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof39
+			goto _testEof39
 		}
-	st_case_39:
+	stCase39:
 		switch (m.data)[(m.p)] {
 		case 33:
 			goto st40
@@ -2621,9 +2482,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr46
 	st40:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof40
+			goto _testEof40
 		}
-	st_case_40:
+	stCase40:
 		switch (m.data)[(m.p)] {
 		case 33:
 			goto st41
@@ -2641,9 +2502,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr46
 	st41:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof41
+			goto _testEof41
 		}
-	st_case_41:
+	stCase41:
 		switch (m.data)[(m.p)] {
 		case 33:
 			goto st42
@@ -2661,9 +2522,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr46
 	st42:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof42
+			goto _testEof42
 		}
-	st_case_42:
+	stCase42:
 		switch (m.data)[(m.p)] {
 		case 33:
 			goto st43
@@ -2681,9 +2542,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr46
 	st43:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof43
+			goto _testEof43
 		}
-	st_case_43:
+	stCase43:
 		switch (m.data)[(m.p)] {
 		case 33:
 			goto st44
@@ -2701,9 +2562,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr46
 	st44:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof44
+			goto _testEof44
 		}
-	st_case_44:
+	stCase44:
 		switch (m.data)[(m.p)] {
 		case 33:
 			goto st45
@@ -2721,9 +2582,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr46
 	st45:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof45
+			goto _testEof45
 		}
-	st_case_45:
+	stCase45:
 		switch (m.data)[(m.p)] {
 		case 33:
 			goto st46
@@ -2741,9 +2602,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr46
 	st46:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof46
+			goto _testEof46
 		}
-	st_case_46:
+	stCase46:
 		switch (m.data)[(m.p)] {
 		case 33:
 			goto st47
@@ -2761,9 +2622,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr46
 	st47:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof47
+			goto _testEof47
 		}
-	st_case_47:
+	stCase47:
 		switch (m.data)[(m.p)] {
 		case 33:
 			goto st48
@@ -2781,9 +2642,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr46
 	st48:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof48
+			goto _testEof48
 		}
-	st_case_48:
+	stCase48:
 		switch (m.data)[(m.p)] {
 		case 33:
 			goto st49
@@ -2801,9 +2662,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr46
 	st49:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof49
+			goto _testEof49
 		}
-	st_case_49:
+	stCase49:
 		switch (m.data)[(m.p)] {
 		case 33:
 			goto st50
@@ -2821,9 +2682,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr46
 	st50:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof50
+			goto _testEof50
 		}
-	st_case_50:
+	stCase50:
 		switch (m.data)[(m.p)] {
 		case 33:
 			goto st51
@@ -2841,9 +2702,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr46
 	st51:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof51
+			goto _testEof51
 		}
-	st_case_51:
+	stCase51:
 		switch (m.data)[(m.p)] {
 		case 33:
 			goto st52
@@ -2861,9 +2722,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr46
 	st52:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof52
+			goto _testEof52
 		}
-	st_case_52:
+	stCase52:
 		switch (m.data)[(m.p)] {
 		case 33:
 			goto st53
@@ -2881,9 +2742,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr46
 	st53:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof53
+			goto _testEof53
 		}
-	st_case_53:
+	stCase53:
 		switch (m.data)[(m.p)] {
 		case 33:
 			goto st54
@@ -2901,9 +2762,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr46
 	st54:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof54
+			goto _testEof54
 		}
-	st_case_54:
+	stCase54:
 		switch (m.data)[(m.p)] {
 		case 33:
 			goto st55
@@ -2921,9 +2782,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr46
 	st55:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof55
+			goto _testEof55
 		}
-	st_case_55:
+	stCase55:
 		switch (m.data)[(m.p)] {
 		case 33:
 			goto st56
@@ -2941,9 +2802,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr46
 	st56:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof56
+			goto _testEof56
 		}
-	st_case_56:
+	stCase56:
 		switch (m.data)[(m.p)] {
 		case 33:
 			goto st57
@@ -2961,9 +2822,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr46
 	st57:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof57
+			goto _testEof57
 		}
-	st_case_57:
+	stCase57:
 		switch (m.data)[(m.p)] {
 		case 33:
 			goto st58
@@ -2981,34 +2842,32 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr46
 	st58:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof58
+			goto _testEof58
 		}
-	st_case_58:
+	stCase58:
 		if (m.data)[(m.p)] == 61 {
 			goto tr49
 		}
 		goto tr46
 	tr49:
-//line rfc5424/machine.go.rl:128
 
 		m.currentparam = string(m.text())
 
 		goto st59
 	st59:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof59
+			goto _testEof59
 		}
-	st_case_59:
-//line rfc5424/machine.go:2936
+	stCase59:
 		if (m.data)[(m.p)] == 34 {
 			goto st60
 		}
 		goto tr46
 	st60:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof60
+			goto _testEof60
 		}
-	st_case_60:
+	stCase60:
 		switch (m.data)[(m.p)] {
 		case 34:
 			goto tr82
@@ -3049,17 +2908,15 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		}
 		goto tr81
 	tr81:
-//line rfc5424/machine.go.rl:58
 
 		m.pb = m.p
 
 		goto st61
 	st61:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof61
+			goto _testEof61
 		}
-	st_case_61:
-//line rfc5424/machine.go:2996
+	stCase61:
 		switch (m.data)[(m.p)] {
 		case 34:
 			goto tr93
@@ -3100,11 +2957,8 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		}
 		goto st61
 	tr82:
-//line rfc5424/machine.go.rl:58
 
 		m.pb = m.p
-
-//line rfc5424/machine.go.rl:132
 
 		if output.hasElements {
 			// (fixme) > what if SD-PARAM-NAME already exist for the current element (ie., current SD-ID)?
@@ -3121,7 +2975,6 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 
 		goto st62
 	tr93:
-//line rfc5424/machine.go.rl:132
 
 		if output.hasElements {
 			// (fixme) > what if SD-PARAM-NAME already exist for the current element (ie., current SD-ID)?
@@ -3139,10 +2992,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto st62
 	st62:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof62
+			goto _testEof62
 		}
-	st_case_62:
-//line rfc5424/machine.go:3079
+	stCase62:
 		switch (m.data)[(m.p)] {
 		case 32:
 			goto st26
@@ -3151,7 +3003,6 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		}
 		goto tr46
 	tr45:
-//line rfc5424/machine.go.rl:106
 
 		if _, ok := output.structuredData[string(m.text())]; ok {
 			// As per RFC5424 section 6.3.2 SD-ID MUST NOT exist more than once in a message
@@ -3171,10 +3022,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto st606
 	st606:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof606
+			goto _testEof606
 		}
-	st_case_606:
-//line rfc5424/machine.go:3109
+	stCase606:
 		switch (m.data)[(m.p)] {
 		case 32:
 			goto st604
@@ -3183,27 +3033,22 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		}
 		goto tr645
 	tr83:
-//line rfc5424/machine.go.rl:58
 
 		m.pb = m.p
-
-//line rfc5424/machine.go.rl:124
 
 		m.backslashat = append(m.backslashat, m.p)
 
 		goto st63
 	tr94:
-//line rfc5424/machine.go.rl:124
 
 		m.backslashat = append(m.backslashat, m.p)
 
 		goto st63
 	st63:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof63
+			goto _testEof63
 		}
-	st_case_63:
-//line rfc5424/machine.go:3138
+	stCase63:
 		if (m.data)[(m.p)] == 34 {
 			goto st61
 		}
@@ -3212,122 +3057,108 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		}
 		goto tr84
 	tr85:
-//line rfc5424/machine.go.rl:58
 
 		m.pb = m.p
 
 		goto st64
 	st64:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof64
+			goto _testEof64
 		}
-	st_case_64:
-//line rfc5424/machine.go:3157
+	stCase64:
 		if 128 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 191 {
 			goto st61
 		}
 		goto tr46
 	tr86:
-//line rfc5424/machine.go.rl:58
 
 		m.pb = m.p
 
 		goto st65
 	st65:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof65
+			goto _testEof65
 		}
-	st_case_65:
-//line rfc5424/machine.go:3173
+	stCase65:
 		if 160 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 191 {
 			goto st64
 		}
 		goto tr46
 	tr87:
-//line rfc5424/machine.go.rl:58
 
 		m.pb = m.p
 
 		goto st66
 	st66:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof66
+			goto _testEof66
 		}
-	st_case_66:
-//line rfc5424/machine.go:3189
+	stCase66:
 		if 128 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 191 {
 			goto st64
 		}
 		goto tr46
 	tr88:
-//line rfc5424/machine.go.rl:58
 
 		m.pb = m.p
 
 		goto st67
 	st67:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof67
+			goto _testEof67
 		}
-	st_case_67:
-//line rfc5424/machine.go:3205
+	stCase67:
 		if 128 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 159 {
 			goto st64
 		}
 		goto tr46
 	tr89:
-//line rfc5424/machine.go.rl:58
 
 		m.pb = m.p
 
 		goto st68
 	st68:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof68
+			goto _testEof68
 		}
-	st_case_68:
-//line rfc5424/machine.go:3221
+	stCase68:
 		if 144 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 191 {
 			goto st66
 		}
 		goto tr46
 	tr90:
-//line rfc5424/machine.go.rl:58
 
 		m.pb = m.p
 
 		goto st69
 	st69:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof69
+			goto _testEof69
 		}
-	st_case_69:
-//line rfc5424/machine.go:3237
+	stCase69:
 		if 128 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 191 {
 			goto st66
 		}
 		goto tr46
 	tr91:
-//line rfc5424/machine.go.rl:58
 
 		m.pb = m.p
 
 		goto st70
 	st70:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof70
+			goto _testEof70
 		}
-	st_case_70:
-//line rfc5424/machine.go:3253
+	stCase70:
 		if 128 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 143 {
 			goto st66
 		}
 		goto tr46
 	st71:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof71
+			goto _testEof71
 		}
-	st_case_71:
+	stCase71:
 		switch (m.data)[(m.p)] {
 		case 32:
 			goto tr43
@@ -3347,9 +3178,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr42
 	st72:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof72
+			goto _testEof72
 		}
-	st_case_72:
+	stCase72:
 		switch (m.data)[(m.p)] {
 		case 32:
 			goto tr43
@@ -3369,9 +3200,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr42
 	st73:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof73
+			goto _testEof73
 		}
-	st_case_73:
+	stCase73:
 		switch (m.data)[(m.p)] {
 		case 32:
 			goto tr43
@@ -3391,9 +3222,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr42
 	st74:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof74
+			goto _testEof74
 		}
-	st_case_74:
+	stCase74:
 		switch (m.data)[(m.p)] {
 		case 32:
 			goto tr43
@@ -3413,9 +3244,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr42
 	st75:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof75
+			goto _testEof75
 		}
-	st_case_75:
+	stCase75:
 		switch (m.data)[(m.p)] {
 		case 32:
 			goto tr43
@@ -3435,9 +3266,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr42
 	st76:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof76
+			goto _testEof76
 		}
-	st_case_76:
+	stCase76:
 		switch (m.data)[(m.p)] {
 		case 32:
 			goto tr43
@@ -3457,9 +3288,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr42
 	st77:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof77
+			goto _testEof77
 		}
-	st_case_77:
+	stCase77:
 		switch (m.data)[(m.p)] {
 		case 32:
 			goto tr43
@@ -3479,9 +3310,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr42
 	st78:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof78
+			goto _testEof78
 		}
-	st_case_78:
+	stCase78:
 		switch (m.data)[(m.p)] {
 		case 32:
 			goto tr43
@@ -3501,9 +3332,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr42
 	st79:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof79
+			goto _testEof79
 		}
-	st_case_79:
+	stCase79:
 		switch (m.data)[(m.p)] {
 		case 32:
 			goto tr43
@@ -3523,9 +3354,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr42
 	st80:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof80
+			goto _testEof80
 		}
-	st_case_80:
+	stCase80:
 		switch (m.data)[(m.p)] {
 		case 32:
 			goto tr43
@@ -3545,9 +3376,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr42
 	st81:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof81
+			goto _testEof81
 		}
-	st_case_81:
+	stCase81:
 		switch (m.data)[(m.p)] {
 		case 32:
 			goto tr43
@@ -3567,9 +3398,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr42
 	st82:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof82
+			goto _testEof82
 		}
-	st_case_82:
+	stCase82:
 		switch (m.data)[(m.p)] {
 		case 32:
 			goto tr43
@@ -3589,9 +3420,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr42
 	st83:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof83
+			goto _testEof83
 		}
-	st_case_83:
+	stCase83:
 		switch (m.data)[(m.p)] {
 		case 32:
 			goto tr43
@@ -3611,9 +3442,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr42
 	st84:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof84
+			goto _testEof84
 		}
-	st_case_84:
+	stCase84:
 		switch (m.data)[(m.p)] {
 		case 32:
 			goto tr43
@@ -3633,9 +3464,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr42
 	st85:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof85
+			goto _testEof85
 		}
-	st_case_85:
+	stCase85:
 		switch (m.data)[(m.p)] {
 		case 32:
 			goto tr43
@@ -3655,9 +3486,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr42
 	st86:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof86
+			goto _testEof86
 		}
-	st_case_86:
+	stCase86:
 		switch (m.data)[(m.p)] {
 		case 32:
 			goto tr43
@@ -3677,9 +3508,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr42
 	st87:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof87
+			goto _testEof87
 		}
-	st_case_87:
+	stCase87:
 		switch (m.data)[(m.p)] {
 		case 32:
 			goto tr43
@@ -3699,9 +3530,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr42
 	st88:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof88
+			goto _testEof88
 		}
-	st_case_88:
+	stCase88:
 		switch (m.data)[(m.p)] {
 		case 32:
 			goto tr43
@@ -3721,9 +3552,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr42
 	st89:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof89
+			goto _testEof89
 		}
-	st_case_89:
+	stCase89:
 		switch (m.data)[(m.p)] {
 		case 32:
 			goto tr43
@@ -3743,9 +3574,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr42
 	st90:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof90
+			goto _testEof90
 		}
-	st_case_90:
+	stCase90:
 		switch (m.data)[(m.p)] {
 		case 32:
 			goto tr43
@@ -3765,9 +3596,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr42
 	st91:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof91
+			goto _testEof91
 		}
-	st_case_91:
+	stCase91:
 		switch (m.data)[(m.p)] {
 		case 32:
 			goto tr43
@@ -3787,9 +3618,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr42
 	st92:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof92
+			goto _testEof92
 		}
-	st_case_92:
+	stCase92:
 		switch (m.data)[(m.p)] {
 		case 32:
 			goto tr43
@@ -3809,9 +3640,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr42
 	st93:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof93
+			goto _testEof93
 		}
-	st_case_93:
+	stCase93:
 		switch (m.data)[(m.p)] {
 		case 32:
 			goto tr43
@@ -3831,9 +3662,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr42
 	st94:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof94
+			goto _testEof94
 		}
-	st_case_94:
+	stCase94:
 		switch (m.data)[(m.p)] {
 		case 32:
 			goto tr43
@@ -3853,9 +3684,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr42
 	st95:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof95
+			goto _testEof95
 		}
-	st_case_95:
+	stCase95:
 		switch (m.data)[(m.p)] {
 		case 32:
 			goto tr43
@@ -3875,9 +3706,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr42
 	st96:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof96
+			goto _testEof96
 		}
-	st_case_96:
+	stCase96:
 		switch (m.data)[(m.p)] {
 		case 32:
 			goto tr43
@@ -3897,9 +3728,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr42
 	st97:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof97
+			goto _testEof97
 		}
-	st_case_97:
+	stCase97:
 		switch (m.data)[(m.p)] {
 		case 32:
 			goto tr43
@@ -3919,9 +3750,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr42
 	st98:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof98
+			goto _testEof98
 		}
-	st_case_98:
+	stCase98:
 		switch (m.data)[(m.p)] {
 		case 32:
 			goto tr43
@@ -3941,9 +3772,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr42
 	st99:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof99
+			goto _testEof99
 		}
-	st_case_99:
+	stCase99:
 		switch (m.data)[(m.p)] {
 		case 32:
 			goto tr43
@@ -3963,9 +3794,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr42
 	st100:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof100
+			goto _testEof100
 		}
-	st_case_100:
+	stCase100:
 		switch (m.data)[(m.p)] {
 		case 32:
 			goto tr43
@@ -3985,9 +3816,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr42
 	st101:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof101
+			goto _testEof101
 		}
-	st_case_101:
+	stCase101:
 		switch (m.data)[(m.p)] {
 		case 32:
 			goto tr43
@@ -3997,9 +3828,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr42
 	st102:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof102
+			goto _testEof102
 		}
-	st_case_102:
+	stCase102:
 		if (m.data)[(m.p)] == 32 {
 			goto tr31
 		}
@@ -4009,9 +3840,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr30
 	st103:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof103
+			goto _testEof103
 		}
-	st_case_103:
+	stCase103:
 		if (m.data)[(m.p)] == 32 {
 			goto tr31
 		}
@@ -4021,9 +3852,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr30
 	st104:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof104
+			goto _testEof104
 		}
-	st_case_104:
+	stCase104:
 		if (m.data)[(m.p)] == 32 {
 			goto tr31
 		}
@@ -4033,9 +3864,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr30
 	st105:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof105
+			goto _testEof105
 		}
-	st_case_105:
+	stCase105:
 		if (m.data)[(m.p)] == 32 {
 			goto tr31
 		}
@@ -4045,9 +3876,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr30
 	st106:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof106
+			goto _testEof106
 		}
-	st_case_106:
+	stCase106:
 		if (m.data)[(m.p)] == 32 {
 			goto tr31
 		}
@@ -4057,9 +3888,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr30
 	st107:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof107
+			goto _testEof107
 		}
-	st_case_107:
+	stCase107:
 		if (m.data)[(m.p)] == 32 {
 			goto tr31
 		}
@@ -4069,9 +3900,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr30
 	st108:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof108
+			goto _testEof108
 		}
-	st_case_108:
+	stCase108:
 		if (m.data)[(m.p)] == 32 {
 			goto tr31
 		}
@@ -4081,9 +3912,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr30
 	st109:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof109
+			goto _testEof109
 		}
-	st_case_109:
+	stCase109:
 		if (m.data)[(m.p)] == 32 {
 			goto tr31
 		}
@@ -4093,9 +3924,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr30
 	st110:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof110
+			goto _testEof110
 		}
-	st_case_110:
+	stCase110:
 		if (m.data)[(m.p)] == 32 {
 			goto tr31
 		}
@@ -4105,9 +3936,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr30
 	st111:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof111
+			goto _testEof111
 		}
-	st_case_111:
+	stCase111:
 		if (m.data)[(m.p)] == 32 {
 			goto tr31
 		}
@@ -4117,9 +3948,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr30
 	st112:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof112
+			goto _testEof112
 		}
-	st_case_112:
+	stCase112:
 		if (m.data)[(m.p)] == 32 {
 			goto tr31
 		}
@@ -4129,9 +3960,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr30
 	st113:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof113
+			goto _testEof113
 		}
-	st_case_113:
+	stCase113:
 		if (m.data)[(m.p)] == 32 {
 			goto tr31
 		}
@@ -4141,9 +3972,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr30
 	st114:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof114
+			goto _testEof114
 		}
-	st_case_114:
+	stCase114:
 		if (m.data)[(m.p)] == 32 {
 			goto tr31
 		}
@@ -4153,9 +3984,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr30
 	st115:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof115
+			goto _testEof115
 		}
-	st_case_115:
+	stCase115:
 		if (m.data)[(m.p)] == 32 {
 			goto tr31
 		}
@@ -4165,9 +3996,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr30
 	st116:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof116
+			goto _testEof116
 		}
-	st_case_116:
+	stCase116:
 		if (m.data)[(m.p)] == 32 {
 			goto tr31
 		}
@@ -4177,9 +4008,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr30
 	st117:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof117
+			goto _testEof117
 		}
-	st_case_117:
+	stCase117:
 		if (m.data)[(m.p)] == 32 {
 			goto tr31
 		}
@@ -4189,9 +4020,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr30
 	st118:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof118
+			goto _testEof118
 		}
-	st_case_118:
+	stCase118:
 		if (m.data)[(m.p)] == 32 {
 			goto tr31
 		}
@@ -4201,9 +4032,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr30
 	st119:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof119
+			goto _testEof119
 		}
-	st_case_119:
+	stCase119:
 		if (m.data)[(m.p)] == 32 {
 			goto tr31
 		}
@@ -4213,9 +4044,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr30
 	st120:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof120
+			goto _testEof120
 		}
-	st_case_120:
+	stCase120:
 		if (m.data)[(m.p)] == 32 {
 			goto tr31
 		}
@@ -4225,9 +4056,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr30
 	st121:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof121
+			goto _testEof121
 		}
-	st_case_121:
+	stCase121:
 		if (m.data)[(m.p)] == 32 {
 			goto tr31
 		}
@@ -4237,9 +4068,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr30
 	st122:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof122
+			goto _testEof122
 		}
-	st_case_122:
+	stCase122:
 		if (m.data)[(m.p)] == 32 {
 			goto tr31
 		}
@@ -4249,9 +4080,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr30
 	st123:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof123
+			goto _testEof123
 		}
-	st_case_123:
+	stCase123:
 		if (m.data)[(m.p)] == 32 {
 			goto tr31
 		}
@@ -4261,9 +4092,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr30
 	st124:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof124
+			goto _testEof124
 		}
-	st_case_124:
+	stCase124:
 		if (m.data)[(m.p)] == 32 {
 			goto tr31
 		}
@@ -4273,9 +4104,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr30
 	st125:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof125
+			goto _testEof125
 		}
-	st_case_125:
+	stCase125:
 		if (m.data)[(m.p)] == 32 {
 			goto tr31
 		}
@@ -4285,9 +4116,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr30
 	st126:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof126
+			goto _testEof126
 		}
-	st_case_126:
+	stCase126:
 		if (m.data)[(m.p)] == 32 {
 			goto tr31
 		}
@@ -4297,9 +4128,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr30
 	st127:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof127
+			goto _testEof127
 		}
-	st_case_127:
+	stCase127:
 		if (m.data)[(m.p)] == 32 {
 			goto tr31
 		}
@@ -4309,9 +4140,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr30
 	st128:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof128
+			goto _testEof128
 		}
-	st_case_128:
+	stCase128:
 		if (m.data)[(m.p)] == 32 {
 			goto tr31
 		}
@@ -4321,9 +4152,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr30
 	st129:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof129
+			goto _testEof129
 		}
-	st_case_129:
+	stCase129:
 		if (m.data)[(m.p)] == 32 {
 			goto tr31
 		}
@@ -4333,9 +4164,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr30
 	st130:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof130
+			goto _testEof130
 		}
-	st_case_130:
+	stCase130:
 		if (m.data)[(m.p)] == 32 {
 			goto tr31
 		}
@@ -4345,9 +4176,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr30
 	st131:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof131
+			goto _testEof131
 		}
-	st_case_131:
+	stCase131:
 		if (m.data)[(m.p)] == 32 {
 			goto tr31
 		}
@@ -4357,18 +4188,18 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr30
 	st132:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof132
+			goto _testEof132
 		}
-	st_case_132:
+	stCase132:
 		if (m.data)[(m.p)] == 32 {
 			goto tr31
 		}
 		goto tr30
 	st133:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof133
+			goto _testEof133
 		}
-	st_case_133:
+	stCase133:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -4378,9 +4209,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st134:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof134
+			goto _testEof134
 		}
-	st_case_134:
+	stCase134:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -4390,9 +4221,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st135:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof135
+			goto _testEof135
 		}
-	st_case_135:
+	stCase135:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -4402,9 +4233,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st136:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof136
+			goto _testEof136
 		}
-	st_case_136:
+	stCase136:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -4414,9 +4245,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st137:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof137
+			goto _testEof137
 		}
-	st_case_137:
+	stCase137:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -4426,9 +4257,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st138:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof138
+			goto _testEof138
 		}
-	st_case_138:
+	stCase138:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -4438,9 +4269,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st139:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof139
+			goto _testEof139
 		}
-	st_case_139:
+	stCase139:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -4450,9 +4281,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st140:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof140
+			goto _testEof140
 		}
-	st_case_140:
+	stCase140:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -4462,9 +4293,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st141:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof141
+			goto _testEof141
 		}
-	st_case_141:
+	stCase141:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -4474,9 +4305,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st142:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof142
+			goto _testEof142
 		}
-	st_case_142:
+	stCase142:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -4486,9 +4317,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st143:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof143
+			goto _testEof143
 		}
-	st_case_143:
+	stCase143:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -4498,9 +4329,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st144:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof144
+			goto _testEof144
 		}
-	st_case_144:
+	stCase144:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -4510,9 +4341,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st145:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof145
+			goto _testEof145
 		}
-	st_case_145:
+	stCase145:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -4522,9 +4353,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st146:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof146
+			goto _testEof146
 		}
-	st_case_146:
+	stCase146:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -4534,9 +4365,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st147:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof147
+			goto _testEof147
 		}
-	st_case_147:
+	stCase147:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -4546,9 +4377,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st148:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof148
+			goto _testEof148
 		}
-	st_case_148:
+	stCase148:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -4558,9 +4389,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st149:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof149
+			goto _testEof149
 		}
-	st_case_149:
+	stCase149:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -4570,9 +4401,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st150:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof150
+			goto _testEof150
 		}
-	st_case_150:
+	stCase150:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -4582,9 +4413,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st151:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof151
+			goto _testEof151
 		}
-	st_case_151:
+	stCase151:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -4594,9 +4425,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st152:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof152
+			goto _testEof152
 		}
-	st_case_152:
+	stCase152:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -4606,9 +4437,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st153:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof153
+			goto _testEof153
 		}
-	st_case_153:
+	stCase153:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -4618,9 +4449,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st154:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof154
+			goto _testEof154
 		}
-	st_case_154:
+	stCase154:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -4630,9 +4461,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st155:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof155
+			goto _testEof155
 		}
-	st_case_155:
+	stCase155:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -4642,9 +4473,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st156:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof156
+			goto _testEof156
 		}
-	st_case_156:
+	stCase156:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -4654,9 +4485,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st157:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof157
+			goto _testEof157
 		}
-	st_case_157:
+	stCase157:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -4666,9 +4497,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st158:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof158
+			goto _testEof158
 		}
-	st_case_158:
+	stCase158:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -4678,9 +4509,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st159:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof159
+			goto _testEof159
 		}
-	st_case_159:
+	stCase159:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -4690,9 +4521,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st160:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof160
+			goto _testEof160
 		}
-	st_case_160:
+	stCase160:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -4702,9 +4533,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st161:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof161
+			goto _testEof161
 		}
-	st_case_161:
+	stCase161:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -4714,9 +4545,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st162:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof162
+			goto _testEof162
 		}
-	st_case_162:
+	stCase162:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -4726,9 +4557,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st163:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof163
+			goto _testEof163
 		}
-	st_case_163:
+	stCase163:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -4738,9 +4569,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st164:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof164
+			goto _testEof164
 		}
-	st_case_164:
+	stCase164:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -4750,9 +4581,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st165:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof165
+			goto _testEof165
 		}
-	st_case_165:
+	stCase165:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -4762,9 +4593,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st166:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof166
+			goto _testEof166
 		}
-	st_case_166:
+	stCase166:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -4774,9 +4605,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st167:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof167
+			goto _testEof167
 		}
-	st_case_167:
+	stCase167:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -4786,9 +4617,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st168:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof168
+			goto _testEof168
 		}
-	st_case_168:
+	stCase168:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -4798,9 +4629,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st169:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof169
+			goto _testEof169
 		}
-	st_case_169:
+	stCase169:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -4810,9 +4641,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st170:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof170
+			goto _testEof170
 		}
-	st_case_170:
+	stCase170:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -4822,9 +4653,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st171:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof171
+			goto _testEof171
 		}
-	st_case_171:
+	stCase171:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -4834,9 +4665,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st172:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof172
+			goto _testEof172
 		}
-	st_case_172:
+	stCase172:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -4846,9 +4677,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st173:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof173
+			goto _testEof173
 		}
-	st_case_173:
+	stCase173:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -4858,9 +4689,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st174:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof174
+			goto _testEof174
 		}
-	st_case_174:
+	stCase174:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -4870,9 +4701,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st175:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof175
+			goto _testEof175
 		}
-	st_case_175:
+	stCase175:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -4882,9 +4713,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st176:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof176
+			goto _testEof176
 		}
-	st_case_176:
+	stCase176:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -4894,9 +4725,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st177:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof177
+			goto _testEof177
 		}
-	st_case_177:
+	stCase177:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -4906,9 +4737,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st178:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof178
+			goto _testEof178
 		}
-	st_case_178:
+	stCase178:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -4918,9 +4749,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st179:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof179
+			goto _testEof179
 		}
-	st_case_179:
+	stCase179:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -4930,9 +4761,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st180:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof180
+			goto _testEof180
 		}
-	st_case_180:
+	stCase180:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -4942,9 +4773,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st181:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof181
+			goto _testEof181
 		}
-	st_case_181:
+	stCase181:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -4954,9 +4785,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st182:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof182
+			goto _testEof182
 		}
-	st_case_182:
+	stCase182:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -4966,9 +4797,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st183:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof183
+			goto _testEof183
 		}
-	st_case_183:
+	stCase183:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -4978,9 +4809,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st184:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof184
+			goto _testEof184
 		}
-	st_case_184:
+	stCase184:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -4990,9 +4821,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st185:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof185
+			goto _testEof185
 		}
-	st_case_185:
+	stCase185:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -5002,9 +4833,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st186:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof186
+			goto _testEof186
 		}
-	st_case_186:
+	stCase186:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -5014,9 +4845,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st187:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof187
+			goto _testEof187
 		}
-	st_case_187:
+	stCase187:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -5026,9 +4857,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st188:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof188
+			goto _testEof188
 		}
-	st_case_188:
+	stCase188:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -5038,9 +4869,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st189:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof189
+			goto _testEof189
 		}
-	st_case_189:
+	stCase189:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -5050,9 +4881,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st190:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof190
+			goto _testEof190
 		}
-	st_case_190:
+	stCase190:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -5062,9 +4893,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st191:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof191
+			goto _testEof191
 		}
-	st_case_191:
+	stCase191:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -5074,9 +4905,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st192:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof192
+			goto _testEof192
 		}
-	st_case_192:
+	stCase192:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -5086,9 +4917,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st193:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof193
+			goto _testEof193
 		}
-	st_case_193:
+	stCase193:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -5098,9 +4929,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st194:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof194
+			goto _testEof194
 		}
-	st_case_194:
+	stCase194:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -5110,9 +4941,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st195:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof195
+			goto _testEof195
 		}
-	st_case_195:
+	stCase195:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -5122,9 +4953,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st196:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof196
+			goto _testEof196
 		}
-	st_case_196:
+	stCase196:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -5134,9 +4965,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st197:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof197
+			goto _testEof197
 		}
-	st_case_197:
+	stCase197:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -5146,9 +4977,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st198:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof198
+			goto _testEof198
 		}
-	st_case_198:
+	stCase198:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -5158,9 +4989,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st199:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof199
+			goto _testEof199
 		}
-	st_case_199:
+	stCase199:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -5170,9 +5001,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st200:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof200
+			goto _testEof200
 		}
-	st_case_200:
+	stCase200:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -5182,9 +5013,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st201:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof201
+			goto _testEof201
 		}
-	st_case_201:
+	stCase201:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -5194,9 +5025,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st202:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof202
+			goto _testEof202
 		}
-	st_case_202:
+	stCase202:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -5206,9 +5037,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st203:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof203
+			goto _testEof203
 		}
-	st_case_203:
+	stCase203:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -5218,9 +5049,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st204:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof204
+			goto _testEof204
 		}
-	st_case_204:
+	stCase204:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -5230,9 +5061,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st205:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof205
+			goto _testEof205
 		}
-	st_case_205:
+	stCase205:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -5242,9 +5073,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st206:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof206
+			goto _testEof206
 		}
-	st_case_206:
+	stCase206:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -5254,9 +5085,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st207:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof207
+			goto _testEof207
 		}
-	st_case_207:
+	stCase207:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -5266,9 +5097,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st208:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof208
+			goto _testEof208
 		}
-	st_case_208:
+	stCase208:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -5278,9 +5109,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st209:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof209
+			goto _testEof209
 		}
-	st_case_209:
+	stCase209:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -5290,9 +5121,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st210:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof210
+			goto _testEof210
 		}
-	st_case_210:
+	stCase210:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -5302,9 +5133,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st211:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof211
+			goto _testEof211
 		}
-	st_case_211:
+	stCase211:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -5314,9 +5145,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st212:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof212
+			goto _testEof212
 		}
-	st_case_212:
+	stCase212:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -5326,9 +5157,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st213:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof213
+			goto _testEof213
 		}
-	st_case_213:
+	stCase213:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -5338,9 +5169,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st214:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof214
+			goto _testEof214
 		}
-	st_case_214:
+	stCase214:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -5350,9 +5181,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st215:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof215
+			goto _testEof215
 		}
-	st_case_215:
+	stCase215:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -5362,9 +5193,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st216:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof216
+			goto _testEof216
 		}
-	st_case_216:
+	stCase216:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -5374,9 +5205,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st217:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof217
+			goto _testEof217
 		}
-	st_case_217:
+	stCase217:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -5386,9 +5217,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st218:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof218
+			goto _testEof218
 		}
-	st_case_218:
+	stCase218:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -5398,9 +5229,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st219:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof219
+			goto _testEof219
 		}
-	st_case_219:
+	stCase219:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -5410,9 +5241,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st220:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof220
+			goto _testEof220
 		}
-	st_case_220:
+	stCase220:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -5422,9 +5253,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st221:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof221
+			goto _testEof221
 		}
-	st_case_221:
+	stCase221:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -5434,9 +5265,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st222:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof222
+			goto _testEof222
 		}
-	st_case_222:
+	stCase222:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -5446,9 +5277,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st223:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof223
+			goto _testEof223
 		}
-	st_case_223:
+	stCase223:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -5458,9 +5289,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st224:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof224
+			goto _testEof224
 		}
-	st_case_224:
+	stCase224:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -5470,9 +5301,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st225:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof225
+			goto _testEof225
 		}
-	st_case_225:
+	stCase225:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -5482,9 +5313,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st226:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof226
+			goto _testEof226
 		}
-	st_case_226:
+	stCase226:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -5494,9 +5325,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st227:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof227
+			goto _testEof227
 		}
-	st_case_227:
+	stCase227:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -5506,9 +5337,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st228:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof228
+			goto _testEof228
 		}
-	st_case_228:
+	stCase228:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -5518,9 +5349,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st229:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof229
+			goto _testEof229
 		}
-	st_case_229:
+	stCase229:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -5530,9 +5361,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st230:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof230
+			goto _testEof230
 		}
-	st_case_230:
+	stCase230:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -5542,9 +5373,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st231:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof231
+			goto _testEof231
 		}
-	st_case_231:
+	stCase231:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -5554,9 +5385,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st232:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof232
+			goto _testEof232
 		}
-	st_case_232:
+	stCase232:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -5566,9 +5397,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st233:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof233
+			goto _testEof233
 		}
-	st_case_233:
+	stCase233:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -5578,9 +5409,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st234:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof234
+			goto _testEof234
 		}
-	st_case_234:
+	stCase234:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -5590,9 +5421,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st235:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof235
+			goto _testEof235
 		}
-	st_case_235:
+	stCase235:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -5602,9 +5433,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st236:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof236
+			goto _testEof236
 		}
-	st_case_236:
+	stCase236:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -5614,9 +5445,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st237:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof237
+			goto _testEof237
 		}
-	st_case_237:
+	stCase237:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -5626,9 +5457,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st238:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof238
+			goto _testEof238
 		}
-	st_case_238:
+	stCase238:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -5638,9 +5469,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st239:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof239
+			goto _testEof239
 		}
-	st_case_239:
+	stCase239:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -5650,9 +5481,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st240:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof240
+			goto _testEof240
 		}
-	st_case_240:
+	stCase240:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -5662,9 +5493,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st241:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof241
+			goto _testEof241
 		}
-	st_case_241:
+	stCase241:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -5674,9 +5505,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st242:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof242
+			goto _testEof242
 		}
-	st_case_242:
+	stCase242:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -5686,9 +5517,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st243:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof243
+			goto _testEof243
 		}
-	st_case_243:
+	stCase243:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -5698,9 +5529,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st244:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof244
+			goto _testEof244
 		}
-	st_case_244:
+	stCase244:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -5710,9 +5541,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st245:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof245
+			goto _testEof245
 		}
-	st_case_245:
+	stCase245:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -5722,9 +5553,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st246:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof246
+			goto _testEof246
 		}
-	st_case_246:
+	stCase246:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -5734,9 +5565,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st247:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof247
+			goto _testEof247
 		}
-	st_case_247:
+	stCase247:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -5746,9 +5577,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st248:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof248
+			goto _testEof248
 		}
-	st_case_248:
+	stCase248:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -5758,9 +5589,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st249:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof249
+			goto _testEof249
 		}
-	st_case_249:
+	stCase249:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -5770,9 +5601,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st250:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof250
+			goto _testEof250
 		}
-	st_case_250:
+	stCase250:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -5782,9 +5613,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st251:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof251
+			goto _testEof251
 		}
-	st_case_251:
+	stCase251:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -5794,9 +5625,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st252:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof252
+			goto _testEof252
 		}
-	st_case_252:
+	stCase252:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -5806,9 +5637,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st253:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof253
+			goto _testEof253
 		}
-	st_case_253:
+	stCase253:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -5818,9 +5649,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st254:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof254
+			goto _testEof254
 		}
-	st_case_254:
+	stCase254:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -5830,9 +5661,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st255:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof255
+			goto _testEof255
 		}
-	st_case_255:
+	stCase255:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -5842,9 +5673,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st256:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof256
+			goto _testEof256
 		}
-	st_case_256:
+	stCase256:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -5854,9 +5685,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st257:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof257
+			goto _testEof257
 		}
-	st_case_257:
+	stCase257:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -5866,9 +5697,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st258:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof258
+			goto _testEof258
 		}
-	st_case_258:
+	stCase258:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -5878,18 +5709,18 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st259:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof259
+			goto _testEof259
 		}
-	st_case_259:
+	stCase259:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
 		goto tr24
 	st260:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof260
+			goto _testEof260
 		}
-	st_case_260:
+	stCase260:
 		if (m.data)[(m.p)] == 32 {
 			goto tr22
 		}
@@ -5899,9 +5730,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr20
 	st261:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof261
+			goto _testEof261
 		}
-	st_case_261:
+	stCase261:
 		if (m.data)[(m.p)] == 32 {
 			goto tr22
 		}
@@ -5911,9 +5742,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr20
 	st262:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof262
+			goto _testEof262
 		}
-	st_case_262:
+	stCase262:
 		if (m.data)[(m.p)] == 32 {
 			goto tr22
 		}
@@ -5923,9 +5754,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr20
 	st263:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof263
+			goto _testEof263
 		}
-	st_case_263:
+	stCase263:
 		if (m.data)[(m.p)] == 32 {
 			goto tr22
 		}
@@ -5935,9 +5766,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr20
 	st264:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof264
+			goto _testEof264
 		}
-	st_case_264:
+	stCase264:
 		if (m.data)[(m.p)] == 32 {
 			goto tr22
 		}
@@ -5947,9 +5778,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr20
 	st265:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof265
+			goto _testEof265
 		}
-	st_case_265:
+	stCase265:
 		if (m.data)[(m.p)] == 32 {
 			goto tr22
 		}
@@ -5959,9 +5790,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr20
 	st266:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof266
+			goto _testEof266
 		}
-	st_case_266:
+	stCase266:
 		if (m.data)[(m.p)] == 32 {
 			goto tr22
 		}
@@ -5971,9 +5802,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr20
 	st267:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof267
+			goto _testEof267
 		}
-	st_case_267:
+	stCase267:
 		if (m.data)[(m.p)] == 32 {
 			goto tr22
 		}
@@ -5983,9 +5814,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr20
 	st268:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof268
+			goto _testEof268
 		}
-	st_case_268:
+	stCase268:
 		if (m.data)[(m.p)] == 32 {
 			goto tr22
 		}
@@ -5995,9 +5826,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr20
 	st269:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof269
+			goto _testEof269
 		}
-	st_case_269:
+	stCase269:
 		if (m.data)[(m.p)] == 32 {
 			goto tr22
 		}
@@ -6007,9 +5838,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr20
 	st270:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof270
+			goto _testEof270
 		}
-	st_case_270:
+	stCase270:
 		if (m.data)[(m.p)] == 32 {
 			goto tr22
 		}
@@ -6019,9 +5850,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr20
 	st271:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof271
+			goto _testEof271
 		}
-	st_case_271:
+	stCase271:
 		if (m.data)[(m.p)] == 32 {
 			goto tr22
 		}
@@ -6031,9 +5862,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr20
 	st272:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof272
+			goto _testEof272
 		}
-	st_case_272:
+	stCase272:
 		if (m.data)[(m.p)] == 32 {
 			goto tr22
 		}
@@ -6043,9 +5874,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr20
 	st273:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof273
+			goto _testEof273
 		}
-	st_case_273:
+	stCase273:
 		if (m.data)[(m.p)] == 32 {
 			goto tr22
 		}
@@ -6055,9 +5886,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr20
 	st274:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof274
+			goto _testEof274
 		}
-	st_case_274:
+	stCase274:
 		if (m.data)[(m.p)] == 32 {
 			goto tr22
 		}
@@ -6067,9 +5898,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr20
 	st275:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof275
+			goto _testEof275
 		}
-	st_case_275:
+	stCase275:
 		if (m.data)[(m.p)] == 32 {
 			goto tr22
 		}
@@ -6079,9 +5910,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr20
 	st276:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof276
+			goto _testEof276
 		}
-	st_case_276:
+	stCase276:
 		if (m.data)[(m.p)] == 32 {
 			goto tr22
 		}
@@ -6091,9 +5922,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr20
 	st277:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof277
+			goto _testEof277
 		}
-	st_case_277:
+	stCase277:
 		if (m.data)[(m.p)] == 32 {
 			goto tr22
 		}
@@ -6103,9 +5934,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr20
 	st278:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof278
+			goto _testEof278
 		}
-	st_case_278:
+	stCase278:
 		if (m.data)[(m.p)] == 32 {
 			goto tr22
 		}
@@ -6115,9 +5946,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr20
 	st279:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof279
+			goto _testEof279
 		}
-	st_case_279:
+	stCase279:
 		if (m.data)[(m.p)] == 32 {
 			goto tr22
 		}
@@ -6127,9 +5958,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr20
 	st280:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof280
+			goto _testEof280
 		}
-	st_case_280:
+	stCase280:
 		if (m.data)[(m.p)] == 32 {
 			goto tr22
 		}
@@ -6139,9 +5970,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr20
 	st281:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof281
+			goto _testEof281
 		}
-	st_case_281:
+	stCase281:
 		if (m.data)[(m.p)] == 32 {
 			goto tr22
 		}
@@ -6151,9 +5982,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr20
 	st282:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof282
+			goto _testEof282
 		}
-	st_case_282:
+	stCase282:
 		if (m.data)[(m.p)] == 32 {
 			goto tr22
 		}
@@ -6163,9 +5994,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr20
 	st283:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof283
+			goto _testEof283
 		}
-	st_case_283:
+	stCase283:
 		if (m.data)[(m.p)] == 32 {
 			goto tr22
 		}
@@ -6175,9 +6006,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr20
 	st284:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof284
+			goto _testEof284
 		}
-	st_case_284:
+	stCase284:
 		if (m.data)[(m.p)] == 32 {
 			goto tr22
 		}
@@ -6187,9 +6018,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr20
 	st285:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof285
+			goto _testEof285
 		}
-	st_case_285:
+	stCase285:
 		if (m.data)[(m.p)] == 32 {
 			goto tr22
 		}
@@ -6199,9 +6030,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr20
 	st286:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof286
+			goto _testEof286
 		}
-	st_case_286:
+	stCase286:
 		if (m.data)[(m.p)] == 32 {
 			goto tr22
 		}
@@ -6211,9 +6042,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr20
 	st287:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof287
+			goto _testEof287
 		}
-	st_case_287:
+	stCase287:
 		if (m.data)[(m.p)] == 32 {
 			goto tr22
 		}
@@ -6223,9 +6054,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr20
 	st288:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof288
+			goto _testEof288
 		}
-	st_case_288:
+	stCase288:
 		if (m.data)[(m.p)] == 32 {
 			goto tr22
 		}
@@ -6235,9 +6066,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr20
 	st289:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof289
+			goto _testEof289
 		}
-	st_case_289:
+	stCase289:
 		if (m.data)[(m.p)] == 32 {
 			goto tr22
 		}
@@ -6247,9 +6078,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr20
 	st290:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof290
+			goto _testEof290
 		}
-	st_case_290:
+	stCase290:
 		if (m.data)[(m.p)] == 32 {
 			goto tr22
 		}
@@ -6259,9 +6090,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr20
 	st291:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof291
+			goto _testEof291
 		}
-	st_case_291:
+	stCase291:
 		if (m.data)[(m.p)] == 32 {
 			goto tr22
 		}
@@ -6271,9 +6102,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr20
 	st292:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof292
+			goto _testEof292
 		}
-	st_case_292:
+	stCase292:
 		if (m.data)[(m.p)] == 32 {
 			goto tr22
 		}
@@ -6283,9 +6114,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr20
 	st293:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof293
+			goto _testEof293
 		}
-	st_case_293:
+	stCase293:
 		if (m.data)[(m.p)] == 32 {
 			goto tr22
 		}
@@ -6295,9 +6126,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr20
 	st294:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof294
+			goto _testEof294
 		}
-	st_case_294:
+	stCase294:
 		if (m.data)[(m.p)] == 32 {
 			goto tr22
 		}
@@ -6307,9 +6138,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr20
 	st295:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof295
+			goto _testEof295
 		}
-	st_case_295:
+	stCase295:
 		if (m.data)[(m.p)] == 32 {
 			goto tr22
 		}
@@ -6319,9 +6150,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr20
 	st296:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof296
+			goto _testEof296
 		}
-	st_case_296:
+	stCase296:
 		if (m.data)[(m.p)] == 32 {
 			goto tr22
 		}
@@ -6331,9 +6162,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr20
 	st297:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof297
+			goto _testEof297
 		}
-	st_case_297:
+	stCase297:
 		if (m.data)[(m.p)] == 32 {
 			goto tr22
 		}
@@ -6343,9 +6174,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr20
 	st298:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof298
+			goto _testEof298
 		}
-	st_case_298:
+	stCase298:
 		if (m.data)[(m.p)] == 32 {
 			goto tr22
 		}
@@ -6355,9 +6186,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr20
 	st299:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof299
+			goto _testEof299
 		}
-	st_case_299:
+	stCase299:
 		if (m.data)[(m.p)] == 32 {
 			goto tr22
 		}
@@ -6367,9 +6198,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr20
 	st300:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof300
+			goto _testEof300
 		}
-	st_case_300:
+	stCase300:
 		if (m.data)[(m.p)] == 32 {
 			goto tr22
 		}
@@ -6379,9 +6210,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr20
 	st301:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof301
+			goto _testEof301
 		}
-	st_case_301:
+	stCase301:
 		if (m.data)[(m.p)] == 32 {
 			goto tr22
 		}
@@ -6391,9 +6222,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr20
 	st302:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof302
+			goto _testEof302
 		}
-	st_case_302:
+	stCase302:
 		if (m.data)[(m.p)] == 32 {
 			goto tr22
 		}
@@ -6403,9 +6234,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr20
 	st303:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof303
+			goto _testEof303
 		}
-	st_case_303:
+	stCase303:
 		if (m.data)[(m.p)] == 32 {
 			goto tr22
 		}
@@ -6415,9 +6246,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr20
 	st304:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof304
+			goto _testEof304
 		}
-	st_case_304:
+	stCase304:
 		if (m.data)[(m.p)] == 32 {
 			goto tr22
 		}
@@ -6427,9 +6258,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr20
 	st305:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof305
+			goto _testEof305
 		}
-	st_case_305:
+	stCase305:
 		if (m.data)[(m.p)] == 32 {
 			goto tr22
 		}
@@ -6439,18 +6270,18 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr20
 	st306:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof306
+			goto _testEof306
 		}
-	st_case_306:
+	stCase306:
 		if (m.data)[(m.p)] == 32 {
 			goto tr22
 		}
 		goto tr20
 	st307:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof307
+			goto _testEof307
 		}
-	st_case_307:
+	stCase307:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -6460,9 +6291,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st308:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof308
+			goto _testEof308
 		}
-	st_case_308:
+	stCase308:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -6472,9 +6303,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st309:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof309
+			goto _testEof309
 		}
-	st_case_309:
+	stCase309:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -6484,9 +6315,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st310:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof310
+			goto _testEof310
 		}
-	st_case_310:
+	stCase310:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -6496,9 +6327,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st311:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof311
+			goto _testEof311
 		}
-	st_case_311:
+	stCase311:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -6508,9 +6339,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st312:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof312
+			goto _testEof312
 		}
-	st_case_312:
+	stCase312:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -6520,9 +6351,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st313:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof313
+			goto _testEof313
 		}
-	st_case_313:
+	stCase313:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -6532,9 +6363,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st314:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof314
+			goto _testEof314
 		}
-	st_case_314:
+	stCase314:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -6544,9 +6375,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st315:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof315
+			goto _testEof315
 		}
-	st_case_315:
+	stCase315:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -6556,9 +6387,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st316:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof316
+			goto _testEof316
 		}
-	st_case_316:
+	stCase316:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -6568,9 +6399,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st317:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof317
+			goto _testEof317
 		}
-	st_case_317:
+	stCase317:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -6580,9 +6411,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st318:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof318
+			goto _testEof318
 		}
-	st_case_318:
+	stCase318:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -6592,9 +6423,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st319:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof319
+			goto _testEof319
 		}
-	st_case_319:
+	stCase319:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -6604,9 +6435,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st320:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof320
+			goto _testEof320
 		}
-	st_case_320:
+	stCase320:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -6616,9 +6447,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st321:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof321
+			goto _testEof321
 		}
-	st_case_321:
+	stCase321:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -6628,9 +6459,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st322:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof322
+			goto _testEof322
 		}
-	st_case_322:
+	stCase322:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -6640,9 +6471,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st323:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof323
+			goto _testEof323
 		}
-	st_case_323:
+	stCase323:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -6652,9 +6483,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st324:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof324
+			goto _testEof324
 		}
-	st_case_324:
+	stCase324:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -6664,9 +6495,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st325:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof325
+			goto _testEof325
 		}
-	st_case_325:
+	stCase325:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -6676,9 +6507,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st326:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof326
+			goto _testEof326
 		}
-	st_case_326:
+	stCase326:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -6688,9 +6519,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st327:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof327
+			goto _testEof327
 		}
-	st_case_327:
+	stCase327:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -6700,9 +6531,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st328:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof328
+			goto _testEof328
 		}
-	st_case_328:
+	stCase328:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -6712,9 +6543,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st329:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof329
+			goto _testEof329
 		}
-	st_case_329:
+	stCase329:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -6724,9 +6555,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st330:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof330
+			goto _testEof330
 		}
-	st_case_330:
+	stCase330:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -6736,9 +6567,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st331:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof331
+			goto _testEof331
 		}
-	st_case_331:
+	stCase331:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -6748,9 +6579,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st332:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof332
+			goto _testEof332
 		}
-	st_case_332:
+	stCase332:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -6760,9 +6591,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st333:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof333
+			goto _testEof333
 		}
-	st_case_333:
+	stCase333:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -6772,9 +6603,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st334:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof334
+			goto _testEof334
 		}
-	st_case_334:
+	stCase334:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -6784,9 +6615,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st335:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof335
+			goto _testEof335
 		}
-	st_case_335:
+	stCase335:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -6796,9 +6627,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st336:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof336
+			goto _testEof336
 		}
-	st_case_336:
+	stCase336:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -6808,9 +6639,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st337:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof337
+			goto _testEof337
 		}
-	st_case_337:
+	stCase337:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -6820,9 +6651,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st338:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof338
+			goto _testEof338
 		}
-	st_case_338:
+	stCase338:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -6832,9 +6663,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st339:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof339
+			goto _testEof339
 		}
-	st_case_339:
+	stCase339:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -6844,9 +6675,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st340:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof340
+			goto _testEof340
 		}
-	st_case_340:
+	stCase340:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -6856,9 +6687,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st341:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof341
+			goto _testEof341
 		}
-	st_case_341:
+	stCase341:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -6868,9 +6699,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st342:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof342
+			goto _testEof342
 		}
-	st_case_342:
+	stCase342:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -6880,9 +6711,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st343:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof343
+			goto _testEof343
 		}
-	st_case_343:
+	stCase343:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -6892,9 +6723,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st344:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof344
+			goto _testEof344
 		}
-	st_case_344:
+	stCase344:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -6904,9 +6735,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st345:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof345
+			goto _testEof345
 		}
-	st_case_345:
+	stCase345:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -6916,9 +6747,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st346:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof346
+			goto _testEof346
 		}
-	st_case_346:
+	stCase346:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -6928,9 +6759,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st347:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof347
+			goto _testEof347
 		}
-	st_case_347:
+	stCase347:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -6940,9 +6771,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st348:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof348
+			goto _testEof348
 		}
-	st_case_348:
+	stCase348:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -6952,9 +6783,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st349:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof349
+			goto _testEof349
 		}
-	st_case_349:
+	stCase349:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -6964,9 +6795,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st350:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof350
+			goto _testEof350
 		}
-	st_case_350:
+	stCase350:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -6976,9 +6807,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st351:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof351
+			goto _testEof351
 		}
-	st_case_351:
+	stCase351:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -6988,9 +6819,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st352:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof352
+			goto _testEof352
 		}
-	st_case_352:
+	stCase352:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -7000,9 +6831,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st353:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof353
+			goto _testEof353
 		}
-	st_case_353:
+	stCase353:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -7012,9 +6843,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st354:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof354
+			goto _testEof354
 		}
-	st_case_354:
+	stCase354:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -7024,9 +6855,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st355:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof355
+			goto _testEof355
 		}
-	st_case_355:
+	stCase355:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -7036,9 +6867,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st356:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof356
+			goto _testEof356
 		}
-	st_case_356:
+	stCase356:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -7048,9 +6879,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st357:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof357
+			goto _testEof357
 		}
-	st_case_357:
+	stCase357:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -7060,9 +6891,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st358:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof358
+			goto _testEof358
 		}
-	st_case_358:
+	stCase358:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -7072,9 +6903,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st359:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof359
+			goto _testEof359
 		}
-	st_case_359:
+	stCase359:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -7084,9 +6915,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st360:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof360
+			goto _testEof360
 		}
-	st_case_360:
+	stCase360:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -7096,9 +6927,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st361:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof361
+			goto _testEof361
 		}
-	st_case_361:
+	stCase361:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -7108,9 +6939,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st362:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof362
+			goto _testEof362
 		}
-	st_case_362:
+	stCase362:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -7120,9 +6951,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st363:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof363
+			goto _testEof363
 		}
-	st_case_363:
+	stCase363:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -7132,9 +6963,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st364:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof364
+			goto _testEof364
 		}
-	st_case_364:
+	stCase364:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -7144,9 +6975,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st365:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof365
+			goto _testEof365
 		}
-	st_case_365:
+	stCase365:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -7156,9 +6987,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st366:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof366
+			goto _testEof366
 		}
-	st_case_366:
+	stCase366:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -7168,9 +6999,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st367:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof367
+			goto _testEof367
 		}
-	st_case_367:
+	stCase367:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -7180,9 +7011,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st368:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof368
+			goto _testEof368
 		}
-	st_case_368:
+	stCase368:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -7192,9 +7023,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st369:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof369
+			goto _testEof369
 		}
-	st_case_369:
+	stCase369:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -7204,9 +7035,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st370:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof370
+			goto _testEof370
 		}
-	st_case_370:
+	stCase370:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -7216,9 +7047,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st371:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof371
+			goto _testEof371
 		}
-	st_case_371:
+	stCase371:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -7228,9 +7059,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st372:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof372
+			goto _testEof372
 		}
-	st_case_372:
+	stCase372:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -7240,9 +7071,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st373:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof373
+			goto _testEof373
 		}
-	st_case_373:
+	stCase373:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -7252,9 +7083,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st374:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof374
+			goto _testEof374
 		}
-	st_case_374:
+	stCase374:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -7264,9 +7095,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st375:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof375
+			goto _testEof375
 		}
-	st_case_375:
+	stCase375:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -7276,9 +7107,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st376:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof376
+			goto _testEof376
 		}
-	st_case_376:
+	stCase376:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -7288,9 +7119,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st377:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof377
+			goto _testEof377
 		}
-	st_case_377:
+	stCase377:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -7300,9 +7131,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st378:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof378
+			goto _testEof378
 		}
-	st_case_378:
+	stCase378:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -7312,9 +7143,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st379:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof379
+			goto _testEof379
 		}
-	st_case_379:
+	stCase379:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -7324,9 +7155,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st380:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof380
+			goto _testEof380
 		}
-	st_case_380:
+	stCase380:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -7336,9 +7167,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st381:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof381
+			goto _testEof381
 		}
-	st_case_381:
+	stCase381:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -7348,9 +7179,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st382:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof382
+			goto _testEof382
 		}
-	st_case_382:
+	stCase382:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -7360,9 +7191,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st383:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof383
+			goto _testEof383
 		}
-	st_case_383:
+	stCase383:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -7372,9 +7203,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st384:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof384
+			goto _testEof384
 		}
-	st_case_384:
+	stCase384:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -7384,9 +7215,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st385:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof385
+			goto _testEof385
 		}
-	st_case_385:
+	stCase385:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -7396,9 +7227,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st386:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof386
+			goto _testEof386
 		}
-	st_case_386:
+	stCase386:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -7408,9 +7239,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st387:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof387
+			goto _testEof387
 		}
-	st_case_387:
+	stCase387:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -7420,9 +7251,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st388:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof388
+			goto _testEof388
 		}
-	st_case_388:
+	stCase388:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -7432,9 +7263,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st389:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof389
+			goto _testEof389
 		}
-	st_case_389:
+	stCase389:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -7444,9 +7275,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st390:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof390
+			goto _testEof390
 		}
-	st_case_390:
+	stCase390:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -7456,9 +7287,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st391:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof391
+			goto _testEof391
 		}
-	st_case_391:
+	stCase391:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -7468,9 +7299,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st392:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof392
+			goto _testEof392
 		}
-	st_case_392:
+	stCase392:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -7480,9 +7311,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st393:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof393
+			goto _testEof393
 		}
-	st_case_393:
+	stCase393:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -7492,9 +7323,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st394:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof394
+			goto _testEof394
 		}
-	st_case_394:
+	stCase394:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -7504,9 +7335,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st395:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof395
+			goto _testEof395
 		}
-	st_case_395:
+	stCase395:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -7516,9 +7347,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st396:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof396
+			goto _testEof396
 		}
-	st_case_396:
+	stCase396:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -7528,9 +7359,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st397:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof397
+			goto _testEof397
 		}
-	st_case_397:
+	stCase397:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -7540,9 +7371,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st398:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof398
+			goto _testEof398
 		}
-	st_case_398:
+	stCase398:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -7552,9 +7383,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st399:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof399
+			goto _testEof399
 		}
-	st_case_399:
+	stCase399:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -7564,9 +7395,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st400:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof400
+			goto _testEof400
 		}
-	st_case_400:
+	stCase400:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -7576,9 +7407,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st401:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof401
+			goto _testEof401
 		}
-	st_case_401:
+	stCase401:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -7588,9 +7419,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st402:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof402
+			goto _testEof402
 		}
-	st_case_402:
+	stCase402:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -7600,9 +7431,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st403:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof403
+			goto _testEof403
 		}
-	st_case_403:
+	stCase403:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -7612,9 +7443,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st404:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof404
+			goto _testEof404
 		}
-	st_case_404:
+	stCase404:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -7624,9 +7455,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st405:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof405
+			goto _testEof405
 		}
-	st_case_405:
+	stCase405:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -7636,9 +7467,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st406:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof406
+			goto _testEof406
 		}
-	st_case_406:
+	stCase406:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -7648,9 +7479,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st407:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof407
+			goto _testEof407
 		}
-	st_case_407:
+	stCase407:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -7660,9 +7491,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st408:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof408
+			goto _testEof408
 		}
-	st_case_408:
+	stCase408:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -7672,9 +7503,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st409:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof409
+			goto _testEof409
 		}
-	st_case_409:
+	stCase409:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -7684,9 +7515,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st410:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof410
+			goto _testEof410
 		}
-	st_case_410:
+	stCase410:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -7696,9 +7527,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st411:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof411
+			goto _testEof411
 		}
-	st_case_411:
+	stCase411:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -7708,9 +7539,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st412:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof412
+			goto _testEof412
 		}
-	st_case_412:
+	stCase412:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -7720,9 +7551,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st413:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof413
+			goto _testEof413
 		}
-	st_case_413:
+	stCase413:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -7732,9 +7563,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st414:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof414
+			goto _testEof414
 		}
-	st_case_414:
+	stCase414:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -7744,9 +7575,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st415:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof415
+			goto _testEof415
 		}
-	st_case_415:
+	stCase415:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -7756,9 +7587,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st416:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof416
+			goto _testEof416
 		}
-	st_case_416:
+	stCase416:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -7768,9 +7599,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st417:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof417
+			goto _testEof417
 		}
-	st_case_417:
+	stCase417:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -7780,9 +7611,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st418:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof418
+			goto _testEof418
 		}
-	st_case_418:
+	stCase418:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -7792,9 +7623,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st419:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof419
+			goto _testEof419
 		}
-	st_case_419:
+	stCase419:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -7804,9 +7635,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st420:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof420
+			goto _testEof420
 		}
-	st_case_420:
+	stCase420:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -7816,9 +7647,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st421:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof421
+			goto _testEof421
 		}
-	st_case_421:
+	stCase421:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -7828,9 +7659,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st422:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof422
+			goto _testEof422
 		}
-	st_case_422:
+	stCase422:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -7840,9 +7671,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st423:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof423
+			goto _testEof423
 		}
-	st_case_423:
+	stCase423:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -7852,9 +7683,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st424:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof424
+			goto _testEof424
 		}
-	st_case_424:
+	stCase424:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -7864,9 +7695,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st425:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof425
+			goto _testEof425
 		}
-	st_case_425:
+	stCase425:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -7876,9 +7707,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st426:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof426
+			goto _testEof426
 		}
-	st_case_426:
+	stCase426:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -7888,9 +7719,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st427:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof427
+			goto _testEof427
 		}
-	st_case_427:
+	stCase427:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -7900,9 +7731,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st428:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof428
+			goto _testEof428
 		}
-	st_case_428:
+	stCase428:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -7912,9 +7743,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st429:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof429
+			goto _testEof429
 		}
-	st_case_429:
+	stCase429:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -7924,9 +7755,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st430:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof430
+			goto _testEof430
 		}
-	st_case_430:
+	stCase430:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -7936,9 +7767,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st431:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof431
+			goto _testEof431
 		}
-	st_case_431:
+	stCase431:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -7948,9 +7779,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st432:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof432
+			goto _testEof432
 		}
-	st_case_432:
+	stCase432:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -7960,9 +7791,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st433:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof433
+			goto _testEof433
 		}
-	st_case_433:
+	stCase433:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -7972,9 +7803,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st434:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof434
+			goto _testEof434
 		}
-	st_case_434:
+	stCase434:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -7984,9 +7815,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st435:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof435
+			goto _testEof435
 		}
-	st_case_435:
+	stCase435:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -7996,9 +7827,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st436:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof436
+			goto _testEof436
 		}
-	st_case_436:
+	stCase436:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -8008,9 +7839,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st437:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof437
+			goto _testEof437
 		}
-	st_case_437:
+	stCase437:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -8020,9 +7851,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st438:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof438
+			goto _testEof438
 		}
-	st_case_438:
+	stCase438:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -8032,9 +7863,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st439:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof439
+			goto _testEof439
 		}
-	st_case_439:
+	stCase439:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -8044,9 +7875,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st440:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof440
+			goto _testEof440
 		}
-	st_case_440:
+	stCase440:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -8056,9 +7887,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st441:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof441
+			goto _testEof441
 		}
-	st_case_441:
+	stCase441:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -8068,9 +7899,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st442:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof442
+			goto _testEof442
 		}
-	st_case_442:
+	stCase442:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -8080,9 +7911,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st443:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof443
+			goto _testEof443
 		}
-	st_case_443:
+	stCase443:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -8092,9 +7923,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st444:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof444
+			goto _testEof444
 		}
-	st_case_444:
+	stCase444:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -8104,9 +7935,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st445:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof445
+			goto _testEof445
 		}
-	st_case_445:
+	stCase445:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -8116,9 +7947,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st446:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof446
+			goto _testEof446
 		}
-	st_case_446:
+	stCase446:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -8128,9 +7959,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st447:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof447
+			goto _testEof447
 		}
-	st_case_447:
+	stCase447:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -8140,9 +7971,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st448:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof448
+			goto _testEof448
 		}
-	st_case_448:
+	stCase448:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -8152,9 +7983,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st449:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof449
+			goto _testEof449
 		}
-	st_case_449:
+	stCase449:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -8164,9 +7995,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st450:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof450
+			goto _testEof450
 		}
-	st_case_450:
+	stCase450:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -8176,9 +8007,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st451:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof451
+			goto _testEof451
 		}
-	st_case_451:
+	stCase451:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -8188,9 +8019,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st452:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof452
+			goto _testEof452
 		}
-	st_case_452:
+	stCase452:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -8200,9 +8031,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st453:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof453
+			goto _testEof453
 		}
-	st_case_453:
+	stCase453:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -8212,9 +8043,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st454:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof454
+			goto _testEof454
 		}
-	st_case_454:
+	stCase454:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -8224,9 +8055,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st455:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof455
+			goto _testEof455
 		}
-	st_case_455:
+	stCase455:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -8236,9 +8067,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st456:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof456
+			goto _testEof456
 		}
-	st_case_456:
+	stCase456:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -8248,9 +8079,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st457:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof457
+			goto _testEof457
 		}
-	st_case_457:
+	stCase457:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -8260,9 +8091,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st458:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof458
+			goto _testEof458
 		}
-	st_case_458:
+	stCase458:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -8272,9 +8103,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st459:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof459
+			goto _testEof459
 		}
-	st_case_459:
+	stCase459:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -8284,9 +8115,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st460:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof460
+			goto _testEof460
 		}
-	st_case_460:
+	stCase460:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -8296,9 +8127,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st461:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof461
+			goto _testEof461
 		}
-	st_case_461:
+	stCase461:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -8308,9 +8139,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st462:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof462
+			goto _testEof462
 		}
-	st_case_462:
+	stCase462:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -8320,9 +8151,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st463:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof463
+			goto _testEof463
 		}
-	st_case_463:
+	stCase463:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -8332,9 +8163,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st464:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof464
+			goto _testEof464
 		}
-	st_case_464:
+	stCase464:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -8344,9 +8175,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st465:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof465
+			goto _testEof465
 		}
-	st_case_465:
+	stCase465:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -8356,9 +8187,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st466:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof466
+			goto _testEof466
 		}
-	st_case_466:
+	stCase466:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -8368,9 +8199,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st467:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof467
+			goto _testEof467
 		}
-	st_case_467:
+	stCase467:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -8380,9 +8211,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st468:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof468
+			goto _testEof468
 		}
-	st_case_468:
+	stCase468:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -8392,9 +8223,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st469:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof469
+			goto _testEof469
 		}
-	st_case_469:
+	stCase469:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -8404,9 +8235,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st470:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof470
+			goto _testEof470
 		}
-	st_case_470:
+	stCase470:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -8416,9 +8247,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st471:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof471
+			goto _testEof471
 		}
-	st_case_471:
+	stCase471:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -8428,9 +8259,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st472:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof472
+			goto _testEof472
 		}
-	st_case_472:
+	stCase472:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -8440,9 +8271,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st473:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof473
+			goto _testEof473
 		}
-	st_case_473:
+	stCase473:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -8452,9 +8283,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st474:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof474
+			goto _testEof474
 		}
-	st_case_474:
+	stCase474:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -8464,9 +8295,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st475:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof475
+			goto _testEof475
 		}
-	st_case_475:
+	stCase475:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -8476,9 +8307,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st476:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof476
+			goto _testEof476
 		}
-	st_case_476:
+	stCase476:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -8488,9 +8319,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st477:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof477
+			goto _testEof477
 		}
-	st_case_477:
+	stCase477:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -8500,9 +8331,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st478:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof478
+			goto _testEof478
 		}
-	st_case_478:
+	stCase478:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -8512,9 +8343,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st479:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof479
+			goto _testEof479
 		}
-	st_case_479:
+	stCase479:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -8524,9 +8355,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st480:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof480
+			goto _testEof480
 		}
-	st_case_480:
+	stCase480:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -8536,9 +8367,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st481:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof481
+			goto _testEof481
 		}
-	st_case_481:
+	stCase481:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -8548,9 +8379,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st482:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof482
+			goto _testEof482
 		}
-	st_case_482:
+	stCase482:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -8560,9 +8391,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st483:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof483
+			goto _testEof483
 		}
-	st_case_483:
+	stCase483:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -8572,9 +8403,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st484:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof484
+			goto _testEof484
 		}
-	st_case_484:
+	stCase484:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -8584,9 +8415,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st485:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof485
+			goto _testEof485
 		}
-	st_case_485:
+	stCase485:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -8596,9 +8427,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st486:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof486
+			goto _testEof486
 		}
-	st_case_486:
+	stCase486:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -8608,9 +8439,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st487:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof487
+			goto _testEof487
 		}
-	st_case_487:
+	stCase487:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -8620,9 +8451,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st488:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof488
+			goto _testEof488
 		}
-	st_case_488:
+	stCase488:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -8632,9 +8463,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st489:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof489
+			goto _testEof489
 		}
-	st_case_489:
+	stCase489:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -8644,9 +8475,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st490:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof490
+			goto _testEof490
 		}
-	st_case_490:
+	stCase490:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -8656,9 +8487,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st491:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof491
+			goto _testEof491
 		}
-	st_case_491:
+	stCase491:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -8668,9 +8499,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st492:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof492
+			goto _testEof492
 		}
-	st_case_492:
+	stCase492:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -8680,9 +8511,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st493:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof493
+			goto _testEof493
 		}
-	st_case_493:
+	stCase493:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -8692,9 +8523,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st494:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof494
+			goto _testEof494
 		}
-	st_case_494:
+	stCase494:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -8704,9 +8535,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st495:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof495
+			goto _testEof495
 		}
-	st_case_495:
+	stCase495:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -8716,9 +8547,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st496:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof496
+			goto _testEof496
 		}
-	st_case_496:
+	stCase496:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -8728,9 +8559,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st497:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof497
+			goto _testEof497
 		}
-	st_case_497:
+	stCase497:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -8740,9 +8571,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st498:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof498
+			goto _testEof498
 		}
-	st_case_498:
+	stCase498:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -8752,9 +8583,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st499:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof499
+			goto _testEof499
 		}
-	st_case_499:
+	stCase499:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -8764,9 +8595,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st500:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof500
+			goto _testEof500
 		}
-	st_case_500:
+	stCase500:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -8776,9 +8607,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st501:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof501
+			goto _testEof501
 		}
-	st_case_501:
+	stCase501:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -8788,9 +8619,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st502:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof502
+			goto _testEof502
 		}
-	st_case_502:
+	stCase502:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -8800,9 +8631,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st503:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof503
+			goto _testEof503
 		}
-	st_case_503:
+	stCase503:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -8812,9 +8643,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st504:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof504
+			goto _testEof504
 		}
-	st_case_504:
+	stCase504:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -8824,9 +8655,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st505:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof505
+			goto _testEof505
 		}
-	st_case_505:
+	stCase505:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -8836,9 +8667,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st506:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof506
+			goto _testEof506
 		}
-	st_case_506:
+	stCase506:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -8848,9 +8679,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st507:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof507
+			goto _testEof507
 		}
-	st_case_507:
+	stCase507:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -8860,9 +8691,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st508:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof508
+			goto _testEof508
 		}
-	st_case_508:
+	stCase508:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -8872,9 +8703,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st509:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof509
+			goto _testEof509
 		}
-	st_case_509:
+	stCase509:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -8884,9 +8715,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st510:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof510
+			goto _testEof510
 		}
-	st_case_510:
+	stCase510:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -8896,9 +8727,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st511:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof511
+			goto _testEof511
 		}
-	st_case_511:
+	stCase511:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -8908,9 +8739,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st512:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof512
+			goto _testEof512
 		}
-	st_case_512:
+	stCase512:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -8920,9 +8751,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st513:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof513
+			goto _testEof513
 		}
-	st_case_513:
+	stCase513:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -8932,9 +8763,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st514:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof514
+			goto _testEof514
 		}
-	st_case_514:
+	stCase514:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -8944,9 +8775,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st515:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof515
+			goto _testEof515
 		}
-	st_case_515:
+	stCase515:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -8956,9 +8787,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st516:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof516
+			goto _testEof516
 		}
-	st_case_516:
+	stCase516:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -8968,9 +8799,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st517:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof517
+			goto _testEof517
 		}
-	st_case_517:
+	stCase517:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -8980,9 +8811,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st518:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof518
+			goto _testEof518
 		}
-	st_case_518:
+	stCase518:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -8992,9 +8823,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st519:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof519
+			goto _testEof519
 		}
-	st_case_519:
+	stCase519:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -9004,9 +8835,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st520:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof520
+			goto _testEof520
 		}
-	st_case_520:
+	stCase520:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -9016,9 +8847,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st521:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof521
+			goto _testEof521
 		}
-	st_case_521:
+	stCase521:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -9028,9 +8859,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st522:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof522
+			goto _testEof522
 		}
-	st_case_522:
+	stCase522:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -9040,9 +8871,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st523:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof523
+			goto _testEof523
 		}
-	st_case_523:
+	stCase523:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -9052,9 +8883,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st524:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof524
+			goto _testEof524
 		}
-	st_case_524:
+	stCase524:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -9064,9 +8895,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st525:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof525
+			goto _testEof525
 		}
-	st_case_525:
+	stCase525:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -9076,9 +8907,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st526:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof526
+			goto _testEof526
 		}
-	st_case_526:
+	stCase526:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -9088,9 +8919,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st527:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof527
+			goto _testEof527
 		}
-	st_case_527:
+	stCase527:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -9100,9 +8931,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st528:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof528
+			goto _testEof528
 		}
-	st_case_528:
+	stCase528:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -9112,9 +8943,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st529:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof529
+			goto _testEof529
 		}
-	st_case_529:
+	stCase529:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -9124,9 +8955,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st530:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof530
+			goto _testEof530
 		}
-	st_case_530:
+	stCase530:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -9136,9 +8967,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st531:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof531
+			goto _testEof531
 		}
-	st_case_531:
+	stCase531:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -9148,9 +8979,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st532:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof532
+			goto _testEof532
 		}
-	st_case_532:
+	stCase532:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -9160,9 +8991,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st533:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof533
+			goto _testEof533
 		}
-	st_case_533:
+	stCase533:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -9172,9 +9003,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st534:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof534
+			goto _testEof534
 		}
-	st_case_534:
+	stCase534:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -9184,9 +9015,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st535:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof535
+			goto _testEof535
 		}
-	st_case_535:
+	stCase535:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -9196,9 +9027,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st536:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof536
+			goto _testEof536
 		}
-	st_case_536:
+	stCase536:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -9208,9 +9039,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st537:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof537
+			goto _testEof537
 		}
-	st_case_537:
+	stCase537:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -9220,9 +9051,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st538:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof538
+			goto _testEof538
 		}
-	st_case_538:
+	stCase538:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -9232,9 +9063,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st539:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof539
+			goto _testEof539
 		}
-	st_case_539:
+	stCase539:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -9244,9 +9075,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st540:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof540
+			goto _testEof540
 		}
-	st_case_540:
+	stCase540:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -9256,9 +9087,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st541:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof541
+			goto _testEof541
 		}
-	st_case_541:
+	stCase541:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -9268,9 +9099,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st542:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof542
+			goto _testEof542
 		}
-	st_case_542:
+	stCase542:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -9280,9 +9111,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st543:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof543
+			goto _testEof543
 		}
-	st_case_543:
+	stCase543:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -9292,9 +9123,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st544:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof544
+			goto _testEof544
 		}
-	st_case_544:
+	stCase544:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -9304,9 +9135,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st545:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof545
+			goto _testEof545
 		}
-	st_case_545:
+	stCase545:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -9316,9 +9147,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st546:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof546
+			goto _testEof546
 		}
-	st_case_546:
+	stCase546:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -9328,9 +9159,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st547:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof547
+			goto _testEof547
 		}
-	st_case_547:
+	stCase547:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -9340,9 +9171,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st548:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof548
+			goto _testEof548
 		}
-	st_case_548:
+	stCase548:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -9352,9 +9183,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st549:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof549
+			goto _testEof549
 		}
-	st_case_549:
+	stCase549:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -9364,9 +9195,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st550:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof550
+			goto _testEof550
 		}
-	st_case_550:
+	stCase550:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -9376,9 +9207,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st551:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof551
+			goto _testEof551
 		}
-	st_case_551:
+	stCase551:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -9388,9 +9219,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st552:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof552
+			goto _testEof552
 		}
-	st_case_552:
+	stCase552:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -9400,9 +9231,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st553:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof553
+			goto _testEof553
 		}
-	st_case_553:
+	stCase553:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -9412,9 +9243,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st554:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof554
+			goto _testEof554
 		}
-	st_case_554:
+	stCase554:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -9424,9 +9255,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st555:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof555
+			goto _testEof555
 		}
-	st_case_555:
+	stCase555:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -9436,9 +9267,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st556:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof556
+			goto _testEof556
 		}
-	st_case_556:
+	stCase556:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -9448,9 +9279,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st557:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof557
+			goto _testEof557
 		}
-	st_case_557:
+	stCase557:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -9460,9 +9291,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st558:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof558
+			goto _testEof558
 		}
-	st_case_558:
+	stCase558:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -9472,9 +9303,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st559:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof559
+			goto _testEof559
 		}
-	st_case_559:
+	stCase559:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -9484,61 +9315,59 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st560:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof560
+			goto _testEof560
 		}
-	st_case_560:
+	stCase560:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
 		goto tr16
 	tr14:
-//line rfc5424/machine.go.rl:58
 
 		m.pb = m.p
 
 		goto st561
 	st561:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof561
+			goto _testEof561
 		}
-	st_case_561:
-//line rfc5424/machine.go:9437
+	stCase561:
 		if 48 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 57 {
 			goto st562
 		}
 		goto tr12
 	st562:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof562
+			goto _testEof562
 		}
-	st_case_562:
+	stCase562:
 		if 48 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 57 {
 			goto st563
 		}
 		goto tr12
 	st563:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof563
+			goto _testEof563
 		}
-	st_case_563:
+	stCase563:
 		if 48 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 57 {
 			goto st564
 		}
 		goto tr12
 	st564:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof564
+			goto _testEof564
 		}
-	st_case_564:
+	stCase564:
 		if (m.data)[(m.p)] == 45 {
 			goto st565
 		}
 		goto tr12
 	st565:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof565
+			goto _testEof565
 		}
-	st_case_565:
+	stCase565:
 		switch (m.data)[(m.p)] {
 		case 48:
 			goto st566
@@ -9548,27 +9377,27 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr12
 	st566:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof566
+			goto _testEof566
 		}
-	st_case_566:
+	stCase566:
 		if 49 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 57 {
 			goto st567
 		}
 		goto tr12
 	st567:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof567
+			goto _testEof567
 		}
-	st_case_567:
+	stCase567:
 		if (m.data)[(m.p)] == 45 {
 			goto st568
 		}
 		goto tr12
 	st568:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof568
+			goto _testEof568
 		}
-	st_case_568:
+	stCase568:
 		switch (m.data)[(m.p)] {
 		case 48:
 			goto st569
@@ -9581,27 +9410,27 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr12
 	st569:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof569
+			goto _testEof569
 		}
-	st_case_569:
+	stCase569:
 		if 49 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 57 {
 			goto st570
 		}
 		goto tr12
 	st570:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof570
+			goto _testEof570
 		}
-	st_case_570:
+	stCase570:
 		if (m.data)[(m.p)] == 84 {
 			goto st571
 		}
 		goto tr12
 	st571:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof571
+			goto _testEof571
 		}
-	st_case_571:
+	stCase571:
 		if (m.data)[(m.p)] == 50 {
 			goto st594
 		}
@@ -9611,72 +9440,72 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr12
 	st572:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof572
+			goto _testEof572
 		}
-	st_case_572:
+	stCase572:
 		if 48 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 57 {
 			goto st573
 		}
 		goto tr12
 	st573:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof573
+			goto _testEof573
 		}
-	st_case_573:
+	stCase573:
 		if (m.data)[(m.p)] == 58 {
 			goto st574
 		}
 		goto tr12
 	st574:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof574
+			goto _testEof574
 		}
-	st_case_574:
+	stCase574:
 		if 48 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 53 {
 			goto st575
 		}
 		goto tr12
 	st575:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof575
+			goto _testEof575
 		}
-	st_case_575:
+	stCase575:
 		if 48 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 57 {
 			goto st576
 		}
 		goto tr12
 	st576:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof576
+			goto _testEof576
 		}
-	st_case_576:
+	stCase576:
 		if (m.data)[(m.p)] == 58 {
 			goto st577
 		}
 		goto tr12
 	st577:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof577
+			goto _testEof577
 		}
-	st_case_577:
+	stCase577:
 		if 48 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 53 {
 			goto st578
 		}
 		goto tr12
 	st578:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof578
+			goto _testEof578
 		}
-	st_case_578:
+	stCase578:
 		if 48 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 57 {
 			goto st579
 		}
 		goto tr12
 	st579:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof579
+			goto _testEof579
 		}
-	st_case_579:
+	stCase579:
 		switch (m.data)[(m.p)] {
 		case 43:
 			goto st580
@@ -9690,9 +9519,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr12
 	st580:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof580
+			goto _testEof580
 		}
-	st_case_580:
+	stCase580:
 		if (m.data)[(m.p)] == 50 {
 			goto st586
 		}
@@ -9702,72 +9531,72 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr12
 	st581:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof581
+			goto _testEof581
 		}
-	st_case_581:
+	stCase581:
 		if 48 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 57 {
 			goto st582
 		}
 		goto tr12
 	st582:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof582
+			goto _testEof582
 		}
-	st_case_582:
+	stCase582:
 		if (m.data)[(m.p)] == 58 {
 			goto st583
 		}
 		goto tr12
 	st583:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof583
+			goto _testEof583
 		}
-	st_case_583:
+	stCase583:
 		if 48 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 53 {
 			goto st584
 		}
 		goto tr12
 	st584:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof584
+			goto _testEof584
 		}
-	st_case_584:
+	stCase584:
 		if 48 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 57 {
 			goto st585
 		}
 		goto tr12
 	st585:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof585
+			goto _testEof585
 		}
-	st_case_585:
+	stCase585:
 		if (m.data)[(m.p)] == 32 {
 			goto tr620
 		}
 		goto tr619
 	st586:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof586
+			goto _testEof586
 		}
-	st_case_586:
+	stCase586:
 		if 48 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 51 {
 			goto st582
 		}
 		goto tr12
 	st587:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof587
+			goto _testEof587
 		}
-	st_case_587:
+	stCase587:
 		if 48 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 57 {
 			goto st588
 		}
 		goto tr12
 	st588:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof588
+			goto _testEof588
 		}
-	st_case_588:
+	stCase588:
 		switch (m.data)[(m.p)] {
 		case 43:
 			goto st580
@@ -9782,9 +9611,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr12
 	st589:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof589
+			goto _testEof589
 		}
-	st_case_589:
+	stCase589:
 		switch (m.data)[(m.p)] {
 		case 43:
 			goto st580
@@ -9799,9 +9628,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr12
 	st590:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof590
+			goto _testEof590
 		}
-	st_case_590:
+	stCase590:
 		switch (m.data)[(m.p)] {
 		case 43:
 			goto st580
@@ -9816,9 +9645,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr12
 	st591:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof591
+			goto _testEof591
 		}
-	st_case_591:
+	stCase591:
 		switch (m.data)[(m.p)] {
 		case 43:
 			goto st580
@@ -9833,9 +9662,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr12
 	st592:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof592
+			goto _testEof592
 		}
-	st_case_592:
+	stCase592:
 		switch (m.data)[(m.p)] {
 		case 43:
 			goto st580
@@ -9850,9 +9679,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr12
 	st593:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof593
+			goto _testEof593
 		}
-	st_case_593:
+	stCase593:
 		switch (m.data)[(m.p)] {
 		case 43:
 			goto st580
@@ -9864,50 +9693,48 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr12
 	st594:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof594
+			goto _testEof594
 		}
-	st_case_594:
+	stCase594:
 		if 48 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 51 {
 			goto st573
 		}
 		goto tr12
 	st595:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof595
+			goto _testEof595
 		}
-	st_case_595:
+	stCase595:
 		if 48 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 57 {
 			goto st570
 		}
 		goto tr12
 	st596:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof596
+			goto _testEof596
 		}
-	st_case_596:
+	stCase596:
 		if 48 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 49 {
 			goto st570
 		}
 		goto tr12
 	st597:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof597
+			goto _testEof597
 		}
-	st_case_597:
+	stCase597:
 		if 48 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 50 {
 			goto st567
 		}
 		goto tr12
 	st598:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof598
+			goto _testEof598
 		}
-	st_case_598:
-//line rfc5424/machine.go.rl:71
+	stCase598:
 
 		output.version = uint16(common.UnsafeUTF8DecimalCodePointsToInt(m.text()))
 
-//line rfc5424/machine.go:9842
 		if (m.data)[(m.p)] == 32 {
 			goto st6
 		}
@@ -9917,35 +9744,30 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr7
 	st599:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof599
+			goto _testEof599
 		}
-	st_case_599:
-//line rfc5424/machine.go.rl:71
+	stCase599:
 
 		output.version = uint16(common.UnsafeUTF8DecimalCodePointsToInt(m.text()))
 
-//line rfc5424/machine.go:9859
 		if (m.data)[(m.p)] == 32 {
 			goto st6
 		}
 		goto tr7
 	tr4:
-//line rfc5424/machine.go.rl:58
 
 		m.pb = m.p
 
 		goto st600
 	st600:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof600
+			goto _testEof600
 		}
-	st_case_600:
-//line rfc5424/machine.go.rl:66
+	stCase600:
 
 		output.priority = uint8(common.UnsafeUTF8DecimalCodePointsToInt(m.text()))
 		output.prioritySet = true
 
-//line rfc5424/machine.go:9880
 		switch (m.data)[(m.p)] {
 		case 57:
 			goto st602
@@ -9957,22 +9779,19 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		}
 		goto tr2
 	tr5:
-//line rfc5424/machine.go.rl:58
 
 		m.pb = m.p
 
 		goto st601
 	st601:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof601
+			goto _testEof601
 		}
-	st_case_601:
-//line rfc5424/machine.go.rl:66
+	stCase601:
 
 		output.priority = uint8(common.UnsafeUTF8DecimalCodePointsToInt(m.text()))
 		output.prioritySet = true
 
-//line rfc5424/machine.go:9907
 		if (m.data)[(m.p)] == 62 {
 			goto st4
 		}
@@ -9982,15 +9801,13 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr2
 	st602:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof602
+			goto _testEof602
 		}
-	st_case_602:
-//line rfc5424/machine.go.rl:66
+	stCase602:
 
 		output.priority = uint8(common.UnsafeUTF8DecimalCodePointsToInt(m.text()))
 		output.prioritySet = true
 
-//line rfc5424/machine.go:9925
 		if (m.data)[(m.p)] == 62 {
 			goto st4
 		}
@@ -10000,9 +9817,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr2
 	st607:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _test_eof607
+			goto _testEof607
 		}
-	st_case_607:
+	stCase607:
 		switch (m.data)[(m.p)] {
 		case 10:
 			goto st0
@@ -10010,1838 +9827,1836 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 			goto st0
 		}
 		goto st607
-	st_out:
-	_test_eof2:
+	stOut:
+	_testEof2:
 		m.cs = 2
-		goto _test_eof
-	_test_eof3:
+		goto _testEof
+	_testEof3:
 		m.cs = 3
-		goto _test_eof
-	_test_eof4:
+		goto _testEof
+	_testEof4:
 		m.cs = 4
-		goto _test_eof
-	_test_eof5:
+		goto _testEof
+	_testEof5:
 		m.cs = 5
-		goto _test_eof
-	_test_eof6:
+		goto _testEof
+	_testEof6:
 		m.cs = 6
-		goto _test_eof
-	_test_eof7:
+		goto _testEof
+	_testEof7:
 		m.cs = 7
-		goto _test_eof
-	_test_eof8:
+		goto _testEof
+	_testEof8:
 		m.cs = 8
-		goto _test_eof
-	_test_eof9:
+		goto _testEof
+	_testEof9:
 		m.cs = 9
-		goto _test_eof
-	_test_eof10:
+		goto _testEof
+	_testEof10:
 		m.cs = 10
-		goto _test_eof
-	_test_eof11:
+		goto _testEof
+	_testEof11:
 		m.cs = 11
-		goto _test_eof
-	_test_eof12:
+		goto _testEof
+	_testEof12:
 		m.cs = 12
-		goto _test_eof
-	_test_eof13:
+		goto _testEof
+	_testEof13:
 		m.cs = 13
-		goto _test_eof
-	_test_eof14:
+		goto _testEof
+	_testEof14:
 		m.cs = 14
-		goto _test_eof
-	_test_eof15:
+		goto _testEof
+	_testEof15:
 		m.cs = 15
-		goto _test_eof
-	_test_eof16:
+		goto _testEof
+	_testEof16:
 		m.cs = 16
-		goto _test_eof
-	_test_eof603:
+		goto _testEof
+	_testEof603:
 		m.cs = 603
-		goto _test_eof
-	_test_eof604:
+		goto _testEof
+	_testEof604:
 		m.cs = 604
-		goto _test_eof
-	_test_eof605:
+		goto _testEof
+	_testEof605:
 		m.cs = 605
-		goto _test_eof
-	_test_eof17:
+		goto _testEof
+	_testEof17:
 		m.cs = 17
-		goto _test_eof
-	_test_eof18:
+		goto _testEof
+	_testEof18:
 		m.cs = 18
-		goto _test_eof
-	_test_eof19:
+		goto _testEof
+	_testEof19:
 		m.cs = 19
-		goto _test_eof
-	_test_eof20:
+		goto _testEof
+	_testEof20:
 		m.cs = 20
-		goto _test_eof
-	_test_eof21:
+		goto _testEof
+	_testEof21:
 		m.cs = 21
-		goto _test_eof
-	_test_eof22:
+		goto _testEof
+	_testEof22:
 		m.cs = 22
-		goto _test_eof
-	_test_eof23:
+		goto _testEof
+	_testEof23:
 		m.cs = 23
-		goto _test_eof
-	_test_eof24:
+		goto _testEof
+	_testEof24:
 		m.cs = 24
-		goto _test_eof
-	_test_eof25:
+		goto _testEof
+	_testEof25:
 		m.cs = 25
-		goto _test_eof
-	_test_eof26:
+		goto _testEof
+	_testEof26:
 		m.cs = 26
-		goto _test_eof
-	_test_eof27:
+		goto _testEof
+	_testEof27:
 		m.cs = 27
-		goto _test_eof
-	_test_eof28:
+		goto _testEof
+	_testEof28:
 		m.cs = 28
-		goto _test_eof
-	_test_eof29:
+		goto _testEof
+	_testEof29:
 		m.cs = 29
-		goto _test_eof
-	_test_eof30:
+		goto _testEof
+	_testEof30:
 		m.cs = 30
-		goto _test_eof
-	_test_eof31:
+		goto _testEof
+	_testEof31:
 		m.cs = 31
-		goto _test_eof
-	_test_eof32:
+		goto _testEof
+	_testEof32:
 		m.cs = 32
-		goto _test_eof
-	_test_eof33:
+		goto _testEof
+	_testEof33:
 		m.cs = 33
-		goto _test_eof
-	_test_eof34:
+		goto _testEof
+	_testEof34:
 		m.cs = 34
-		goto _test_eof
-	_test_eof35:
+		goto _testEof
+	_testEof35:
 		m.cs = 35
-		goto _test_eof
-	_test_eof36:
+		goto _testEof
+	_testEof36:
 		m.cs = 36
-		goto _test_eof
-	_test_eof37:
+		goto _testEof
+	_testEof37:
 		m.cs = 37
-		goto _test_eof
-	_test_eof38:
+		goto _testEof
+	_testEof38:
 		m.cs = 38
-		goto _test_eof
-	_test_eof39:
+		goto _testEof
+	_testEof39:
 		m.cs = 39
-		goto _test_eof
-	_test_eof40:
+		goto _testEof
+	_testEof40:
 		m.cs = 40
-		goto _test_eof
-	_test_eof41:
+		goto _testEof
+	_testEof41:
 		m.cs = 41
-		goto _test_eof
-	_test_eof42:
+		goto _testEof
+	_testEof42:
 		m.cs = 42
-		goto _test_eof
-	_test_eof43:
+		goto _testEof
+	_testEof43:
 		m.cs = 43
-		goto _test_eof
-	_test_eof44:
+		goto _testEof
+	_testEof44:
 		m.cs = 44
-		goto _test_eof
-	_test_eof45:
+		goto _testEof
+	_testEof45:
 		m.cs = 45
-		goto _test_eof
-	_test_eof46:
+		goto _testEof
+	_testEof46:
 		m.cs = 46
-		goto _test_eof
-	_test_eof47:
+		goto _testEof
+	_testEof47:
 		m.cs = 47
-		goto _test_eof
-	_test_eof48:
+		goto _testEof
+	_testEof48:
 		m.cs = 48
-		goto _test_eof
-	_test_eof49:
+		goto _testEof
+	_testEof49:
 		m.cs = 49
-		goto _test_eof
-	_test_eof50:
+		goto _testEof
+	_testEof50:
 		m.cs = 50
-		goto _test_eof
-	_test_eof51:
+		goto _testEof
+	_testEof51:
 		m.cs = 51
-		goto _test_eof
-	_test_eof52:
+		goto _testEof
+	_testEof52:
 		m.cs = 52
-		goto _test_eof
-	_test_eof53:
+		goto _testEof
+	_testEof53:
 		m.cs = 53
-		goto _test_eof
-	_test_eof54:
+		goto _testEof
+	_testEof54:
 		m.cs = 54
-		goto _test_eof
-	_test_eof55:
+		goto _testEof
+	_testEof55:
 		m.cs = 55
-		goto _test_eof
-	_test_eof56:
+		goto _testEof
+	_testEof56:
 		m.cs = 56
-		goto _test_eof
-	_test_eof57:
+		goto _testEof
+	_testEof57:
 		m.cs = 57
-		goto _test_eof
-	_test_eof58:
+		goto _testEof
+	_testEof58:
 		m.cs = 58
-		goto _test_eof
-	_test_eof59:
+		goto _testEof
+	_testEof59:
 		m.cs = 59
-		goto _test_eof
-	_test_eof60:
+		goto _testEof
+	_testEof60:
 		m.cs = 60
-		goto _test_eof
-	_test_eof61:
+		goto _testEof
+	_testEof61:
 		m.cs = 61
-		goto _test_eof
-	_test_eof62:
+		goto _testEof
+	_testEof62:
 		m.cs = 62
-		goto _test_eof
-	_test_eof606:
+		goto _testEof
+	_testEof606:
 		m.cs = 606
-		goto _test_eof
-	_test_eof63:
+		goto _testEof
+	_testEof63:
 		m.cs = 63
-		goto _test_eof
-	_test_eof64:
+		goto _testEof
+	_testEof64:
 		m.cs = 64
-		goto _test_eof
-	_test_eof65:
+		goto _testEof
+	_testEof65:
 		m.cs = 65
-		goto _test_eof
-	_test_eof66:
+		goto _testEof
+	_testEof66:
 		m.cs = 66
-		goto _test_eof
-	_test_eof67:
+		goto _testEof
+	_testEof67:
 		m.cs = 67
-		goto _test_eof
-	_test_eof68:
+		goto _testEof
+	_testEof68:
 		m.cs = 68
-		goto _test_eof
-	_test_eof69:
+		goto _testEof
+	_testEof69:
 		m.cs = 69
-		goto _test_eof
-	_test_eof70:
+		goto _testEof
+	_testEof70:
 		m.cs = 70
-		goto _test_eof
-	_test_eof71:
+		goto _testEof
+	_testEof71:
 		m.cs = 71
-		goto _test_eof
-	_test_eof72:
+		goto _testEof
+	_testEof72:
 		m.cs = 72
-		goto _test_eof
-	_test_eof73:
+		goto _testEof
+	_testEof73:
 		m.cs = 73
-		goto _test_eof
-	_test_eof74:
+		goto _testEof
+	_testEof74:
 		m.cs = 74
-		goto _test_eof
-	_test_eof75:
+		goto _testEof
+	_testEof75:
 		m.cs = 75
-		goto _test_eof
-	_test_eof76:
+		goto _testEof
+	_testEof76:
 		m.cs = 76
-		goto _test_eof
-	_test_eof77:
+		goto _testEof
+	_testEof77:
 		m.cs = 77
-		goto _test_eof
-	_test_eof78:
+		goto _testEof
+	_testEof78:
 		m.cs = 78
-		goto _test_eof
-	_test_eof79:
+		goto _testEof
+	_testEof79:
 		m.cs = 79
-		goto _test_eof
-	_test_eof80:
+		goto _testEof
+	_testEof80:
 		m.cs = 80
-		goto _test_eof
-	_test_eof81:
+		goto _testEof
+	_testEof81:
 		m.cs = 81
-		goto _test_eof
-	_test_eof82:
+		goto _testEof
+	_testEof82:
 		m.cs = 82
-		goto _test_eof
-	_test_eof83:
+		goto _testEof
+	_testEof83:
 		m.cs = 83
-		goto _test_eof
-	_test_eof84:
+		goto _testEof
+	_testEof84:
 		m.cs = 84
-		goto _test_eof
-	_test_eof85:
+		goto _testEof
+	_testEof85:
 		m.cs = 85
-		goto _test_eof
-	_test_eof86:
+		goto _testEof
+	_testEof86:
 		m.cs = 86
-		goto _test_eof
-	_test_eof87:
+		goto _testEof
+	_testEof87:
 		m.cs = 87
-		goto _test_eof
-	_test_eof88:
+		goto _testEof
+	_testEof88:
 		m.cs = 88
-		goto _test_eof
-	_test_eof89:
+		goto _testEof
+	_testEof89:
 		m.cs = 89
-		goto _test_eof
-	_test_eof90:
+		goto _testEof
+	_testEof90:
 		m.cs = 90
-		goto _test_eof
-	_test_eof91:
+		goto _testEof
+	_testEof91:
 		m.cs = 91
-		goto _test_eof
-	_test_eof92:
+		goto _testEof
+	_testEof92:
 		m.cs = 92
-		goto _test_eof
-	_test_eof93:
+		goto _testEof
+	_testEof93:
 		m.cs = 93
-		goto _test_eof
-	_test_eof94:
+		goto _testEof
+	_testEof94:
 		m.cs = 94
-		goto _test_eof
-	_test_eof95:
+		goto _testEof
+	_testEof95:
 		m.cs = 95
-		goto _test_eof
-	_test_eof96:
+		goto _testEof
+	_testEof96:
 		m.cs = 96
-		goto _test_eof
-	_test_eof97:
+		goto _testEof
+	_testEof97:
 		m.cs = 97
-		goto _test_eof
-	_test_eof98:
+		goto _testEof
+	_testEof98:
 		m.cs = 98
-		goto _test_eof
-	_test_eof99:
+		goto _testEof
+	_testEof99:
 		m.cs = 99
-		goto _test_eof
-	_test_eof100:
+		goto _testEof
+	_testEof100:
 		m.cs = 100
-		goto _test_eof
-	_test_eof101:
+		goto _testEof
+	_testEof101:
 		m.cs = 101
-		goto _test_eof
-	_test_eof102:
+		goto _testEof
+	_testEof102:
 		m.cs = 102
-		goto _test_eof
-	_test_eof103:
+		goto _testEof
+	_testEof103:
 		m.cs = 103
-		goto _test_eof
-	_test_eof104:
+		goto _testEof
+	_testEof104:
 		m.cs = 104
-		goto _test_eof
-	_test_eof105:
+		goto _testEof
+	_testEof105:
 		m.cs = 105
-		goto _test_eof
-	_test_eof106:
+		goto _testEof
+	_testEof106:
 		m.cs = 106
-		goto _test_eof
-	_test_eof107:
+		goto _testEof
+	_testEof107:
 		m.cs = 107
-		goto _test_eof
-	_test_eof108:
+		goto _testEof
+	_testEof108:
 		m.cs = 108
-		goto _test_eof
-	_test_eof109:
+		goto _testEof
+	_testEof109:
 		m.cs = 109
-		goto _test_eof
-	_test_eof110:
+		goto _testEof
+	_testEof110:
 		m.cs = 110
-		goto _test_eof
-	_test_eof111:
+		goto _testEof
+	_testEof111:
 		m.cs = 111
-		goto _test_eof
-	_test_eof112:
+		goto _testEof
+	_testEof112:
 		m.cs = 112
-		goto _test_eof
-	_test_eof113:
+		goto _testEof
+	_testEof113:
 		m.cs = 113
-		goto _test_eof
-	_test_eof114:
+		goto _testEof
+	_testEof114:
 		m.cs = 114
-		goto _test_eof
-	_test_eof115:
+		goto _testEof
+	_testEof115:
 		m.cs = 115
-		goto _test_eof
-	_test_eof116:
+		goto _testEof
+	_testEof116:
 		m.cs = 116
-		goto _test_eof
-	_test_eof117:
+		goto _testEof
+	_testEof117:
 		m.cs = 117
-		goto _test_eof
-	_test_eof118:
+		goto _testEof
+	_testEof118:
 		m.cs = 118
-		goto _test_eof
-	_test_eof119:
+		goto _testEof
+	_testEof119:
 		m.cs = 119
-		goto _test_eof
-	_test_eof120:
+		goto _testEof
+	_testEof120:
 		m.cs = 120
-		goto _test_eof
-	_test_eof121:
+		goto _testEof
+	_testEof121:
 		m.cs = 121
-		goto _test_eof
-	_test_eof122:
+		goto _testEof
+	_testEof122:
 		m.cs = 122
-		goto _test_eof
-	_test_eof123:
+		goto _testEof
+	_testEof123:
 		m.cs = 123
-		goto _test_eof
-	_test_eof124:
+		goto _testEof
+	_testEof124:
 		m.cs = 124
-		goto _test_eof
-	_test_eof125:
+		goto _testEof
+	_testEof125:
 		m.cs = 125
-		goto _test_eof
-	_test_eof126:
+		goto _testEof
+	_testEof126:
 		m.cs = 126
-		goto _test_eof
-	_test_eof127:
+		goto _testEof
+	_testEof127:
 		m.cs = 127
-		goto _test_eof
-	_test_eof128:
+		goto _testEof
+	_testEof128:
 		m.cs = 128
-		goto _test_eof
-	_test_eof129:
+		goto _testEof
+	_testEof129:
 		m.cs = 129
-		goto _test_eof
-	_test_eof130:
+		goto _testEof
+	_testEof130:
 		m.cs = 130
-		goto _test_eof
-	_test_eof131:
+		goto _testEof
+	_testEof131:
 		m.cs = 131
-		goto _test_eof
-	_test_eof132:
+		goto _testEof
+	_testEof132:
 		m.cs = 132
-		goto _test_eof
-	_test_eof133:
+		goto _testEof
+	_testEof133:
 		m.cs = 133
-		goto _test_eof
-	_test_eof134:
+		goto _testEof
+	_testEof134:
 		m.cs = 134
-		goto _test_eof
-	_test_eof135:
+		goto _testEof
+	_testEof135:
 		m.cs = 135
-		goto _test_eof
-	_test_eof136:
+		goto _testEof
+	_testEof136:
 		m.cs = 136
-		goto _test_eof
-	_test_eof137:
+		goto _testEof
+	_testEof137:
 		m.cs = 137
-		goto _test_eof
-	_test_eof138:
+		goto _testEof
+	_testEof138:
 		m.cs = 138
-		goto _test_eof
-	_test_eof139:
+		goto _testEof
+	_testEof139:
 		m.cs = 139
-		goto _test_eof
-	_test_eof140:
+		goto _testEof
+	_testEof140:
 		m.cs = 140
-		goto _test_eof
-	_test_eof141:
+		goto _testEof
+	_testEof141:
 		m.cs = 141
-		goto _test_eof
-	_test_eof142:
+		goto _testEof
+	_testEof142:
 		m.cs = 142
-		goto _test_eof
-	_test_eof143:
+		goto _testEof
+	_testEof143:
 		m.cs = 143
-		goto _test_eof
-	_test_eof144:
+		goto _testEof
+	_testEof144:
 		m.cs = 144
-		goto _test_eof
-	_test_eof145:
+		goto _testEof
+	_testEof145:
 		m.cs = 145
-		goto _test_eof
-	_test_eof146:
+		goto _testEof
+	_testEof146:
 		m.cs = 146
-		goto _test_eof
-	_test_eof147:
+		goto _testEof
+	_testEof147:
 		m.cs = 147
-		goto _test_eof
-	_test_eof148:
+		goto _testEof
+	_testEof148:
 		m.cs = 148
-		goto _test_eof
-	_test_eof149:
+		goto _testEof
+	_testEof149:
 		m.cs = 149
-		goto _test_eof
-	_test_eof150:
+		goto _testEof
+	_testEof150:
 		m.cs = 150
-		goto _test_eof
-	_test_eof151:
+		goto _testEof
+	_testEof151:
 		m.cs = 151
-		goto _test_eof
-	_test_eof152:
+		goto _testEof
+	_testEof152:
 		m.cs = 152
-		goto _test_eof
-	_test_eof153:
+		goto _testEof
+	_testEof153:
 		m.cs = 153
-		goto _test_eof
-	_test_eof154:
+		goto _testEof
+	_testEof154:
 		m.cs = 154
-		goto _test_eof
-	_test_eof155:
+		goto _testEof
+	_testEof155:
 		m.cs = 155
-		goto _test_eof
-	_test_eof156:
+		goto _testEof
+	_testEof156:
 		m.cs = 156
-		goto _test_eof
-	_test_eof157:
+		goto _testEof
+	_testEof157:
 		m.cs = 157
-		goto _test_eof
-	_test_eof158:
+		goto _testEof
+	_testEof158:
 		m.cs = 158
-		goto _test_eof
-	_test_eof159:
+		goto _testEof
+	_testEof159:
 		m.cs = 159
-		goto _test_eof
-	_test_eof160:
+		goto _testEof
+	_testEof160:
 		m.cs = 160
-		goto _test_eof
-	_test_eof161:
+		goto _testEof
+	_testEof161:
 		m.cs = 161
-		goto _test_eof
-	_test_eof162:
+		goto _testEof
+	_testEof162:
 		m.cs = 162
-		goto _test_eof
-	_test_eof163:
+		goto _testEof
+	_testEof163:
 		m.cs = 163
-		goto _test_eof
-	_test_eof164:
+		goto _testEof
+	_testEof164:
 		m.cs = 164
-		goto _test_eof
-	_test_eof165:
+		goto _testEof
+	_testEof165:
 		m.cs = 165
-		goto _test_eof
-	_test_eof166:
+		goto _testEof
+	_testEof166:
 		m.cs = 166
-		goto _test_eof
-	_test_eof167:
+		goto _testEof
+	_testEof167:
 		m.cs = 167
-		goto _test_eof
-	_test_eof168:
+		goto _testEof
+	_testEof168:
 		m.cs = 168
-		goto _test_eof
-	_test_eof169:
+		goto _testEof
+	_testEof169:
 		m.cs = 169
-		goto _test_eof
-	_test_eof170:
+		goto _testEof
+	_testEof170:
 		m.cs = 170
-		goto _test_eof
-	_test_eof171:
+		goto _testEof
+	_testEof171:
 		m.cs = 171
-		goto _test_eof
-	_test_eof172:
+		goto _testEof
+	_testEof172:
 		m.cs = 172
-		goto _test_eof
-	_test_eof173:
+		goto _testEof
+	_testEof173:
 		m.cs = 173
-		goto _test_eof
-	_test_eof174:
+		goto _testEof
+	_testEof174:
 		m.cs = 174
-		goto _test_eof
-	_test_eof175:
+		goto _testEof
+	_testEof175:
 		m.cs = 175
-		goto _test_eof
-	_test_eof176:
+		goto _testEof
+	_testEof176:
 		m.cs = 176
-		goto _test_eof
-	_test_eof177:
+		goto _testEof
+	_testEof177:
 		m.cs = 177
-		goto _test_eof
-	_test_eof178:
+		goto _testEof
+	_testEof178:
 		m.cs = 178
-		goto _test_eof
-	_test_eof179:
+		goto _testEof
+	_testEof179:
 		m.cs = 179
-		goto _test_eof
-	_test_eof180:
+		goto _testEof
+	_testEof180:
 		m.cs = 180
-		goto _test_eof
-	_test_eof181:
+		goto _testEof
+	_testEof181:
 		m.cs = 181
-		goto _test_eof
-	_test_eof182:
+		goto _testEof
+	_testEof182:
 		m.cs = 182
-		goto _test_eof
-	_test_eof183:
+		goto _testEof
+	_testEof183:
 		m.cs = 183
-		goto _test_eof
-	_test_eof184:
+		goto _testEof
+	_testEof184:
 		m.cs = 184
-		goto _test_eof
-	_test_eof185:
+		goto _testEof
+	_testEof185:
 		m.cs = 185
-		goto _test_eof
-	_test_eof186:
+		goto _testEof
+	_testEof186:
 		m.cs = 186
-		goto _test_eof
-	_test_eof187:
+		goto _testEof
+	_testEof187:
 		m.cs = 187
-		goto _test_eof
-	_test_eof188:
+		goto _testEof
+	_testEof188:
 		m.cs = 188
-		goto _test_eof
-	_test_eof189:
+		goto _testEof
+	_testEof189:
 		m.cs = 189
-		goto _test_eof
-	_test_eof190:
+		goto _testEof
+	_testEof190:
 		m.cs = 190
-		goto _test_eof
-	_test_eof191:
+		goto _testEof
+	_testEof191:
 		m.cs = 191
-		goto _test_eof
-	_test_eof192:
+		goto _testEof
+	_testEof192:
 		m.cs = 192
-		goto _test_eof
-	_test_eof193:
+		goto _testEof
+	_testEof193:
 		m.cs = 193
-		goto _test_eof
-	_test_eof194:
+		goto _testEof
+	_testEof194:
 		m.cs = 194
-		goto _test_eof
-	_test_eof195:
+		goto _testEof
+	_testEof195:
 		m.cs = 195
-		goto _test_eof
-	_test_eof196:
+		goto _testEof
+	_testEof196:
 		m.cs = 196
-		goto _test_eof
-	_test_eof197:
+		goto _testEof
+	_testEof197:
 		m.cs = 197
-		goto _test_eof
-	_test_eof198:
+		goto _testEof
+	_testEof198:
 		m.cs = 198
-		goto _test_eof
-	_test_eof199:
+		goto _testEof
+	_testEof199:
 		m.cs = 199
-		goto _test_eof
-	_test_eof200:
+		goto _testEof
+	_testEof200:
 		m.cs = 200
-		goto _test_eof
-	_test_eof201:
+		goto _testEof
+	_testEof201:
 		m.cs = 201
-		goto _test_eof
-	_test_eof202:
+		goto _testEof
+	_testEof202:
 		m.cs = 202
-		goto _test_eof
-	_test_eof203:
+		goto _testEof
+	_testEof203:
 		m.cs = 203
-		goto _test_eof
-	_test_eof204:
+		goto _testEof
+	_testEof204:
 		m.cs = 204
-		goto _test_eof
-	_test_eof205:
+		goto _testEof
+	_testEof205:
 		m.cs = 205
-		goto _test_eof
-	_test_eof206:
+		goto _testEof
+	_testEof206:
 		m.cs = 206
-		goto _test_eof
-	_test_eof207:
+		goto _testEof
+	_testEof207:
 		m.cs = 207
-		goto _test_eof
-	_test_eof208:
+		goto _testEof
+	_testEof208:
 		m.cs = 208
-		goto _test_eof
-	_test_eof209:
+		goto _testEof
+	_testEof209:
 		m.cs = 209
-		goto _test_eof
-	_test_eof210:
+		goto _testEof
+	_testEof210:
 		m.cs = 210
-		goto _test_eof
-	_test_eof211:
+		goto _testEof
+	_testEof211:
 		m.cs = 211
-		goto _test_eof
-	_test_eof212:
+		goto _testEof
+	_testEof212:
 		m.cs = 212
-		goto _test_eof
-	_test_eof213:
+		goto _testEof
+	_testEof213:
 		m.cs = 213
-		goto _test_eof
-	_test_eof214:
+		goto _testEof
+	_testEof214:
 		m.cs = 214
-		goto _test_eof
-	_test_eof215:
+		goto _testEof
+	_testEof215:
 		m.cs = 215
-		goto _test_eof
-	_test_eof216:
+		goto _testEof
+	_testEof216:
 		m.cs = 216
-		goto _test_eof
-	_test_eof217:
+		goto _testEof
+	_testEof217:
 		m.cs = 217
-		goto _test_eof
-	_test_eof218:
+		goto _testEof
+	_testEof218:
 		m.cs = 218
-		goto _test_eof
-	_test_eof219:
+		goto _testEof
+	_testEof219:
 		m.cs = 219
-		goto _test_eof
-	_test_eof220:
+		goto _testEof
+	_testEof220:
 		m.cs = 220
-		goto _test_eof
-	_test_eof221:
+		goto _testEof
+	_testEof221:
 		m.cs = 221
-		goto _test_eof
-	_test_eof222:
+		goto _testEof
+	_testEof222:
 		m.cs = 222
-		goto _test_eof
-	_test_eof223:
+		goto _testEof
+	_testEof223:
 		m.cs = 223
-		goto _test_eof
-	_test_eof224:
+		goto _testEof
+	_testEof224:
 		m.cs = 224
-		goto _test_eof
-	_test_eof225:
+		goto _testEof
+	_testEof225:
 		m.cs = 225
-		goto _test_eof
-	_test_eof226:
+		goto _testEof
+	_testEof226:
 		m.cs = 226
-		goto _test_eof
-	_test_eof227:
+		goto _testEof
+	_testEof227:
 		m.cs = 227
-		goto _test_eof
-	_test_eof228:
+		goto _testEof
+	_testEof228:
 		m.cs = 228
-		goto _test_eof
-	_test_eof229:
+		goto _testEof
+	_testEof229:
 		m.cs = 229
-		goto _test_eof
-	_test_eof230:
+		goto _testEof
+	_testEof230:
 		m.cs = 230
-		goto _test_eof
-	_test_eof231:
+		goto _testEof
+	_testEof231:
 		m.cs = 231
-		goto _test_eof
-	_test_eof232:
+		goto _testEof
+	_testEof232:
 		m.cs = 232
-		goto _test_eof
-	_test_eof233:
+		goto _testEof
+	_testEof233:
 		m.cs = 233
-		goto _test_eof
-	_test_eof234:
+		goto _testEof
+	_testEof234:
 		m.cs = 234
-		goto _test_eof
-	_test_eof235:
+		goto _testEof
+	_testEof235:
 		m.cs = 235
-		goto _test_eof
-	_test_eof236:
+		goto _testEof
+	_testEof236:
 		m.cs = 236
-		goto _test_eof
-	_test_eof237:
+		goto _testEof
+	_testEof237:
 		m.cs = 237
-		goto _test_eof
-	_test_eof238:
+		goto _testEof
+	_testEof238:
 		m.cs = 238
-		goto _test_eof
-	_test_eof239:
+		goto _testEof
+	_testEof239:
 		m.cs = 239
-		goto _test_eof
-	_test_eof240:
+		goto _testEof
+	_testEof240:
 		m.cs = 240
-		goto _test_eof
-	_test_eof241:
+		goto _testEof
+	_testEof241:
 		m.cs = 241
-		goto _test_eof
-	_test_eof242:
+		goto _testEof
+	_testEof242:
 		m.cs = 242
-		goto _test_eof
-	_test_eof243:
+		goto _testEof
+	_testEof243:
 		m.cs = 243
-		goto _test_eof
-	_test_eof244:
+		goto _testEof
+	_testEof244:
 		m.cs = 244
-		goto _test_eof
-	_test_eof245:
+		goto _testEof
+	_testEof245:
 		m.cs = 245
-		goto _test_eof
-	_test_eof246:
+		goto _testEof
+	_testEof246:
 		m.cs = 246
-		goto _test_eof
-	_test_eof247:
+		goto _testEof
+	_testEof247:
 		m.cs = 247
-		goto _test_eof
-	_test_eof248:
+		goto _testEof
+	_testEof248:
 		m.cs = 248
-		goto _test_eof
-	_test_eof249:
+		goto _testEof
+	_testEof249:
 		m.cs = 249
-		goto _test_eof
-	_test_eof250:
+		goto _testEof
+	_testEof250:
 		m.cs = 250
-		goto _test_eof
-	_test_eof251:
+		goto _testEof
+	_testEof251:
 		m.cs = 251
-		goto _test_eof
-	_test_eof252:
+		goto _testEof
+	_testEof252:
 		m.cs = 252
-		goto _test_eof
-	_test_eof253:
+		goto _testEof
+	_testEof253:
 		m.cs = 253
-		goto _test_eof
-	_test_eof254:
+		goto _testEof
+	_testEof254:
 		m.cs = 254
-		goto _test_eof
-	_test_eof255:
+		goto _testEof
+	_testEof255:
 		m.cs = 255
-		goto _test_eof
-	_test_eof256:
+		goto _testEof
+	_testEof256:
 		m.cs = 256
-		goto _test_eof
-	_test_eof257:
+		goto _testEof
+	_testEof257:
 		m.cs = 257
-		goto _test_eof
-	_test_eof258:
+		goto _testEof
+	_testEof258:
 		m.cs = 258
-		goto _test_eof
-	_test_eof259:
+		goto _testEof
+	_testEof259:
 		m.cs = 259
-		goto _test_eof
-	_test_eof260:
+		goto _testEof
+	_testEof260:
 		m.cs = 260
-		goto _test_eof
-	_test_eof261:
+		goto _testEof
+	_testEof261:
 		m.cs = 261
-		goto _test_eof
-	_test_eof262:
+		goto _testEof
+	_testEof262:
 		m.cs = 262
-		goto _test_eof
-	_test_eof263:
+		goto _testEof
+	_testEof263:
 		m.cs = 263
-		goto _test_eof
-	_test_eof264:
+		goto _testEof
+	_testEof264:
 		m.cs = 264
-		goto _test_eof
-	_test_eof265:
+		goto _testEof
+	_testEof265:
 		m.cs = 265
-		goto _test_eof
-	_test_eof266:
+		goto _testEof
+	_testEof266:
 		m.cs = 266
-		goto _test_eof
-	_test_eof267:
+		goto _testEof
+	_testEof267:
 		m.cs = 267
-		goto _test_eof
-	_test_eof268:
+		goto _testEof
+	_testEof268:
 		m.cs = 268
-		goto _test_eof
-	_test_eof269:
+		goto _testEof
+	_testEof269:
 		m.cs = 269
-		goto _test_eof
-	_test_eof270:
+		goto _testEof
+	_testEof270:
 		m.cs = 270
-		goto _test_eof
-	_test_eof271:
+		goto _testEof
+	_testEof271:
 		m.cs = 271
-		goto _test_eof
-	_test_eof272:
+		goto _testEof
+	_testEof272:
 		m.cs = 272
-		goto _test_eof
-	_test_eof273:
+		goto _testEof
+	_testEof273:
 		m.cs = 273
-		goto _test_eof
-	_test_eof274:
+		goto _testEof
+	_testEof274:
 		m.cs = 274
-		goto _test_eof
-	_test_eof275:
+		goto _testEof
+	_testEof275:
 		m.cs = 275
-		goto _test_eof
-	_test_eof276:
+		goto _testEof
+	_testEof276:
 		m.cs = 276
-		goto _test_eof
-	_test_eof277:
+		goto _testEof
+	_testEof277:
 		m.cs = 277
-		goto _test_eof
-	_test_eof278:
+		goto _testEof
+	_testEof278:
 		m.cs = 278
-		goto _test_eof
-	_test_eof279:
+		goto _testEof
+	_testEof279:
 		m.cs = 279
-		goto _test_eof
-	_test_eof280:
+		goto _testEof
+	_testEof280:
 		m.cs = 280
-		goto _test_eof
-	_test_eof281:
+		goto _testEof
+	_testEof281:
 		m.cs = 281
-		goto _test_eof
-	_test_eof282:
+		goto _testEof
+	_testEof282:
 		m.cs = 282
-		goto _test_eof
-	_test_eof283:
+		goto _testEof
+	_testEof283:
 		m.cs = 283
-		goto _test_eof
-	_test_eof284:
+		goto _testEof
+	_testEof284:
 		m.cs = 284
-		goto _test_eof
-	_test_eof285:
+		goto _testEof
+	_testEof285:
 		m.cs = 285
-		goto _test_eof
-	_test_eof286:
+		goto _testEof
+	_testEof286:
 		m.cs = 286
-		goto _test_eof
-	_test_eof287:
+		goto _testEof
+	_testEof287:
 		m.cs = 287
-		goto _test_eof
-	_test_eof288:
+		goto _testEof
+	_testEof288:
 		m.cs = 288
-		goto _test_eof
-	_test_eof289:
+		goto _testEof
+	_testEof289:
 		m.cs = 289
-		goto _test_eof
-	_test_eof290:
+		goto _testEof
+	_testEof290:
 		m.cs = 290
-		goto _test_eof
-	_test_eof291:
+		goto _testEof
+	_testEof291:
 		m.cs = 291
-		goto _test_eof
-	_test_eof292:
+		goto _testEof
+	_testEof292:
 		m.cs = 292
-		goto _test_eof
-	_test_eof293:
+		goto _testEof
+	_testEof293:
 		m.cs = 293
-		goto _test_eof
-	_test_eof294:
+		goto _testEof
+	_testEof294:
 		m.cs = 294
-		goto _test_eof
-	_test_eof295:
+		goto _testEof
+	_testEof295:
 		m.cs = 295
-		goto _test_eof
-	_test_eof296:
+		goto _testEof
+	_testEof296:
 		m.cs = 296
-		goto _test_eof
-	_test_eof297:
+		goto _testEof
+	_testEof297:
 		m.cs = 297
-		goto _test_eof
-	_test_eof298:
+		goto _testEof
+	_testEof298:
 		m.cs = 298
-		goto _test_eof
-	_test_eof299:
+		goto _testEof
+	_testEof299:
 		m.cs = 299
-		goto _test_eof
-	_test_eof300:
+		goto _testEof
+	_testEof300:
 		m.cs = 300
-		goto _test_eof
-	_test_eof301:
+		goto _testEof
+	_testEof301:
 		m.cs = 301
-		goto _test_eof
-	_test_eof302:
+		goto _testEof
+	_testEof302:
 		m.cs = 302
-		goto _test_eof
-	_test_eof303:
+		goto _testEof
+	_testEof303:
 		m.cs = 303
-		goto _test_eof
-	_test_eof304:
+		goto _testEof
+	_testEof304:
 		m.cs = 304
-		goto _test_eof
-	_test_eof305:
+		goto _testEof
+	_testEof305:
 		m.cs = 305
-		goto _test_eof
-	_test_eof306:
+		goto _testEof
+	_testEof306:
 		m.cs = 306
-		goto _test_eof
-	_test_eof307:
+		goto _testEof
+	_testEof307:
 		m.cs = 307
-		goto _test_eof
-	_test_eof308:
+		goto _testEof
+	_testEof308:
 		m.cs = 308
-		goto _test_eof
-	_test_eof309:
+		goto _testEof
+	_testEof309:
 		m.cs = 309
-		goto _test_eof
-	_test_eof310:
+		goto _testEof
+	_testEof310:
 		m.cs = 310
-		goto _test_eof
-	_test_eof311:
+		goto _testEof
+	_testEof311:
 		m.cs = 311
-		goto _test_eof
-	_test_eof312:
+		goto _testEof
+	_testEof312:
 		m.cs = 312
-		goto _test_eof
-	_test_eof313:
+		goto _testEof
+	_testEof313:
 		m.cs = 313
-		goto _test_eof
-	_test_eof314:
+		goto _testEof
+	_testEof314:
 		m.cs = 314
-		goto _test_eof
-	_test_eof315:
+		goto _testEof
+	_testEof315:
 		m.cs = 315
-		goto _test_eof
-	_test_eof316:
+		goto _testEof
+	_testEof316:
 		m.cs = 316
-		goto _test_eof
-	_test_eof317:
+		goto _testEof
+	_testEof317:
 		m.cs = 317
-		goto _test_eof
-	_test_eof318:
+		goto _testEof
+	_testEof318:
 		m.cs = 318
-		goto _test_eof
-	_test_eof319:
+		goto _testEof
+	_testEof319:
 		m.cs = 319
-		goto _test_eof
-	_test_eof320:
+		goto _testEof
+	_testEof320:
 		m.cs = 320
-		goto _test_eof
-	_test_eof321:
+		goto _testEof
+	_testEof321:
 		m.cs = 321
-		goto _test_eof
-	_test_eof322:
+		goto _testEof
+	_testEof322:
 		m.cs = 322
-		goto _test_eof
-	_test_eof323:
+		goto _testEof
+	_testEof323:
 		m.cs = 323
-		goto _test_eof
-	_test_eof324:
+		goto _testEof
+	_testEof324:
 		m.cs = 324
-		goto _test_eof
-	_test_eof325:
+		goto _testEof
+	_testEof325:
 		m.cs = 325
-		goto _test_eof
-	_test_eof326:
+		goto _testEof
+	_testEof326:
 		m.cs = 326
-		goto _test_eof
-	_test_eof327:
+		goto _testEof
+	_testEof327:
 		m.cs = 327
-		goto _test_eof
-	_test_eof328:
+		goto _testEof
+	_testEof328:
 		m.cs = 328
-		goto _test_eof
-	_test_eof329:
+		goto _testEof
+	_testEof329:
 		m.cs = 329
-		goto _test_eof
-	_test_eof330:
+		goto _testEof
+	_testEof330:
 		m.cs = 330
-		goto _test_eof
-	_test_eof331:
+		goto _testEof
+	_testEof331:
 		m.cs = 331
-		goto _test_eof
-	_test_eof332:
+		goto _testEof
+	_testEof332:
 		m.cs = 332
-		goto _test_eof
-	_test_eof333:
+		goto _testEof
+	_testEof333:
 		m.cs = 333
-		goto _test_eof
-	_test_eof334:
+		goto _testEof
+	_testEof334:
 		m.cs = 334
-		goto _test_eof
-	_test_eof335:
+		goto _testEof
+	_testEof335:
 		m.cs = 335
-		goto _test_eof
-	_test_eof336:
+		goto _testEof
+	_testEof336:
 		m.cs = 336
-		goto _test_eof
-	_test_eof337:
+		goto _testEof
+	_testEof337:
 		m.cs = 337
-		goto _test_eof
-	_test_eof338:
+		goto _testEof
+	_testEof338:
 		m.cs = 338
-		goto _test_eof
-	_test_eof339:
+		goto _testEof
+	_testEof339:
 		m.cs = 339
-		goto _test_eof
-	_test_eof340:
+		goto _testEof
+	_testEof340:
 		m.cs = 340
-		goto _test_eof
-	_test_eof341:
+		goto _testEof
+	_testEof341:
 		m.cs = 341
-		goto _test_eof
-	_test_eof342:
+		goto _testEof
+	_testEof342:
 		m.cs = 342
-		goto _test_eof
-	_test_eof343:
+		goto _testEof
+	_testEof343:
 		m.cs = 343
-		goto _test_eof
-	_test_eof344:
+		goto _testEof
+	_testEof344:
 		m.cs = 344
-		goto _test_eof
-	_test_eof345:
+		goto _testEof
+	_testEof345:
 		m.cs = 345
-		goto _test_eof
-	_test_eof346:
+		goto _testEof
+	_testEof346:
 		m.cs = 346
-		goto _test_eof
-	_test_eof347:
+		goto _testEof
+	_testEof347:
 		m.cs = 347
-		goto _test_eof
-	_test_eof348:
+		goto _testEof
+	_testEof348:
 		m.cs = 348
-		goto _test_eof
-	_test_eof349:
+		goto _testEof
+	_testEof349:
 		m.cs = 349
-		goto _test_eof
-	_test_eof350:
+		goto _testEof
+	_testEof350:
 		m.cs = 350
-		goto _test_eof
-	_test_eof351:
+		goto _testEof
+	_testEof351:
 		m.cs = 351
-		goto _test_eof
-	_test_eof352:
+		goto _testEof
+	_testEof352:
 		m.cs = 352
-		goto _test_eof
-	_test_eof353:
+		goto _testEof
+	_testEof353:
 		m.cs = 353
-		goto _test_eof
-	_test_eof354:
+		goto _testEof
+	_testEof354:
 		m.cs = 354
-		goto _test_eof
-	_test_eof355:
+		goto _testEof
+	_testEof355:
 		m.cs = 355
-		goto _test_eof
-	_test_eof356:
+		goto _testEof
+	_testEof356:
 		m.cs = 356
-		goto _test_eof
-	_test_eof357:
+		goto _testEof
+	_testEof357:
 		m.cs = 357
-		goto _test_eof
-	_test_eof358:
+		goto _testEof
+	_testEof358:
 		m.cs = 358
-		goto _test_eof
-	_test_eof359:
+		goto _testEof
+	_testEof359:
 		m.cs = 359
-		goto _test_eof
-	_test_eof360:
+		goto _testEof
+	_testEof360:
 		m.cs = 360
-		goto _test_eof
-	_test_eof361:
+		goto _testEof
+	_testEof361:
 		m.cs = 361
-		goto _test_eof
-	_test_eof362:
+		goto _testEof
+	_testEof362:
 		m.cs = 362
-		goto _test_eof
-	_test_eof363:
+		goto _testEof
+	_testEof363:
 		m.cs = 363
-		goto _test_eof
-	_test_eof364:
+		goto _testEof
+	_testEof364:
 		m.cs = 364
-		goto _test_eof
-	_test_eof365:
+		goto _testEof
+	_testEof365:
 		m.cs = 365
-		goto _test_eof
-	_test_eof366:
+		goto _testEof
+	_testEof366:
 		m.cs = 366
-		goto _test_eof
-	_test_eof367:
+		goto _testEof
+	_testEof367:
 		m.cs = 367
-		goto _test_eof
-	_test_eof368:
+		goto _testEof
+	_testEof368:
 		m.cs = 368
-		goto _test_eof
-	_test_eof369:
+		goto _testEof
+	_testEof369:
 		m.cs = 369
-		goto _test_eof
-	_test_eof370:
+		goto _testEof
+	_testEof370:
 		m.cs = 370
-		goto _test_eof
-	_test_eof371:
+		goto _testEof
+	_testEof371:
 		m.cs = 371
-		goto _test_eof
-	_test_eof372:
+		goto _testEof
+	_testEof372:
 		m.cs = 372
-		goto _test_eof
-	_test_eof373:
+		goto _testEof
+	_testEof373:
 		m.cs = 373
-		goto _test_eof
-	_test_eof374:
+		goto _testEof
+	_testEof374:
 		m.cs = 374
-		goto _test_eof
-	_test_eof375:
+		goto _testEof
+	_testEof375:
 		m.cs = 375
-		goto _test_eof
-	_test_eof376:
+		goto _testEof
+	_testEof376:
 		m.cs = 376
-		goto _test_eof
-	_test_eof377:
+		goto _testEof
+	_testEof377:
 		m.cs = 377
-		goto _test_eof
-	_test_eof378:
+		goto _testEof
+	_testEof378:
 		m.cs = 378
-		goto _test_eof
-	_test_eof379:
+		goto _testEof
+	_testEof379:
 		m.cs = 379
-		goto _test_eof
-	_test_eof380:
+		goto _testEof
+	_testEof380:
 		m.cs = 380
-		goto _test_eof
-	_test_eof381:
+		goto _testEof
+	_testEof381:
 		m.cs = 381
-		goto _test_eof
-	_test_eof382:
+		goto _testEof
+	_testEof382:
 		m.cs = 382
-		goto _test_eof
-	_test_eof383:
+		goto _testEof
+	_testEof383:
 		m.cs = 383
-		goto _test_eof
-	_test_eof384:
+		goto _testEof
+	_testEof384:
 		m.cs = 384
-		goto _test_eof
-	_test_eof385:
+		goto _testEof
+	_testEof385:
 		m.cs = 385
-		goto _test_eof
-	_test_eof386:
+		goto _testEof
+	_testEof386:
 		m.cs = 386
-		goto _test_eof
-	_test_eof387:
+		goto _testEof
+	_testEof387:
 		m.cs = 387
-		goto _test_eof
-	_test_eof388:
+		goto _testEof
+	_testEof388:
 		m.cs = 388
-		goto _test_eof
-	_test_eof389:
+		goto _testEof
+	_testEof389:
 		m.cs = 389
-		goto _test_eof
-	_test_eof390:
+		goto _testEof
+	_testEof390:
 		m.cs = 390
-		goto _test_eof
-	_test_eof391:
+		goto _testEof
+	_testEof391:
 		m.cs = 391
-		goto _test_eof
-	_test_eof392:
+		goto _testEof
+	_testEof392:
 		m.cs = 392
-		goto _test_eof
-	_test_eof393:
+		goto _testEof
+	_testEof393:
 		m.cs = 393
-		goto _test_eof
-	_test_eof394:
+		goto _testEof
+	_testEof394:
 		m.cs = 394
-		goto _test_eof
-	_test_eof395:
+		goto _testEof
+	_testEof395:
 		m.cs = 395
-		goto _test_eof
-	_test_eof396:
+		goto _testEof
+	_testEof396:
 		m.cs = 396
-		goto _test_eof
-	_test_eof397:
+		goto _testEof
+	_testEof397:
 		m.cs = 397
-		goto _test_eof
-	_test_eof398:
+		goto _testEof
+	_testEof398:
 		m.cs = 398
-		goto _test_eof
-	_test_eof399:
+		goto _testEof
+	_testEof399:
 		m.cs = 399
-		goto _test_eof
-	_test_eof400:
+		goto _testEof
+	_testEof400:
 		m.cs = 400
-		goto _test_eof
-	_test_eof401:
+		goto _testEof
+	_testEof401:
 		m.cs = 401
-		goto _test_eof
-	_test_eof402:
+		goto _testEof
+	_testEof402:
 		m.cs = 402
-		goto _test_eof
-	_test_eof403:
+		goto _testEof
+	_testEof403:
 		m.cs = 403
-		goto _test_eof
-	_test_eof404:
+		goto _testEof
+	_testEof404:
 		m.cs = 404
-		goto _test_eof
-	_test_eof405:
+		goto _testEof
+	_testEof405:
 		m.cs = 405
-		goto _test_eof
-	_test_eof406:
+		goto _testEof
+	_testEof406:
 		m.cs = 406
-		goto _test_eof
-	_test_eof407:
+		goto _testEof
+	_testEof407:
 		m.cs = 407
-		goto _test_eof
-	_test_eof408:
+		goto _testEof
+	_testEof408:
 		m.cs = 408
-		goto _test_eof
-	_test_eof409:
+		goto _testEof
+	_testEof409:
 		m.cs = 409
-		goto _test_eof
-	_test_eof410:
+		goto _testEof
+	_testEof410:
 		m.cs = 410
-		goto _test_eof
-	_test_eof411:
+		goto _testEof
+	_testEof411:
 		m.cs = 411
-		goto _test_eof
-	_test_eof412:
+		goto _testEof
+	_testEof412:
 		m.cs = 412
-		goto _test_eof
-	_test_eof413:
+		goto _testEof
+	_testEof413:
 		m.cs = 413
-		goto _test_eof
-	_test_eof414:
+		goto _testEof
+	_testEof414:
 		m.cs = 414
-		goto _test_eof
-	_test_eof415:
+		goto _testEof
+	_testEof415:
 		m.cs = 415
-		goto _test_eof
-	_test_eof416:
+		goto _testEof
+	_testEof416:
 		m.cs = 416
-		goto _test_eof
-	_test_eof417:
+		goto _testEof
+	_testEof417:
 		m.cs = 417
-		goto _test_eof
-	_test_eof418:
+		goto _testEof
+	_testEof418:
 		m.cs = 418
-		goto _test_eof
-	_test_eof419:
+		goto _testEof
+	_testEof419:
 		m.cs = 419
-		goto _test_eof
-	_test_eof420:
+		goto _testEof
+	_testEof420:
 		m.cs = 420
-		goto _test_eof
-	_test_eof421:
+		goto _testEof
+	_testEof421:
 		m.cs = 421
-		goto _test_eof
-	_test_eof422:
+		goto _testEof
+	_testEof422:
 		m.cs = 422
-		goto _test_eof
-	_test_eof423:
+		goto _testEof
+	_testEof423:
 		m.cs = 423
-		goto _test_eof
-	_test_eof424:
+		goto _testEof
+	_testEof424:
 		m.cs = 424
-		goto _test_eof
-	_test_eof425:
+		goto _testEof
+	_testEof425:
 		m.cs = 425
-		goto _test_eof
-	_test_eof426:
+		goto _testEof
+	_testEof426:
 		m.cs = 426
-		goto _test_eof
-	_test_eof427:
+		goto _testEof
+	_testEof427:
 		m.cs = 427
-		goto _test_eof
-	_test_eof428:
+		goto _testEof
+	_testEof428:
 		m.cs = 428
-		goto _test_eof
-	_test_eof429:
+		goto _testEof
+	_testEof429:
 		m.cs = 429
-		goto _test_eof
-	_test_eof430:
+		goto _testEof
+	_testEof430:
 		m.cs = 430
-		goto _test_eof
-	_test_eof431:
+		goto _testEof
+	_testEof431:
 		m.cs = 431
-		goto _test_eof
-	_test_eof432:
+		goto _testEof
+	_testEof432:
 		m.cs = 432
-		goto _test_eof
-	_test_eof433:
+		goto _testEof
+	_testEof433:
 		m.cs = 433
-		goto _test_eof
-	_test_eof434:
+		goto _testEof
+	_testEof434:
 		m.cs = 434
-		goto _test_eof
-	_test_eof435:
+		goto _testEof
+	_testEof435:
 		m.cs = 435
-		goto _test_eof
-	_test_eof436:
+		goto _testEof
+	_testEof436:
 		m.cs = 436
-		goto _test_eof
-	_test_eof437:
+		goto _testEof
+	_testEof437:
 		m.cs = 437
-		goto _test_eof
-	_test_eof438:
+		goto _testEof
+	_testEof438:
 		m.cs = 438
-		goto _test_eof
-	_test_eof439:
+		goto _testEof
+	_testEof439:
 		m.cs = 439
-		goto _test_eof
-	_test_eof440:
+		goto _testEof
+	_testEof440:
 		m.cs = 440
-		goto _test_eof
-	_test_eof441:
+		goto _testEof
+	_testEof441:
 		m.cs = 441
-		goto _test_eof
-	_test_eof442:
+		goto _testEof
+	_testEof442:
 		m.cs = 442
-		goto _test_eof
-	_test_eof443:
+		goto _testEof
+	_testEof443:
 		m.cs = 443
-		goto _test_eof
-	_test_eof444:
+		goto _testEof
+	_testEof444:
 		m.cs = 444
-		goto _test_eof
-	_test_eof445:
+		goto _testEof
+	_testEof445:
 		m.cs = 445
-		goto _test_eof
-	_test_eof446:
+		goto _testEof
+	_testEof446:
 		m.cs = 446
-		goto _test_eof
-	_test_eof447:
+		goto _testEof
+	_testEof447:
 		m.cs = 447
-		goto _test_eof
-	_test_eof448:
+		goto _testEof
+	_testEof448:
 		m.cs = 448
-		goto _test_eof
-	_test_eof449:
+		goto _testEof
+	_testEof449:
 		m.cs = 449
-		goto _test_eof
-	_test_eof450:
+		goto _testEof
+	_testEof450:
 		m.cs = 450
-		goto _test_eof
-	_test_eof451:
+		goto _testEof
+	_testEof451:
 		m.cs = 451
-		goto _test_eof
-	_test_eof452:
+		goto _testEof
+	_testEof452:
 		m.cs = 452
-		goto _test_eof
-	_test_eof453:
+		goto _testEof
+	_testEof453:
 		m.cs = 453
-		goto _test_eof
-	_test_eof454:
+		goto _testEof
+	_testEof454:
 		m.cs = 454
-		goto _test_eof
-	_test_eof455:
+		goto _testEof
+	_testEof455:
 		m.cs = 455
-		goto _test_eof
-	_test_eof456:
+		goto _testEof
+	_testEof456:
 		m.cs = 456
-		goto _test_eof
-	_test_eof457:
+		goto _testEof
+	_testEof457:
 		m.cs = 457
-		goto _test_eof
-	_test_eof458:
+		goto _testEof
+	_testEof458:
 		m.cs = 458
-		goto _test_eof
-	_test_eof459:
+		goto _testEof
+	_testEof459:
 		m.cs = 459
-		goto _test_eof
-	_test_eof460:
+		goto _testEof
+	_testEof460:
 		m.cs = 460
-		goto _test_eof
-	_test_eof461:
+		goto _testEof
+	_testEof461:
 		m.cs = 461
-		goto _test_eof
-	_test_eof462:
+		goto _testEof
+	_testEof462:
 		m.cs = 462
-		goto _test_eof
-	_test_eof463:
+		goto _testEof
+	_testEof463:
 		m.cs = 463
-		goto _test_eof
-	_test_eof464:
+		goto _testEof
+	_testEof464:
 		m.cs = 464
-		goto _test_eof
-	_test_eof465:
+		goto _testEof
+	_testEof465:
 		m.cs = 465
-		goto _test_eof
-	_test_eof466:
+		goto _testEof
+	_testEof466:
 		m.cs = 466
-		goto _test_eof
-	_test_eof467:
+		goto _testEof
+	_testEof467:
 		m.cs = 467
-		goto _test_eof
-	_test_eof468:
+		goto _testEof
+	_testEof468:
 		m.cs = 468
-		goto _test_eof
-	_test_eof469:
+		goto _testEof
+	_testEof469:
 		m.cs = 469
-		goto _test_eof
-	_test_eof470:
+		goto _testEof
+	_testEof470:
 		m.cs = 470
-		goto _test_eof
-	_test_eof471:
+		goto _testEof
+	_testEof471:
 		m.cs = 471
-		goto _test_eof
-	_test_eof472:
+		goto _testEof
+	_testEof472:
 		m.cs = 472
-		goto _test_eof
-	_test_eof473:
+		goto _testEof
+	_testEof473:
 		m.cs = 473
-		goto _test_eof
-	_test_eof474:
+		goto _testEof
+	_testEof474:
 		m.cs = 474
-		goto _test_eof
-	_test_eof475:
+		goto _testEof
+	_testEof475:
 		m.cs = 475
-		goto _test_eof
-	_test_eof476:
+		goto _testEof
+	_testEof476:
 		m.cs = 476
-		goto _test_eof
-	_test_eof477:
+		goto _testEof
+	_testEof477:
 		m.cs = 477
-		goto _test_eof
-	_test_eof478:
+		goto _testEof
+	_testEof478:
 		m.cs = 478
-		goto _test_eof
-	_test_eof479:
+		goto _testEof
+	_testEof479:
 		m.cs = 479
-		goto _test_eof
-	_test_eof480:
+		goto _testEof
+	_testEof480:
 		m.cs = 480
-		goto _test_eof
-	_test_eof481:
+		goto _testEof
+	_testEof481:
 		m.cs = 481
-		goto _test_eof
-	_test_eof482:
+		goto _testEof
+	_testEof482:
 		m.cs = 482
-		goto _test_eof
-	_test_eof483:
+		goto _testEof
+	_testEof483:
 		m.cs = 483
-		goto _test_eof
-	_test_eof484:
+		goto _testEof
+	_testEof484:
 		m.cs = 484
-		goto _test_eof
-	_test_eof485:
+		goto _testEof
+	_testEof485:
 		m.cs = 485
-		goto _test_eof
-	_test_eof486:
+		goto _testEof
+	_testEof486:
 		m.cs = 486
-		goto _test_eof
-	_test_eof487:
+		goto _testEof
+	_testEof487:
 		m.cs = 487
-		goto _test_eof
-	_test_eof488:
+		goto _testEof
+	_testEof488:
 		m.cs = 488
-		goto _test_eof
-	_test_eof489:
+		goto _testEof
+	_testEof489:
 		m.cs = 489
-		goto _test_eof
-	_test_eof490:
+		goto _testEof
+	_testEof490:
 		m.cs = 490
-		goto _test_eof
-	_test_eof491:
+		goto _testEof
+	_testEof491:
 		m.cs = 491
-		goto _test_eof
-	_test_eof492:
+		goto _testEof
+	_testEof492:
 		m.cs = 492
-		goto _test_eof
-	_test_eof493:
+		goto _testEof
+	_testEof493:
 		m.cs = 493
-		goto _test_eof
-	_test_eof494:
+		goto _testEof
+	_testEof494:
 		m.cs = 494
-		goto _test_eof
-	_test_eof495:
+		goto _testEof
+	_testEof495:
 		m.cs = 495
-		goto _test_eof
-	_test_eof496:
+		goto _testEof
+	_testEof496:
 		m.cs = 496
-		goto _test_eof
-	_test_eof497:
+		goto _testEof
+	_testEof497:
 		m.cs = 497
-		goto _test_eof
-	_test_eof498:
+		goto _testEof
+	_testEof498:
 		m.cs = 498
-		goto _test_eof
-	_test_eof499:
+		goto _testEof
+	_testEof499:
 		m.cs = 499
-		goto _test_eof
-	_test_eof500:
+		goto _testEof
+	_testEof500:
 		m.cs = 500
-		goto _test_eof
-	_test_eof501:
+		goto _testEof
+	_testEof501:
 		m.cs = 501
-		goto _test_eof
-	_test_eof502:
+		goto _testEof
+	_testEof502:
 		m.cs = 502
-		goto _test_eof
-	_test_eof503:
+		goto _testEof
+	_testEof503:
 		m.cs = 503
-		goto _test_eof
-	_test_eof504:
+		goto _testEof
+	_testEof504:
 		m.cs = 504
-		goto _test_eof
-	_test_eof505:
+		goto _testEof
+	_testEof505:
 		m.cs = 505
-		goto _test_eof
-	_test_eof506:
+		goto _testEof
+	_testEof506:
 		m.cs = 506
-		goto _test_eof
-	_test_eof507:
+		goto _testEof
+	_testEof507:
 		m.cs = 507
-		goto _test_eof
-	_test_eof508:
+		goto _testEof
+	_testEof508:
 		m.cs = 508
-		goto _test_eof
-	_test_eof509:
+		goto _testEof
+	_testEof509:
 		m.cs = 509
-		goto _test_eof
-	_test_eof510:
+		goto _testEof
+	_testEof510:
 		m.cs = 510
-		goto _test_eof
-	_test_eof511:
+		goto _testEof
+	_testEof511:
 		m.cs = 511
-		goto _test_eof
-	_test_eof512:
+		goto _testEof
+	_testEof512:
 		m.cs = 512
-		goto _test_eof
-	_test_eof513:
+		goto _testEof
+	_testEof513:
 		m.cs = 513
-		goto _test_eof
-	_test_eof514:
+		goto _testEof
+	_testEof514:
 		m.cs = 514
-		goto _test_eof
-	_test_eof515:
+		goto _testEof
+	_testEof515:
 		m.cs = 515
-		goto _test_eof
-	_test_eof516:
+		goto _testEof
+	_testEof516:
 		m.cs = 516
-		goto _test_eof
-	_test_eof517:
+		goto _testEof
+	_testEof517:
 		m.cs = 517
-		goto _test_eof
-	_test_eof518:
+		goto _testEof
+	_testEof518:
 		m.cs = 518
-		goto _test_eof
-	_test_eof519:
+		goto _testEof
+	_testEof519:
 		m.cs = 519
-		goto _test_eof
-	_test_eof520:
+		goto _testEof
+	_testEof520:
 		m.cs = 520
-		goto _test_eof
-	_test_eof521:
+		goto _testEof
+	_testEof521:
 		m.cs = 521
-		goto _test_eof
-	_test_eof522:
+		goto _testEof
+	_testEof522:
 		m.cs = 522
-		goto _test_eof
-	_test_eof523:
+		goto _testEof
+	_testEof523:
 		m.cs = 523
-		goto _test_eof
-	_test_eof524:
+		goto _testEof
+	_testEof524:
 		m.cs = 524
-		goto _test_eof
-	_test_eof525:
+		goto _testEof
+	_testEof525:
 		m.cs = 525
-		goto _test_eof
-	_test_eof526:
+		goto _testEof
+	_testEof526:
 		m.cs = 526
-		goto _test_eof
-	_test_eof527:
+		goto _testEof
+	_testEof527:
 		m.cs = 527
-		goto _test_eof
-	_test_eof528:
+		goto _testEof
+	_testEof528:
 		m.cs = 528
-		goto _test_eof
-	_test_eof529:
+		goto _testEof
+	_testEof529:
 		m.cs = 529
-		goto _test_eof
-	_test_eof530:
+		goto _testEof
+	_testEof530:
 		m.cs = 530
-		goto _test_eof
-	_test_eof531:
+		goto _testEof
+	_testEof531:
 		m.cs = 531
-		goto _test_eof
-	_test_eof532:
+		goto _testEof
+	_testEof532:
 		m.cs = 532
-		goto _test_eof
-	_test_eof533:
+		goto _testEof
+	_testEof533:
 		m.cs = 533
-		goto _test_eof
-	_test_eof534:
+		goto _testEof
+	_testEof534:
 		m.cs = 534
-		goto _test_eof
-	_test_eof535:
+		goto _testEof
+	_testEof535:
 		m.cs = 535
-		goto _test_eof
-	_test_eof536:
+		goto _testEof
+	_testEof536:
 		m.cs = 536
-		goto _test_eof
-	_test_eof537:
+		goto _testEof
+	_testEof537:
 		m.cs = 537
-		goto _test_eof
-	_test_eof538:
+		goto _testEof
+	_testEof538:
 		m.cs = 538
-		goto _test_eof
-	_test_eof539:
+		goto _testEof
+	_testEof539:
 		m.cs = 539
-		goto _test_eof
-	_test_eof540:
+		goto _testEof
+	_testEof540:
 		m.cs = 540
-		goto _test_eof
-	_test_eof541:
+		goto _testEof
+	_testEof541:
 		m.cs = 541
-		goto _test_eof
-	_test_eof542:
+		goto _testEof
+	_testEof542:
 		m.cs = 542
-		goto _test_eof
-	_test_eof543:
+		goto _testEof
+	_testEof543:
 		m.cs = 543
-		goto _test_eof
-	_test_eof544:
+		goto _testEof
+	_testEof544:
 		m.cs = 544
-		goto _test_eof
-	_test_eof545:
+		goto _testEof
+	_testEof545:
 		m.cs = 545
-		goto _test_eof
-	_test_eof546:
+		goto _testEof
+	_testEof546:
 		m.cs = 546
-		goto _test_eof
-	_test_eof547:
+		goto _testEof
+	_testEof547:
 		m.cs = 547
-		goto _test_eof
-	_test_eof548:
+		goto _testEof
+	_testEof548:
 		m.cs = 548
-		goto _test_eof
-	_test_eof549:
+		goto _testEof
+	_testEof549:
 		m.cs = 549
-		goto _test_eof
-	_test_eof550:
+		goto _testEof
+	_testEof550:
 		m.cs = 550
-		goto _test_eof
-	_test_eof551:
+		goto _testEof
+	_testEof551:
 		m.cs = 551
-		goto _test_eof
-	_test_eof552:
+		goto _testEof
+	_testEof552:
 		m.cs = 552
-		goto _test_eof
-	_test_eof553:
+		goto _testEof
+	_testEof553:
 		m.cs = 553
-		goto _test_eof
-	_test_eof554:
+		goto _testEof
+	_testEof554:
 		m.cs = 554
-		goto _test_eof
-	_test_eof555:
+		goto _testEof
+	_testEof555:
 		m.cs = 555
-		goto _test_eof
-	_test_eof556:
+		goto _testEof
+	_testEof556:
 		m.cs = 556
-		goto _test_eof
-	_test_eof557:
+		goto _testEof
+	_testEof557:
 		m.cs = 557
-		goto _test_eof
-	_test_eof558:
+		goto _testEof
+	_testEof558:
 		m.cs = 558
-		goto _test_eof
-	_test_eof559:
+		goto _testEof
+	_testEof559:
 		m.cs = 559
-		goto _test_eof
-	_test_eof560:
+		goto _testEof
+	_testEof560:
 		m.cs = 560
-		goto _test_eof
-	_test_eof561:
+		goto _testEof
+	_testEof561:
 		m.cs = 561
-		goto _test_eof
-	_test_eof562:
+		goto _testEof
+	_testEof562:
 		m.cs = 562
-		goto _test_eof
-	_test_eof563:
+		goto _testEof
+	_testEof563:
 		m.cs = 563
-		goto _test_eof
-	_test_eof564:
+		goto _testEof
+	_testEof564:
 		m.cs = 564
-		goto _test_eof
-	_test_eof565:
+		goto _testEof
+	_testEof565:
 		m.cs = 565
-		goto _test_eof
-	_test_eof566:
+		goto _testEof
+	_testEof566:
 		m.cs = 566
-		goto _test_eof
-	_test_eof567:
+		goto _testEof
+	_testEof567:
 		m.cs = 567
-		goto _test_eof
-	_test_eof568:
+		goto _testEof
+	_testEof568:
 		m.cs = 568
-		goto _test_eof
-	_test_eof569:
+		goto _testEof
+	_testEof569:
 		m.cs = 569
-		goto _test_eof
-	_test_eof570:
+		goto _testEof
+	_testEof570:
 		m.cs = 570
-		goto _test_eof
-	_test_eof571:
+		goto _testEof
+	_testEof571:
 		m.cs = 571
-		goto _test_eof
-	_test_eof572:
+		goto _testEof
+	_testEof572:
 		m.cs = 572
-		goto _test_eof
-	_test_eof573:
+		goto _testEof
+	_testEof573:
 		m.cs = 573
-		goto _test_eof
-	_test_eof574:
+		goto _testEof
+	_testEof574:
 		m.cs = 574
-		goto _test_eof
-	_test_eof575:
+		goto _testEof
+	_testEof575:
 		m.cs = 575
-		goto _test_eof
-	_test_eof576:
+		goto _testEof
+	_testEof576:
 		m.cs = 576
-		goto _test_eof
-	_test_eof577:
+		goto _testEof
+	_testEof577:
 		m.cs = 577
-		goto _test_eof
-	_test_eof578:
+		goto _testEof
+	_testEof578:
 		m.cs = 578
-		goto _test_eof
-	_test_eof579:
+		goto _testEof
+	_testEof579:
 		m.cs = 579
-		goto _test_eof
-	_test_eof580:
+		goto _testEof
+	_testEof580:
 		m.cs = 580
-		goto _test_eof
-	_test_eof581:
+		goto _testEof
+	_testEof581:
 		m.cs = 581
-		goto _test_eof
-	_test_eof582:
+		goto _testEof
+	_testEof582:
 		m.cs = 582
-		goto _test_eof
-	_test_eof583:
+		goto _testEof
+	_testEof583:
 		m.cs = 583
-		goto _test_eof
-	_test_eof584:
+		goto _testEof
+	_testEof584:
 		m.cs = 584
-		goto _test_eof
-	_test_eof585:
+		goto _testEof
+	_testEof585:
 		m.cs = 585
-		goto _test_eof
-	_test_eof586:
+		goto _testEof
+	_testEof586:
 		m.cs = 586
-		goto _test_eof
-	_test_eof587:
+		goto _testEof
+	_testEof587:
 		m.cs = 587
-		goto _test_eof
-	_test_eof588:
+		goto _testEof
+	_testEof588:
 		m.cs = 588
-		goto _test_eof
-	_test_eof589:
+		goto _testEof
+	_testEof589:
 		m.cs = 589
-		goto _test_eof
-	_test_eof590:
+		goto _testEof
+	_testEof590:
 		m.cs = 590
-		goto _test_eof
-	_test_eof591:
+		goto _testEof
+	_testEof591:
 		m.cs = 591
-		goto _test_eof
-	_test_eof592:
+		goto _testEof
+	_testEof592:
 		m.cs = 592
-		goto _test_eof
-	_test_eof593:
+		goto _testEof
+	_testEof593:
 		m.cs = 593
-		goto _test_eof
-	_test_eof594:
+		goto _testEof
+	_testEof594:
 		m.cs = 594
-		goto _test_eof
-	_test_eof595:
+		goto _testEof
+	_testEof595:
 		m.cs = 595
-		goto _test_eof
-	_test_eof596:
+		goto _testEof
+	_testEof596:
 		m.cs = 596
-		goto _test_eof
-	_test_eof597:
+		goto _testEof
+	_testEof597:
 		m.cs = 597
-		goto _test_eof
-	_test_eof598:
+		goto _testEof
+	_testEof598:
 		m.cs = 598
-		goto _test_eof
-	_test_eof599:
+		goto _testEof
+	_testEof599:
 		m.cs = 599
-		goto _test_eof
-	_test_eof600:
+		goto _testEof
+	_testEof600:
 		m.cs = 600
-		goto _test_eof
-	_test_eof601:
+		goto _testEof
+	_testEof601:
 		m.cs = 601
-		goto _test_eof
-	_test_eof602:
+		goto _testEof
+	_testEof602:
 		m.cs = 602
-		goto _test_eof
-	_test_eof607:
+		goto _testEof
+	_testEof607:
 		m.cs = 607
-		goto _test_eof
+		goto _testEof
 
-	_test_eof:
+	_testEof:
 		{
 		}
 		if (m.p) == (m.eof) {
 			switch m.cs {
 			case 605:
-//line rfc5424/machine.go.rl:147
 
 				output.message = string(m.text())
 
 			case 1:
-//line rfc5424/machine.go.rl:157
 
 				m.err = fmt.Errorf(ErrPri+ColumnPositionTemplate, m.p)
 				(m.p)--
@@ -11851,7 +11666,6 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 				}
 
 			case 15, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 124, 125, 126, 127, 128, 129, 130, 131, 132:
-//line rfc5424/machine.go.rl:193
 
 				m.err = fmt.Errorf(ErrMsgID+ColumnPositionTemplate, m.p)
 				(m.p)--
@@ -11861,7 +11675,6 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 				}
 
 			case 16:
-//line rfc5424/machine.go.rl:199
 
 				m.err = fmt.Errorf(ErrStructuredData+ColumnPositionTemplate, m.p)
 				(m.p)--
@@ -11871,7 +11684,6 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 				}
 
 			case 7:
-//line rfc5424/machine.go.rl:242
 
 				m.err = fmt.Errorf(ErrParse+ColumnPositionTemplate, m.p)
 				(m.p)--
@@ -11881,11 +11693,8 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 				}
 
 			case 5:
-//line rfc5424/machine.go.rl:71
 
 				output.version = uint16(common.UnsafeUTF8DecimalCodePointsToInt(m.text()))
-
-//line rfc5424/machine.go.rl:242
 
 				m.err = fmt.Errorf(ErrParse+ColumnPositionTemplate, m.p)
 				(m.p)--
@@ -11895,7 +11704,6 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 				}
 
 			case 585:
-//line rfc5424/machine.go.rl:75
 
 				if t, e := time.Parse(RFC3339MICRO, string(m.text())); e != nil {
 					m.err = fmt.Errorf("%s [col %d]", e, m.p)
@@ -11909,8 +11717,6 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 					output.timestampSet = true
 				}
 
-//line rfc5424/machine.go.rl:242
-
 				m.err = fmt.Errorf(ErrParse+ColumnPositionTemplate, m.p)
 				(m.p)--
 
@@ -11919,7 +11725,6 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 				}
 
 			case 4:
-//line rfc5424/machine.go.rl:163
 
 				m.err = fmt.Errorf(ErrVersion+ColumnPositionTemplate, m.p)
 				(m.p)--
@@ -11927,8 +11732,6 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 				{
 					goto st607
 				}
-
-//line rfc5424/machine.go.rl:242
 
 				m.err = fmt.Errorf(ErrParse+ColumnPositionTemplate, m.p)
 				(m.p)--
@@ -11938,7 +11741,6 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 				}
 
 			case 6, 561, 562, 563, 564, 565, 566, 567, 568, 569, 570, 571, 572, 573, 574, 575, 576, 577, 578, 579, 580, 581, 582, 583, 584, 586, 587, 588, 589, 590, 591, 592, 593, 594, 595, 596, 597:
-//line rfc5424/machine.go.rl:169
 
 				m.err = fmt.Errorf(ErrTimestamp+ColumnPositionTemplate, m.p)
 				(m.p)--
@@ -11946,8 +11748,6 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 				{
 					goto st607
 				}
-
-//line rfc5424/machine.go.rl:242
 
 				m.err = fmt.Errorf(ErrParse+ColumnPositionTemplate, m.p)
 				(m.p)--
@@ -11957,7 +11757,6 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 				}
 
 			case 8, 9, 307, 308, 309, 310, 311, 312, 313, 314, 315, 316, 317, 318, 319, 320, 321, 322, 323, 324, 325, 326, 327, 328, 329, 330, 331, 332, 333, 334, 335, 336, 337, 338, 339, 340, 341, 342, 343, 344, 345, 346, 347, 348, 349, 350, 351, 352, 353, 354, 355, 356, 357, 358, 359, 360, 361, 362, 363, 364, 365, 366, 367, 368, 369, 370, 371, 372, 373, 374, 375, 376, 377, 378, 379, 380, 381, 382, 383, 384, 385, 386, 387, 388, 389, 390, 391, 392, 393, 394, 395, 396, 397, 398, 399, 400, 401, 402, 403, 404, 405, 406, 407, 408, 409, 410, 411, 412, 413, 414, 415, 416, 417, 418, 419, 420, 421, 422, 423, 424, 425, 426, 427, 428, 429, 430, 431, 432, 433, 434, 435, 436, 437, 438, 439, 440, 441, 442, 443, 444, 445, 446, 447, 448, 449, 450, 451, 452, 453, 454, 455, 456, 457, 458, 459, 460, 461, 462, 463, 464, 465, 466, 467, 468, 469, 470, 471, 472, 473, 474, 475, 476, 477, 478, 479, 480, 481, 482, 483, 484, 485, 486, 487, 488, 489, 490, 491, 492, 493, 494, 495, 496, 497, 498, 499, 500, 501, 502, 503, 504, 505, 506, 507, 508, 509, 510, 511, 512, 513, 514, 515, 516, 517, 518, 519, 520, 521, 522, 523, 524, 525, 526, 527, 528, 529, 530, 531, 532, 533, 534, 535, 536, 537, 538, 539, 540, 541, 542, 543, 544, 545, 546, 547, 548, 549, 550, 551, 552, 553, 554, 555, 556, 557, 558, 559, 560:
-//line rfc5424/machine.go.rl:175
 
 				m.err = fmt.Errorf(ErrHostname+ColumnPositionTemplate, m.p)
 				(m.p)--
@@ -11965,8 +11764,6 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 				{
 					goto st607
 				}
-
-//line rfc5424/machine.go.rl:242
 
 				m.err = fmt.Errorf(ErrParse+ColumnPositionTemplate, m.p)
 				(m.p)--
@@ -11976,7 +11773,6 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 				}
 
 			case 10, 11, 260, 261, 262, 263, 264, 265, 266, 267, 268, 269, 270, 271, 272, 273, 274, 275, 276, 277, 278, 279, 280, 281, 282, 283, 284, 285, 286, 287, 288, 289, 290, 291, 292, 293, 294, 295, 296, 297, 298, 299, 300, 301, 302, 303, 304, 305, 306:
-//line rfc5424/machine.go.rl:181
 
 				m.err = fmt.Errorf(ErrAppname+ColumnPositionTemplate, m.p)
 				(m.p)--
@@ -11984,8 +11780,6 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 				{
 					goto st607
 				}
-
-//line rfc5424/machine.go.rl:242
 
 				m.err = fmt.Errorf(ErrParse+ColumnPositionTemplate, m.p)
 				(m.p)--
@@ -11995,7 +11789,6 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 				}
 
 			case 12, 13, 133, 134, 135, 136, 137, 138, 139, 140, 141, 142, 143, 144, 145, 146, 147, 148, 149, 150, 151, 152, 153, 154, 155, 156, 157, 158, 159, 160, 161, 162, 163, 164, 165, 166, 167, 168, 169, 170, 171, 172, 173, 174, 175, 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191, 192, 193, 194, 195, 196, 197, 198, 199, 200, 201, 202, 203, 204, 205, 206, 207, 208, 209, 210, 211, 212, 213, 214, 215, 216, 217, 218, 219, 220, 221, 222, 223, 224, 225, 226, 227, 228, 229, 230, 231, 232, 233, 234, 235, 236, 237, 238, 239, 240, 241, 242, 243, 244, 245, 246, 247, 248, 249, 250, 251, 252, 253, 254, 255, 256, 257, 258, 259:
-//line rfc5424/machine.go.rl:187
 
 				m.err = fmt.Errorf(ErrProcID+ColumnPositionTemplate, m.p)
 				(m.p)--
@@ -12003,8 +11796,6 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 				{
 					goto st607
 				}
-
-//line rfc5424/machine.go.rl:242
 
 				m.err = fmt.Errorf(ErrParse+ColumnPositionTemplate, m.p)
 				(m.p)--
@@ -12014,7 +11805,6 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 				}
 
 			case 14:
-//line rfc5424/machine.go.rl:193
 
 				m.err = fmt.Errorf(ErrMsgID+ColumnPositionTemplate, m.p)
 				(m.p)--
@@ -12022,8 +11812,6 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 				{
 					goto st607
 				}
-
-//line rfc5424/machine.go.rl:242
 
 				m.err = fmt.Errorf(ErrParse+ColumnPositionTemplate, m.p)
 				(m.p)--
@@ -12033,7 +11821,6 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 				}
 
 			case 24:
-//line rfc5424/machine.go.rl:205
 
 				delete(output.structuredData, m.currentelem)
 				if len(output.structuredData) == 0 {
@@ -12046,8 +11833,6 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 					goto st607
 				}
 
-//line rfc5424/machine.go.rl:199
-
 				m.err = fmt.Errorf(ErrStructuredData+ColumnPositionTemplate, m.p)
 				(m.p)--
 
@@ -12056,7 +11841,6 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 				}
 
 			case 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 62, 64, 65, 66, 67, 68, 69, 70:
-//line rfc5424/machine.go.rl:215
 
 				if len(output.structuredData) > 0 {
 					delete(output.structuredData[m.currentelem], m.currentparam)
@@ -12068,8 +11852,6 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 					goto st607
 				}
 
-//line rfc5424/machine.go.rl:199
-
 				m.err = fmt.Errorf(ErrStructuredData+ColumnPositionTemplate, m.p)
 				(m.p)--
 
@@ -12078,7 +11860,6 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 				}
 
 			case 17, 18, 19, 20, 21, 22, 23:
-//line rfc5424/machine.go.rl:224
 
 				// If error encountered within the message rule ...
 				if m.msgat > 0 {
@@ -12093,8 +11874,6 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 					goto st607
 				}
 
-//line rfc5424/machine.go.rl:242
-
 				m.err = fmt.Errorf(ErrParse+ColumnPositionTemplate, m.p)
 				(m.p)--
 
@@ -12103,20 +11882,14 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 				}
 
 			case 604:
-//line rfc5424/machine.go.rl:58
 
 				m.pb = m.p
 
-//line rfc5424/machine.go.rl:62
-
 				m.msgat = m.p
-
-//line rfc5424/machine.go.rl:147
 
 				output.message = string(m.text())
 
 			case 25, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100, 101:
-//line rfc5424/machine.go.rl:106
 
 				if _, ok := output.structuredData[string(m.text())]; ok {
 					// As per RFC5424 section 6.3.2 SD-ID MUST NOT exist more than once in a message
@@ -12133,8 +11906,6 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 					m.currentelem = id
 				}
 
-//line rfc5424/machine.go.rl:205
-
 				delete(output.structuredData, m.currentelem)
 				if len(output.structuredData) == 0 {
 					output.hasElements = false
@@ -12146,8 +11917,6 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 					goto st607
 				}
 
-//line rfc5424/machine.go.rl:199
-
 				m.err = fmt.Errorf(ErrStructuredData+ColumnPositionTemplate, m.p)
 				(m.p)--
 
@@ -12156,7 +11925,6 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 				}
 
 			case 2, 3, 600, 601, 602:
-//line rfc5424/machine.go.rl:151
 
 				m.err = fmt.Errorf(ErrPrival+ColumnPositionTemplate, m.p)
 				(m.p)--
@@ -12165,16 +11933,12 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 					goto st607
 				}
 
-//line rfc5424/machine.go.rl:157
-
 				m.err = fmt.Errorf(ErrPri+ColumnPositionTemplate, m.p)
 				(m.p)--
 
 				{
 					goto st607
 				}
-
-//line rfc5424/machine.go.rl:242
 
 				m.err = fmt.Errorf(ErrParse+ColumnPositionTemplate, m.p)
 				(m.p)--
@@ -12184,7 +11948,6 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 				}
 
 			case 598, 599:
-//line rfc5424/machine.go.rl:163
 
 				m.err = fmt.Errorf(ErrVersion+ColumnPositionTemplate, m.p)
 				(m.p)--
@@ -12193,11 +11956,7 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 					goto st607
 				}
 
-//line rfc5424/machine.go.rl:71
-
 				output.version = uint16(common.UnsafeUTF8DecimalCodePointsToInt(m.text()))
-
-//line rfc5424/machine.go.rl:242
 
 				m.err = fmt.Errorf(ErrParse+ColumnPositionTemplate, m.p)
 				(m.p)--
@@ -12207,7 +11966,6 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 				}
 
 			case 60, 61, 63:
-//line rfc5424/machine.go.rl:236
 
 				m.err = fmt.Errorf(ErrEscape+ColumnPositionTemplate, m.p)
 				(m.p)--
@@ -12215,8 +11973,6 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 				{
 					goto st607
 				}
-
-//line rfc5424/machine.go.rl:215
 
 				if len(output.structuredData) > 0 {
 					delete(output.structuredData[m.currentelem], m.currentparam)
@@ -12228,8 +11984,6 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 					goto st607
 				}
 
-//line rfc5424/machine.go.rl:199
-
 				m.err = fmt.Errorf(ErrStructuredData+ColumnPositionTemplate, m.p)
 				(m.p)--
 
@@ -12237,7 +11991,6 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 					goto st607
 				}
 
-//line rfc5424/machine.go:10886
 			}
 		}
 
@@ -12246,9 +11999,7 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		}
 	}
 
-//line rfc5424/machine.go.rl:373
-
-	if m.cs < first_final || m.cs == en_fail {
+	if m.cs < firstFinal || m.cs == enFail {
 		if m.bestEffort && output.valid() {
 			// An error occurred but partial parsing is on and partial message is minimally valid
 			return output.export(), m.err

--- a/rfc5424/machine.go
+++ b/rfc5424/machine.go
@@ -1,11 +1,12 @@
+//line rfc5424/machine.go.rl:1
 package rfc5424
 
 import (
 	"fmt"
 	"time"
 
-	"github.com/influxdata/go-syslog/v2"
-	"github.com/influxdata/go-syslog/v2/common"
+	"github.com/influxdata/go-syslog"
+	"github.com/influxdata/go-syslog/common"
 )
 
 // ColumnPositionTemplate is the template used to communicate the column where errors occur.
@@ -47,11 +48,16 @@ const (
 // RFC3339MICRO represents the timestamp format that RFC5424 mandates.
 const RFC3339MICRO = "2006-01-02T15:04:05.999999Z07:00"
 
-const start int = 1
-const firstFinal int = 603
+//line rfc5424/machine.go.rl:299
 
-const enFail int = 607
-const enMain int = 1
+//line rfc5424/machine.go:58
+const start int = 1
+const first_final int = 603
+
+const en_fail int = 607
+const en_main int = 1
+
+//line rfc5424/machine.go.rl:302
 
 type machine struct {
 	data         []byte
@@ -73,6 +79,16 @@ func NewMachine(options ...syslog.MachineOption) syslog.Machine {
 	for _, opt := range options {
 		opt(m)
 	}
+
+//line rfc5424/machine.go.rl:325
+
+//line rfc5424/machine.go.rl:326
+
+//line rfc5424/machine.go.rl:327
+
+//line rfc5424/machine.go.rl:328
+
+//line rfc5424/machine.go.rl:329
 
 	return m
 }
@@ -115,1239 +131,1244 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 	m.err = nil
 	output := &syslogMessage{}
 
+//line rfc5424/machine.go:142
 	{
 		m.cs = start
 	}
 
+//line rfc5424/machine.go.rl:372
+
+//line rfc5424/machine.go:149
 	{
 		if (m.p) == (m.pe) {
-			goto _testEof
+			goto _test_eof
 		}
 		switch m.cs {
 		case 1:
-			goto stCase1
+			goto st_case_1
 		case 0:
-			goto stCase0
+			goto st_case_0
 		case 2:
-			goto stCase2
+			goto st_case_2
 		case 3:
-			goto stCase3
+			goto st_case_3
 		case 4:
-			goto stCase4
+			goto st_case_4
 		case 5:
-			goto stCase5
+			goto st_case_5
 		case 6:
-			goto stCase6
+			goto st_case_6
 		case 7:
-			goto stCase7
+			goto st_case_7
 		case 8:
-			goto stCase8
+			goto st_case_8
 		case 9:
-			goto stCase9
+			goto st_case_9
 		case 10:
-			goto stCase10
+			goto st_case_10
 		case 11:
-			goto stCase11
+			goto st_case_11
 		case 12:
-			goto stCase12
+			goto st_case_12
 		case 13:
-			goto stCase13
+			goto st_case_13
 		case 14:
-			goto stCase14
+			goto st_case_14
 		case 15:
-			goto stCase15
+			goto st_case_15
 		case 16:
-			goto stCase16
+			goto st_case_16
 		case 603:
-			goto stCase603
+			goto st_case_603
 		case 604:
-			goto stCase604
+			goto st_case_604
 		case 605:
-			goto stCase605
+			goto st_case_605
 		case 17:
-			goto stCase17
+			goto st_case_17
 		case 18:
-			goto stCase18
+			goto st_case_18
 		case 19:
-			goto stCase19
+			goto st_case_19
 		case 20:
-			goto stCase20
+			goto st_case_20
 		case 21:
-			goto stCase21
+			goto st_case_21
 		case 22:
-			goto stCase22
+			goto st_case_22
 		case 23:
-			goto stCase23
+			goto st_case_23
 		case 24:
-			goto stCase24
+			goto st_case_24
 		case 25:
-			goto stCase25
+			goto st_case_25
 		case 26:
-			goto stCase26
+			goto st_case_26
 		case 27:
-			goto stCase27
+			goto st_case_27
 		case 28:
-			goto stCase28
+			goto st_case_28
 		case 29:
-			goto stCase29
+			goto st_case_29
 		case 30:
-			goto stCase30
+			goto st_case_30
 		case 31:
-			goto stCase31
+			goto st_case_31
 		case 32:
-			goto stCase32
+			goto st_case_32
 		case 33:
-			goto stCase33
+			goto st_case_33
 		case 34:
-			goto stCase34
+			goto st_case_34
 		case 35:
-			goto stCase35
+			goto st_case_35
 		case 36:
-			goto stCase36
+			goto st_case_36
 		case 37:
-			goto stCase37
+			goto st_case_37
 		case 38:
-			goto stCase38
+			goto st_case_38
 		case 39:
-			goto stCase39
+			goto st_case_39
 		case 40:
-			goto stCase40
+			goto st_case_40
 		case 41:
-			goto stCase41
+			goto st_case_41
 		case 42:
-			goto stCase42
+			goto st_case_42
 		case 43:
-			goto stCase43
+			goto st_case_43
 		case 44:
-			goto stCase44
+			goto st_case_44
 		case 45:
-			goto stCase45
+			goto st_case_45
 		case 46:
-			goto stCase46
+			goto st_case_46
 		case 47:
-			goto stCase47
+			goto st_case_47
 		case 48:
-			goto stCase48
+			goto st_case_48
 		case 49:
-			goto stCase49
+			goto st_case_49
 		case 50:
-			goto stCase50
+			goto st_case_50
 		case 51:
-			goto stCase51
+			goto st_case_51
 		case 52:
-			goto stCase52
+			goto st_case_52
 		case 53:
-			goto stCase53
+			goto st_case_53
 		case 54:
-			goto stCase54
+			goto st_case_54
 		case 55:
-			goto stCase55
+			goto st_case_55
 		case 56:
-			goto stCase56
+			goto st_case_56
 		case 57:
-			goto stCase57
+			goto st_case_57
 		case 58:
-			goto stCase58
+			goto st_case_58
 		case 59:
-			goto stCase59
+			goto st_case_59
 		case 60:
-			goto stCase60
+			goto st_case_60
 		case 61:
-			goto stCase61
+			goto st_case_61
 		case 62:
-			goto stCase62
+			goto st_case_62
 		case 606:
-			goto stCase606
+			goto st_case_606
 		case 63:
-			goto stCase63
+			goto st_case_63
 		case 64:
-			goto stCase64
+			goto st_case_64
 		case 65:
-			goto stCase65
+			goto st_case_65
 		case 66:
-			goto stCase66
+			goto st_case_66
 		case 67:
-			goto stCase67
+			goto st_case_67
 		case 68:
-			goto stCase68
+			goto st_case_68
 		case 69:
-			goto stCase69
+			goto st_case_69
 		case 70:
-			goto stCase70
+			goto st_case_70
 		case 71:
-			goto stCase71
+			goto st_case_71
 		case 72:
-			goto stCase72
+			goto st_case_72
 		case 73:
-			goto stCase73
+			goto st_case_73
 		case 74:
-			goto stCase74
+			goto st_case_74
 		case 75:
-			goto stCase75
+			goto st_case_75
 		case 76:
-			goto stCase76
+			goto st_case_76
 		case 77:
-			goto stCase77
+			goto st_case_77
 		case 78:
-			goto stCase78
+			goto st_case_78
 		case 79:
-			goto stCase79
+			goto st_case_79
 		case 80:
-			goto stCase80
+			goto st_case_80
 		case 81:
-			goto stCase81
+			goto st_case_81
 		case 82:
-			goto stCase82
+			goto st_case_82
 		case 83:
-			goto stCase83
+			goto st_case_83
 		case 84:
-			goto stCase84
+			goto st_case_84
 		case 85:
-			goto stCase85
+			goto st_case_85
 		case 86:
-			goto stCase86
+			goto st_case_86
 		case 87:
-			goto stCase87
+			goto st_case_87
 		case 88:
-			goto stCase88
+			goto st_case_88
 		case 89:
-			goto stCase89
+			goto st_case_89
 		case 90:
-			goto stCase90
+			goto st_case_90
 		case 91:
-			goto stCase91
+			goto st_case_91
 		case 92:
-			goto stCase92
+			goto st_case_92
 		case 93:
-			goto stCase93
+			goto st_case_93
 		case 94:
-			goto stCase94
+			goto st_case_94
 		case 95:
-			goto stCase95
+			goto st_case_95
 		case 96:
-			goto stCase96
+			goto st_case_96
 		case 97:
-			goto stCase97
+			goto st_case_97
 		case 98:
-			goto stCase98
+			goto st_case_98
 		case 99:
-			goto stCase99
+			goto st_case_99
 		case 100:
-			goto stCase100
+			goto st_case_100
 		case 101:
-			goto stCase101
+			goto st_case_101
 		case 102:
-			goto stCase102
+			goto st_case_102
 		case 103:
-			goto stCase103
+			goto st_case_103
 		case 104:
-			goto stCase104
+			goto st_case_104
 		case 105:
-			goto stCase105
+			goto st_case_105
 		case 106:
-			goto stCase106
+			goto st_case_106
 		case 107:
-			goto stCase107
+			goto st_case_107
 		case 108:
-			goto stCase108
+			goto st_case_108
 		case 109:
-			goto stCase109
+			goto st_case_109
 		case 110:
-			goto stCase110
+			goto st_case_110
 		case 111:
-			goto stCase111
+			goto st_case_111
 		case 112:
-			goto stCase112
+			goto st_case_112
 		case 113:
-			goto stCase113
+			goto st_case_113
 		case 114:
-			goto stCase114
+			goto st_case_114
 		case 115:
-			goto stCase115
+			goto st_case_115
 		case 116:
-			goto stCase116
+			goto st_case_116
 		case 117:
-			goto stCase117
+			goto st_case_117
 		case 118:
-			goto stCase118
+			goto st_case_118
 		case 119:
-			goto stCase119
+			goto st_case_119
 		case 120:
-			goto stCase120
+			goto st_case_120
 		case 121:
-			goto stCase121
+			goto st_case_121
 		case 122:
-			goto stCase122
+			goto st_case_122
 		case 123:
-			goto stCase123
+			goto st_case_123
 		case 124:
-			goto stCase124
+			goto st_case_124
 		case 125:
-			goto stCase125
+			goto st_case_125
 		case 126:
-			goto stCase126
+			goto st_case_126
 		case 127:
-			goto stCase127
+			goto st_case_127
 		case 128:
-			goto stCase128
+			goto st_case_128
 		case 129:
-			goto stCase129
+			goto st_case_129
 		case 130:
-			goto stCase130
+			goto st_case_130
 		case 131:
-			goto stCase131
+			goto st_case_131
 		case 132:
-			goto stCase132
+			goto st_case_132
 		case 133:
-			goto stCase133
+			goto st_case_133
 		case 134:
-			goto stCase134
+			goto st_case_134
 		case 135:
-			goto stCase135
+			goto st_case_135
 		case 136:
-			goto stCase136
+			goto st_case_136
 		case 137:
-			goto stCase137
+			goto st_case_137
 		case 138:
-			goto stCase138
+			goto st_case_138
 		case 139:
-			goto stCase139
+			goto st_case_139
 		case 140:
-			goto stCase140
+			goto st_case_140
 		case 141:
-			goto stCase141
+			goto st_case_141
 		case 142:
-			goto stCase142
+			goto st_case_142
 		case 143:
-			goto stCase143
+			goto st_case_143
 		case 144:
-			goto stCase144
+			goto st_case_144
 		case 145:
-			goto stCase145
+			goto st_case_145
 		case 146:
-			goto stCase146
+			goto st_case_146
 		case 147:
-			goto stCase147
+			goto st_case_147
 		case 148:
-			goto stCase148
+			goto st_case_148
 		case 149:
-			goto stCase149
+			goto st_case_149
 		case 150:
-			goto stCase150
+			goto st_case_150
 		case 151:
-			goto stCase151
+			goto st_case_151
 		case 152:
-			goto stCase152
+			goto st_case_152
 		case 153:
-			goto stCase153
+			goto st_case_153
 		case 154:
-			goto stCase154
+			goto st_case_154
 		case 155:
-			goto stCase155
+			goto st_case_155
 		case 156:
-			goto stCase156
+			goto st_case_156
 		case 157:
-			goto stCase157
+			goto st_case_157
 		case 158:
-			goto stCase158
+			goto st_case_158
 		case 159:
-			goto stCase159
+			goto st_case_159
 		case 160:
-			goto stCase160
+			goto st_case_160
 		case 161:
-			goto stCase161
+			goto st_case_161
 		case 162:
-			goto stCase162
+			goto st_case_162
 		case 163:
-			goto stCase163
+			goto st_case_163
 		case 164:
-			goto stCase164
+			goto st_case_164
 		case 165:
-			goto stCase165
+			goto st_case_165
 		case 166:
-			goto stCase166
+			goto st_case_166
 		case 167:
-			goto stCase167
+			goto st_case_167
 		case 168:
-			goto stCase168
+			goto st_case_168
 		case 169:
-			goto stCase169
+			goto st_case_169
 		case 170:
-			goto stCase170
+			goto st_case_170
 		case 171:
-			goto stCase171
+			goto st_case_171
 		case 172:
-			goto stCase172
+			goto st_case_172
 		case 173:
-			goto stCase173
+			goto st_case_173
 		case 174:
-			goto stCase174
+			goto st_case_174
 		case 175:
-			goto stCase175
+			goto st_case_175
 		case 176:
-			goto stCase176
+			goto st_case_176
 		case 177:
-			goto stCase177
+			goto st_case_177
 		case 178:
-			goto stCase178
+			goto st_case_178
 		case 179:
-			goto stCase179
+			goto st_case_179
 		case 180:
-			goto stCase180
+			goto st_case_180
 		case 181:
-			goto stCase181
+			goto st_case_181
 		case 182:
-			goto stCase182
+			goto st_case_182
 		case 183:
-			goto stCase183
+			goto st_case_183
 		case 184:
-			goto stCase184
+			goto st_case_184
 		case 185:
-			goto stCase185
+			goto st_case_185
 		case 186:
-			goto stCase186
+			goto st_case_186
 		case 187:
-			goto stCase187
+			goto st_case_187
 		case 188:
-			goto stCase188
+			goto st_case_188
 		case 189:
-			goto stCase189
+			goto st_case_189
 		case 190:
-			goto stCase190
+			goto st_case_190
 		case 191:
-			goto stCase191
+			goto st_case_191
 		case 192:
-			goto stCase192
+			goto st_case_192
 		case 193:
-			goto stCase193
+			goto st_case_193
 		case 194:
-			goto stCase194
+			goto st_case_194
 		case 195:
-			goto stCase195
+			goto st_case_195
 		case 196:
-			goto stCase196
+			goto st_case_196
 		case 197:
-			goto stCase197
+			goto st_case_197
 		case 198:
-			goto stCase198
+			goto st_case_198
 		case 199:
-			goto stCase199
+			goto st_case_199
 		case 200:
-			goto stCase200
+			goto st_case_200
 		case 201:
-			goto stCase201
+			goto st_case_201
 		case 202:
-			goto stCase202
+			goto st_case_202
 		case 203:
-			goto stCase203
+			goto st_case_203
 		case 204:
-			goto stCase204
+			goto st_case_204
 		case 205:
-			goto stCase205
+			goto st_case_205
 		case 206:
-			goto stCase206
+			goto st_case_206
 		case 207:
-			goto stCase207
+			goto st_case_207
 		case 208:
-			goto stCase208
+			goto st_case_208
 		case 209:
-			goto stCase209
+			goto st_case_209
 		case 210:
-			goto stCase210
+			goto st_case_210
 		case 211:
-			goto stCase211
+			goto st_case_211
 		case 212:
-			goto stCase212
+			goto st_case_212
 		case 213:
-			goto stCase213
+			goto st_case_213
 		case 214:
-			goto stCase214
+			goto st_case_214
 		case 215:
-			goto stCase215
+			goto st_case_215
 		case 216:
-			goto stCase216
+			goto st_case_216
 		case 217:
-			goto stCase217
+			goto st_case_217
 		case 218:
-			goto stCase218
+			goto st_case_218
 		case 219:
-			goto stCase219
+			goto st_case_219
 		case 220:
-			goto stCase220
+			goto st_case_220
 		case 221:
-			goto stCase221
+			goto st_case_221
 		case 222:
-			goto stCase222
+			goto st_case_222
 		case 223:
-			goto stCase223
+			goto st_case_223
 		case 224:
-			goto stCase224
+			goto st_case_224
 		case 225:
-			goto stCase225
+			goto st_case_225
 		case 226:
-			goto stCase226
+			goto st_case_226
 		case 227:
-			goto stCase227
+			goto st_case_227
 		case 228:
-			goto stCase228
+			goto st_case_228
 		case 229:
-			goto stCase229
+			goto st_case_229
 		case 230:
-			goto stCase230
+			goto st_case_230
 		case 231:
-			goto stCase231
+			goto st_case_231
 		case 232:
-			goto stCase232
+			goto st_case_232
 		case 233:
-			goto stCase233
+			goto st_case_233
 		case 234:
-			goto stCase234
+			goto st_case_234
 		case 235:
-			goto stCase235
+			goto st_case_235
 		case 236:
-			goto stCase236
+			goto st_case_236
 		case 237:
-			goto stCase237
+			goto st_case_237
 		case 238:
-			goto stCase238
+			goto st_case_238
 		case 239:
-			goto stCase239
+			goto st_case_239
 		case 240:
-			goto stCase240
+			goto st_case_240
 		case 241:
-			goto stCase241
+			goto st_case_241
 		case 242:
-			goto stCase242
+			goto st_case_242
 		case 243:
-			goto stCase243
+			goto st_case_243
 		case 244:
-			goto stCase244
+			goto st_case_244
 		case 245:
-			goto stCase245
+			goto st_case_245
 		case 246:
-			goto stCase246
+			goto st_case_246
 		case 247:
-			goto stCase247
+			goto st_case_247
 		case 248:
-			goto stCase248
+			goto st_case_248
 		case 249:
-			goto stCase249
+			goto st_case_249
 		case 250:
-			goto stCase250
+			goto st_case_250
 		case 251:
-			goto stCase251
+			goto st_case_251
 		case 252:
-			goto stCase252
+			goto st_case_252
 		case 253:
-			goto stCase253
+			goto st_case_253
 		case 254:
-			goto stCase254
+			goto st_case_254
 		case 255:
-			goto stCase255
+			goto st_case_255
 		case 256:
-			goto stCase256
+			goto st_case_256
 		case 257:
-			goto stCase257
+			goto st_case_257
 		case 258:
-			goto stCase258
+			goto st_case_258
 		case 259:
-			goto stCase259
+			goto st_case_259
 		case 260:
-			goto stCase260
+			goto st_case_260
 		case 261:
-			goto stCase261
+			goto st_case_261
 		case 262:
-			goto stCase262
+			goto st_case_262
 		case 263:
-			goto stCase263
+			goto st_case_263
 		case 264:
-			goto stCase264
+			goto st_case_264
 		case 265:
-			goto stCase265
+			goto st_case_265
 		case 266:
-			goto stCase266
+			goto st_case_266
 		case 267:
-			goto stCase267
+			goto st_case_267
 		case 268:
-			goto stCase268
+			goto st_case_268
 		case 269:
-			goto stCase269
+			goto st_case_269
 		case 270:
-			goto stCase270
+			goto st_case_270
 		case 271:
-			goto stCase271
+			goto st_case_271
 		case 272:
-			goto stCase272
+			goto st_case_272
 		case 273:
-			goto stCase273
+			goto st_case_273
 		case 274:
-			goto stCase274
+			goto st_case_274
 		case 275:
-			goto stCase275
+			goto st_case_275
 		case 276:
-			goto stCase276
+			goto st_case_276
 		case 277:
-			goto stCase277
+			goto st_case_277
 		case 278:
-			goto stCase278
+			goto st_case_278
 		case 279:
-			goto stCase279
+			goto st_case_279
 		case 280:
-			goto stCase280
+			goto st_case_280
 		case 281:
-			goto stCase281
+			goto st_case_281
 		case 282:
-			goto stCase282
+			goto st_case_282
 		case 283:
-			goto stCase283
+			goto st_case_283
 		case 284:
-			goto stCase284
+			goto st_case_284
 		case 285:
-			goto stCase285
+			goto st_case_285
 		case 286:
-			goto stCase286
+			goto st_case_286
 		case 287:
-			goto stCase287
+			goto st_case_287
 		case 288:
-			goto stCase288
+			goto st_case_288
 		case 289:
-			goto stCase289
+			goto st_case_289
 		case 290:
-			goto stCase290
+			goto st_case_290
 		case 291:
-			goto stCase291
+			goto st_case_291
 		case 292:
-			goto stCase292
+			goto st_case_292
 		case 293:
-			goto stCase293
+			goto st_case_293
 		case 294:
-			goto stCase294
+			goto st_case_294
 		case 295:
-			goto stCase295
+			goto st_case_295
 		case 296:
-			goto stCase296
+			goto st_case_296
 		case 297:
-			goto stCase297
+			goto st_case_297
 		case 298:
-			goto stCase298
+			goto st_case_298
 		case 299:
-			goto stCase299
+			goto st_case_299
 		case 300:
-			goto stCase300
+			goto st_case_300
 		case 301:
-			goto stCase301
+			goto st_case_301
 		case 302:
-			goto stCase302
+			goto st_case_302
 		case 303:
-			goto stCase303
+			goto st_case_303
 		case 304:
-			goto stCase304
+			goto st_case_304
 		case 305:
-			goto stCase305
+			goto st_case_305
 		case 306:
-			goto stCase306
+			goto st_case_306
 		case 307:
-			goto stCase307
+			goto st_case_307
 		case 308:
-			goto stCase308
+			goto st_case_308
 		case 309:
-			goto stCase309
+			goto st_case_309
 		case 310:
-			goto stCase310
+			goto st_case_310
 		case 311:
-			goto stCase311
+			goto st_case_311
 		case 312:
-			goto stCase312
+			goto st_case_312
 		case 313:
-			goto stCase313
+			goto st_case_313
 		case 314:
-			goto stCase314
+			goto st_case_314
 		case 315:
-			goto stCase315
+			goto st_case_315
 		case 316:
-			goto stCase316
+			goto st_case_316
 		case 317:
-			goto stCase317
+			goto st_case_317
 		case 318:
-			goto stCase318
+			goto st_case_318
 		case 319:
-			goto stCase319
+			goto st_case_319
 		case 320:
-			goto stCase320
+			goto st_case_320
 		case 321:
-			goto stCase321
+			goto st_case_321
 		case 322:
-			goto stCase322
+			goto st_case_322
 		case 323:
-			goto stCase323
+			goto st_case_323
 		case 324:
-			goto stCase324
+			goto st_case_324
 		case 325:
-			goto stCase325
+			goto st_case_325
 		case 326:
-			goto stCase326
+			goto st_case_326
 		case 327:
-			goto stCase327
+			goto st_case_327
 		case 328:
-			goto stCase328
+			goto st_case_328
 		case 329:
-			goto stCase329
+			goto st_case_329
 		case 330:
-			goto stCase330
+			goto st_case_330
 		case 331:
-			goto stCase331
+			goto st_case_331
 		case 332:
-			goto stCase332
+			goto st_case_332
 		case 333:
-			goto stCase333
+			goto st_case_333
 		case 334:
-			goto stCase334
+			goto st_case_334
 		case 335:
-			goto stCase335
+			goto st_case_335
 		case 336:
-			goto stCase336
+			goto st_case_336
 		case 337:
-			goto stCase337
+			goto st_case_337
 		case 338:
-			goto stCase338
+			goto st_case_338
 		case 339:
-			goto stCase339
+			goto st_case_339
 		case 340:
-			goto stCase340
+			goto st_case_340
 		case 341:
-			goto stCase341
+			goto st_case_341
 		case 342:
-			goto stCase342
+			goto st_case_342
 		case 343:
-			goto stCase343
+			goto st_case_343
 		case 344:
-			goto stCase344
+			goto st_case_344
 		case 345:
-			goto stCase345
+			goto st_case_345
 		case 346:
-			goto stCase346
+			goto st_case_346
 		case 347:
-			goto stCase347
+			goto st_case_347
 		case 348:
-			goto stCase348
+			goto st_case_348
 		case 349:
-			goto stCase349
+			goto st_case_349
 		case 350:
-			goto stCase350
+			goto st_case_350
 		case 351:
-			goto stCase351
+			goto st_case_351
 		case 352:
-			goto stCase352
+			goto st_case_352
 		case 353:
-			goto stCase353
+			goto st_case_353
 		case 354:
-			goto stCase354
+			goto st_case_354
 		case 355:
-			goto stCase355
+			goto st_case_355
 		case 356:
-			goto stCase356
+			goto st_case_356
 		case 357:
-			goto stCase357
+			goto st_case_357
 		case 358:
-			goto stCase358
+			goto st_case_358
 		case 359:
-			goto stCase359
+			goto st_case_359
 		case 360:
-			goto stCase360
+			goto st_case_360
 		case 361:
-			goto stCase361
+			goto st_case_361
 		case 362:
-			goto stCase362
+			goto st_case_362
 		case 363:
-			goto stCase363
+			goto st_case_363
 		case 364:
-			goto stCase364
+			goto st_case_364
 		case 365:
-			goto stCase365
+			goto st_case_365
 		case 366:
-			goto stCase366
+			goto st_case_366
 		case 367:
-			goto stCase367
+			goto st_case_367
 		case 368:
-			goto stCase368
+			goto st_case_368
 		case 369:
-			goto stCase369
+			goto st_case_369
 		case 370:
-			goto stCase370
+			goto st_case_370
 		case 371:
-			goto stCase371
+			goto st_case_371
 		case 372:
-			goto stCase372
+			goto st_case_372
 		case 373:
-			goto stCase373
+			goto st_case_373
 		case 374:
-			goto stCase374
+			goto st_case_374
 		case 375:
-			goto stCase375
+			goto st_case_375
 		case 376:
-			goto stCase376
+			goto st_case_376
 		case 377:
-			goto stCase377
+			goto st_case_377
 		case 378:
-			goto stCase378
+			goto st_case_378
 		case 379:
-			goto stCase379
+			goto st_case_379
 		case 380:
-			goto stCase380
+			goto st_case_380
 		case 381:
-			goto stCase381
+			goto st_case_381
 		case 382:
-			goto stCase382
+			goto st_case_382
 		case 383:
-			goto stCase383
+			goto st_case_383
 		case 384:
-			goto stCase384
+			goto st_case_384
 		case 385:
-			goto stCase385
+			goto st_case_385
 		case 386:
-			goto stCase386
+			goto st_case_386
 		case 387:
-			goto stCase387
+			goto st_case_387
 		case 388:
-			goto stCase388
+			goto st_case_388
 		case 389:
-			goto stCase389
+			goto st_case_389
 		case 390:
-			goto stCase390
+			goto st_case_390
 		case 391:
-			goto stCase391
+			goto st_case_391
 		case 392:
-			goto stCase392
+			goto st_case_392
 		case 393:
-			goto stCase393
+			goto st_case_393
 		case 394:
-			goto stCase394
+			goto st_case_394
 		case 395:
-			goto stCase395
+			goto st_case_395
 		case 396:
-			goto stCase396
+			goto st_case_396
 		case 397:
-			goto stCase397
+			goto st_case_397
 		case 398:
-			goto stCase398
+			goto st_case_398
 		case 399:
-			goto stCase399
+			goto st_case_399
 		case 400:
-			goto stCase400
+			goto st_case_400
 		case 401:
-			goto stCase401
+			goto st_case_401
 		case 402:
-			goto stCase402
+			goto st_case_402
 		case 403:
-			goto stCase403
+			goto st_case_403
 		case 404:
-			goto stCase404
+			goto st_case_404
 		case 405:
-			goto stCase405
+			goto st_case_405
 		case 406:
-			goto stCase406
+			goto st_case_406
 		case 407:
-			goto stCase407
+			goto st_case_407
 		case 408:
-			goto stCase408
+			goto st_case_408
 		case 409:
-			goto stCase409
+			goto st_case_409
 		case 410:
-			goto stCase410
+			goto st_case_410
 		case 411:
-			goto stCase411
+			goto st_case_411
 		case 412:
-			goto stCase412
+			goto st_case_412
 		case 413:
-			goto stCase413
+			goto st_case_413
 		case 414:
-			goto stCase414
+			goto st_case_414
 		case 415:
-			goto stCase415
+			goto st_case_415
 		case 416:
-			goto stCase416
+			goto st_case_416
 		case 417:
-			goto stCase417
+			goto st_case_417
 		case 418:
-			goto stCase418
+			goto st_case_418
 		case 419:
-			goto stCase419
+			goto st_case_419
 		case 420:
-			goto stCase420
+			goto st_case_420
 		case 421:
-			goto stCase421
+			goto st_case_421
 		case 422:
-			goto stCase422
+			goto st_case_422
 		case 423:
-			goto stCase423
+			goto st_case_423
 		case 424:
-			goto stCase424
+			goto st_case_424
 		case 425:
-			goto stCase425
+			goto st_case_425
 		case 426:
-			goto stCase426
+			goto st_case_426
 		case 427:
-			goto stCase427
+			goto st_case_427
 		case 428:
-			goto stCase428
+			goto st_case_428
 		case 429:
-			goto stCase429
+			goto st_case_429
 		case 430:
-			goto stCase430
+			goto st_case_430
 		case 431:
-			goto stCase431
+			goto st_case_431
 		case 432:
-			goto stCase432
+			goto st_case_432
 		case 433:
-			goto stCase433
+			goto st_case_433
 		case 434:
-			goto stCase434
+			goto st_case_434
 		case 435:
-			goto stCase435
+			goto st_case_435
 		case 436:
-			goto stCase436
+			goto st_case_436
 		case 437:
-			goto stCase437
+			goto st_case_437
 		case 438:
-			goto stCase438
+			goto st_case_438
 		case 439:
-			goto stCase439
+			goto st_case_439
 		case 440:
-			goto stCase440
+			goto st_case_440
 		case 441:
-			goto stCase441
+			goto st_case_441
 		case 442:
-			goto stCase442
+			goto st_case_442
 		case 443:
-			goto stCase443
+			goto st_case_443
 		case 444:
-			goto stCase444
+			goto st_case_444
 		case 445:
-			goto stCase445
+			goto st_case_445
 		case 446:
-			goto stCase446
+			goto st_case_446
 		case 447:
-			goto stCase447
+			goto st_case_447
 		case 448:
-			goto stCase448
+			goto st_case_448
 		case 449:
-			goto stCase449
+			goto st_case_449
 		case 450:
-			goto stCase450
+			goto st_case_450
 		case 451:
-			goto stCase451
+			goto st_case_451
 		case 452:
-			goto stCase452
+			goto st_case_452
 		case 453:
-			goto stCase453
+			goto st_case_453
 		case 454:
-			goto stCase454
+			goto st_case_454
 		case 455:
-			goto stCase455
+			goto st_case_455
 		case 456:
-			goto stCase456
+			goto st_case_456
 		case 457:
-			goto stCase457
+			goto st_case_457
 		case 458:
-			goto stCase458
+			goto st_case_458
 		case 459:
-			goto stCase459
+			goto st_case_459
 		case 460:
-			goto stCase460
+			goto st_case_460
 		case 461:
-			goto stCase461
+			goto st_case_461
 		case 462:
-			goto stCase462
+			goto st_case_462
 		case 463:
-			goto stCase463
+			goto st_case_463
 		case 464:
-			goto stCase464
+			goto st_case_464
 		case 465:
-			goto stCase465
+			goto st_case_465
 		case 466:
-			goto stCase466
+			goto st_case_466
 		case 467:
-			goto stCase467
+			goto st_case_467
 		case 468:
-			goto stCase468
+			goto st_case_468
 		case 469:
-			goto stCase469
+			goto st_case_469
 		case 470:
-			goto stCase470
+			goto st_case_470
 		case 471:
-			goto stCase471
+			goto st_case_471
 		case 472:
-			goto stCase472
+			goto st_case_472
 		case 473:
-			goto stCase473
+			goto st_case_473
 		case 474:
-			goto stCase474
+			goto st_case_474
 		case 475:
-			goto stCase475
+			goto st_case_475
 		case 476:
-			goto stCase476
+			goto st_case_476
 		case 477:
-			goto stCase477
+			goto st_case_477
 		case 478:
-			goto stCase478
+			goto st_case_478
 		case 479:
-			goto stCase479
+			goto st_case_479
 		case 480:
-			goto stCase480
+			goto st_case_480
 		case 481:
-			goto stCase481
+			goto st_case_481
 		case 482:
-			goto stCase482
+			goto st_case_482
 		case 483:
-			goto stCase483
+			goto st_case_483
 		case 484:
-			goto stCase484
+			goto st_case_484
 		case 485:
-			goto stCase485
+			goto st_case_485
 		case 486:
-			goto stCase486
+			goto st_case_486
 		case 487:
-			goto stCase487
+			goto st_case_487
 		case 488:
-			goto stCase488
+			goto st_case_488
 		case 489:
-			goto stCase489
+			goto st_case_489
 		case 490:
-			goto stCase490
+			goto st_case_490
 		case 491:
-			goto stCase491
+			goto st_case_491
 		case 492:
-			goto stCase492
+			goto st_case_492
 		case 493:
-			goto stCase493
+			goto st_case_493
 		case 494:
-			goto stCase494
+			goto st_case_494
 		case 495:
-			goto stCase495
+			goto st_case_495
 		case 496:
-			goto stCase496
+			goto st_case_496
 		case 497:
-			goto stCase497
+			goto st_case_497
 		case 498:
-			goto stCase498
+			goto st_case_498
 		case 499:
-			goto stCase499
+			goto st_case_499
 		case 500:
-			goto stCase500
+			goto st_case_500
 		case 501:
-			goto stCase501
+			goto st_case_501
 		case 502:
-			goto stCase502
+			goto st_case_502
 		case 503:
-			goto stCase503
+			goto st_case_503
 		case 504:
-			goto stCase504
+			goto st_case_504
 		case 505:
-			goto stCase505
+			goto st_case_505
 		case 506:
-			goto stCase506
+			goto st_case_506
 		case 507:
-			goto stCase507
+			goto st_case_507
 		case 508:
-			goto stCase508
+			goto st_case_508
 		case 509:
-			goto stCase509
+			goto st_case_509
 		case 510:
-			goto stCase510
+			goto st_case_510
 		case 511:
-			goto stCase511
+			goto st_case_511
 		case 512:
-			goto stCase512
+			goto st_case_512
 		case 513:
-			goto stCase513
+			goto st_case_513
 		case 514:
-			goto stCase514
+			goto st_case_514
 		case 515:
-			goto stCase515
+			goto st_case_515
 		case 516:
-			goto stCase516
+			goto st_case_516
 		case 517:
-			goto stCase517
+			goto st_case_517
 		case 518:
-			goto stCase518
+			goto st_case_518
 		case 519:
-			goto stCase519
+			goto st_case_519
 		case 520:
-			goto stCase520
+			goto st_case_520
 		case 521:
-			goto stCase521
+			goto st_case_521
 		case 522:
-			goto stCase522
+			goto st_case_522
 		case 523:
-			goto stCase523
+			goto st_case_523
 		case 524:
-			goto stCase524
+			goto st_case_524
 		case 525:
-			goto stCase525
+			goto st_case_525
 		case 526:
-			goto stCase526
+			goto st_case_526
 		case 527:
-			goto stCase527
+			goto st_case_527
 		case 528:
-			goto stCase528
+			goto st_case_528
 		case 529:
-			goto stCase529
+			goto st_case_529
 		case 530:
-			goto stCase530
+			goto st_case_530
 		case 531:
-			goto stCase531
+			goto st_case_531
 		case 532:
-			goto stCase532
+			goto st_case_532
 		case 533:
-			goto stCase533
+			goto st_case_533
 		case 534:
-			goto stCase534
+			goto st_case_534
 		case 535:
-			goto stCase535
+			goto st_case_535
 		case 536:
-			goto stCase536
+			goto st_case_536
 		case 537:
-			goto stCase537
+			goto st_case_537
 		case 538:
-			goto stCase538
+			goto st_case_538
 		case 539:
-			goto stCase539
+			goto st_case_539
 		case 540:
-			goto stCase540
+			goto st_case_540
 		case 541:
-			goto stCase541
+			goto st_case_541
 		case 542:
-			goto stCase542
+			goto st_case_542
 		case 543:
-			goto stCase543
+			goto st_case_543
 		case 544:
-			goto stCase544
+			goto st_case_544
 		case 545:
-			goto stCase545
+			goto st_case_545
 		case 546:
-			goto stCase546
+			goto st_case_546
 		case 547:
-			goto stCase547
+			goto st_case_547
 		case 548:
-			goto stCase548
+			goto st_case_548
 		case 549:
-			goto stCase549
+			goto st_case_549
 		case 550:
-			goto stCase550
+			goto st_case_550
 		case 551:
-			goto stCase551
+			goto st_case_551
 		case 552:
-			goto stCase552
+			goto st_case_552
 		case 553:
-			goto stCase553
+			goto st_case_553
 		case 554:
-			goto stCase554
+			goto st_case_554
 		case 555:
-			goto stCase555
+			goto st_case_555
 		case 556:
-			goto stCase556
+			goto st_case_556
 		case 557:
-			goto stCase557
+			goto st_case_557
 		case 558:
-			goto stCase558
+			goto st_case_558
 		case 559:
-			goto stCase559
+			goto st_case_559
 		case 560:
-			goto stCase560
+			goto st_case_560
 		case 561:
-			goto stCase561
+			goto st_case_561
 		case 562:
-			goto stCase562
+			goto st_case_562
 		case 563:
-			goto stCase563
+			goto st_case_563
 		case 564:
-			goto stCase564
+			goto st_case_564
 		case 565:
-			goto stCase565
+			goto st_case_565
 		case 566:
-			goto stCase566
+			goto st_case_566
 		case 567:
-			goto stCase567
+			goto st_case_567
 		case 568:
-			goto stCase568
+			goto st_case_568
 		case 569:
-			goto stCase569
+			goto st_case_569
 		case 570:
-			goto stCase570
+			goto st_case_570
 		case 571:
-			goto stCase571
+			goto st_case_571
 		case 572:
-			goto stCase572
+			goto st_case_572
 		case 573:
-			goto stCase573
+			goto st_case_573
 		case 574:
-			goto stCase574
+			goto st_case_574
 		case 575:
-			goto stCase575
+			goto st_case_575
 		case 576:
-			goto stCase576
+			goto st_case_576
 		case 577:
-			goto stCase577
+			goto st_case_577
 		case 578:
-			goto stCase578
+			goto st_case_578
 		case 579:
-			goto stCase579
+			goto st_case_579
 		case 580:
-			goto stCase580
+			goto st_case_580
 		case 581:
-			goto stCase581
+			goto st_case_581
 		case 582:
-			goto stCase582
+			goto st_case_582
 		case 583:
-			goto stCase583
+			goto st_case_583
 		case 584:
-			goto stCase584
+			goto st_case_584
 		case 585:
-			goto stCase585
+			goto st_case_585
 		case 586:
-			goto stCase586
+			goto st_case_586
 		case 587:
-			goto stCase587
+			goto st_case_587
 		case 588:
-			goto stCase588
+			goto st_case_588
 		case 589:
-			goto stCase589
+			goto st_case_589
 		case 590:
-			goto stCase590
+			goto st_case_590
 		case 591:
-			goto stCase591
+			goto st_case_591
 		case 592:
-			goto stCase592
+			goto st_case_592
 		case 593:
-			goto stCase593
+			goto st_case_593
 		case 594:
-			goto stCase594
+			goto st_case_594
 		case 595:
-			goto stCase595
+			goto st_case_595
 		case 596:
-			goto stCase596
+			goto st_case_596
 		case 597:
-			goto stCase597
+			goto st_case_597
 		case 598:
-			goto stCase598
+			goto st_case_598
 		case 599:
-			goto stCase599
+			goto st_case_599
 		case 600:
-			goto stCase600
+			goto st_case_600
 		case 601:
-			goto stCase601
+			goto st_case_601
 		case 602:
-			goto stCase602
+			goto st_case_602
 		case 607:
-			goto stCase607
+			goto st_case_607
 		}
-		goto stOut
-	stCase1:
+		goto st_out
+	st_case_1:
 		if (m.data)[(m.p)] == 60 {
 			goto st2
 		}
 		goto tr0
 	tr0:
+//line rfc5424/machine.go.rl:157
 
 		m.err = fmt.Errorf(ErrPri+ColumnPositionTemplate, m.p)
 		(m.p)--
@@ -1358,6 +1379,7 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 
 		goto st0
 	tr2:
+//line rfc5424/machine.go.rl:151
 
 		m.err = fmt.Errorf(ErrPrival+ColumnPositionTemplate, m.p)
 		(m.p)--
@@ -1366,12 +1388,16 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 			goto st607
 		}
 
+//line rfc5424/machine.go.rl:157
+
 		m.err = fmt.Errorf(ErrPri+ColumnPositionTemplate, m.p)
 		(m.p)--
 
 		{
 			goto st607
 		}
+
+//line rfc5424/machine.go.rl:242
 
 		m.err = fmt.Errorf(ErrParse+ColumnPositionTemplate, m.p)
 		(m.p)--
@@ -1382,6 +1408,7 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 
 		goto st0
 	tr7:
+//line rfc5424/machine.go.rl:163
 
 		m.err = fmt.Errorf(ErrVersion+ColumnPositionTemplate, m.p)
 		(m.p)--
@@ -1389,6 +1416,8 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		{
 			goto st607
 		}
+
+//line rfc5424/machine.go.rl:242
 
 		m.err = fmt.Errorf(ErrParse+ColumnPositionTemplate, m.p)
 		(m.p)--
@@ -1399,6 +1428,7 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 
 		goto st0
 	tr9:
+//line rfc5424/machine.go.rl:242
 
 		m.err = fmt.Errorf(ErrParse+ColumnPositionTemplate, m.p)
 		(m.p)--
@@ -1409,6 +1439,7 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 
 		goto st0
 	tr12:
+//line rfc5424/machine.go.rl:169
 
 		m.err = fmt.Errorf(ErrTimestamp+ColumnPositionTemplate, m.p)
 		(m.p)--
@@ -1416,6 +1447,8 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		{
 			goto st607
 		}
+
+//line rfc5424/machine.go.rl:242
 
 		m.err = fmt.Errorf(ErrParse+ColumnPositionTemplate, m.p)
 		(m.p)--
@@ -1426,6 +1459,7 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 
 		goto st0
 	tr16:
+//line rfc5424/machine.go.rl:175
 
 		m.err = fmt.Errorf(ErrHostname+ColumnPositionTemplate, m.p)
 		(m.p)--
@@ -1433,6 +1467,8 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		{
 			goto st607
 		}
+
+//line rfc5424/machine.go.rl:242
 
 		m.err = fmt.Errorf(ErrParse+ColumnPositionTemplate, m.p)
 		(m.p)--
@@ -1443,6 +1479,7 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 
 		goto st0
 	tr20:
+//line rfc5424/machine.go.rl:181
 
 		m.err = fmt.Errorf(ErrAppname+ColumnPositionTemplate, m.p)
 		(m.p)--
@@ -1450,6 +1487,8 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		{
 			goto st607
 		}
+
+//line rfc5424/machine.go.rl:242
 
 		m.err = fmt.Errorf(ErrParse+ColumnPositionTemplate, m.p)
 		(m.p)--
@@ -1460,6 +1499,7 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 
 		goto st0
 	tr24:
+//line rfc5424/machine.go.rl:187
 
 		m.err = fmt.Errorf(ErrProcID+ColumnPositionTemplate, m.p)
 		(m.p)--
@@ -1467,6 +1507,8 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		{
 			goto st607
 		}
+
+//line rfc5424/machine.go.rl:242
 
 		m.err = fmt.Errorf(ErrParse+ColumnPositionTemplate, m.p)
 		(m.p)--
@@ -1477,6 +1519,7 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 
 		goto st0
 	tr28:
+//line rfc5424/machine.go.rl:193
 
 		m.err = fmt.Errorf(ErrMsgID+ColumnPositionTemplate, m.p)
 		(m.p)--
@@ -1484,6 +1527,8 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		{
 			goto st607
 		}
+
+//line rfc5424/machine.go.rl:242
 
 		m.err = fmt.Errorf(ErrParse+ColumnPositionTemplate, m.p)
 		(m.p)--
@@ -1494,6 +1539,7 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 
 		goto st0
 	tr30:
+//line rfc5424/machine.go.rl:193
 
 		m.err = fmt.Errorf(ErrMsgID+ColumnPositionTemplate, m.p)
 		(m.p)--
@@ -1504,6 +1550,7 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 
 		goto st0
 	tr33:
+//line rfc5424/machine.go.rl:199
 
 		m.err = fmt.Errorf(ErrStructuredData+ColumnPositionTemplate, m.p)
 		(m.p)--
@@ -1514,6 +1561,7 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 
 		goto st0
 	tr36:
+//line rfc5424/machine.go.rl:224
 
 		// If error encountered within the message rule ...
 		if m.msgat > 0 {
@@ -1528,6 +1576,8 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 			goto st607
 		}
 
+//line rfc5424/machine.go.rl:242
+
 		m.err = fmt.Errorf(ErrParse+ColumnPositionTemplate, m.p)
 		(m.p)--
 
@@ -1537,6 +1587,7 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 
 		goto st0
 	tr40:
+//line rfc5424/machine.go.rl:205
 
 		delete(output.structuredData, m.currentelem)
 		if len(output.structuredData) == 0 {
@@ -1549,6 +1600,8 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 			goto st607
 		}
 
+//line rfc5424/machine.go.rl:199
+
 		m.err = fmt.Errorf(ErrStructuredData+ColumnPositionTemplate, m.p)
 		(m.p)--
 
@@ -1558,6 +1611,7 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 
 		goto st0
 	tr42:
+//line rfc5424/machine.go.rl:106
 
 		if _, ok := output.structuredData[string(m.text())]; ok {
 			// As per RFC5424 section 6.3.2 SD-ID MUST NOT exist more than once in a message
@@ -1574,6 +1628,8 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 			m.currentelem = id
 		}
 
+//line rfc5424/machine.go.rl:205
+
 		delete(output.structuredData, m.currentelem)
 		if len(output.structuredData) == 0 {
 			output.hasElements = false
@@ -1585,6 +1641,8 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 			goto st607
 		}
 
+//line rfc5424/machine.go.rl:199
+
 		m.err = fmt.Errorf(ErrStructuredData+ColumnPositionTemplate, m.p)
 		(m.p)--
 
@@ -1594,6 +1652,7 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 
 		goto st0
 	tr46:
+//line rfc5424/machine.go.rl:215
 
 		if len(output.structuredData) > 0 {
 			delete(output.structuredData[m.currentelem], m.currentparam)
@@ -1604,6 +1663,8 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		{
 			goto st607
 		}
+
+//line rfc5424/machine.go.rl:199
 
 		m.err = fmt.Errorf(ErrStructuredData+ColumnPositionTemplate, m.p)
 		(m.p)--
@@ -1614,6 +1675,7 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 
 		goto st0
 	tr84:
+//line rfc5424/machine.go.rl:236
 
 		m.err = fmt.Errorf(ErrEscape+ColumnPositionTemplate, m.p)
 		(m.p)--
@@ -1621,6 +1683,8 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		{
 			goto st607
 		}
+
+//line rfc5424/machine.go.rl:215
 
 		if len(output.structuredData) > 0 {
 			delete(output.structuredData[m.currentelem], m.currentparam)
@@ -1632,6 +1696,8 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 			goto st607
 		}
 
+//line rfc5424/machine.go.rl:199
+
 		m.err = fmt.Errorf(ErrStructuredData+ColumnPositionTemplate, m.p)
 		(m.p)--
 
@@ -1641,6 +1707,7 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 
 		goto st0
 	tr619:
+//line rfc5424/machine.go.rl:75
 
 		if t, e := time.Parse(RFC3339MICRO, string(m.text())); e != nil {
 			m.err = fmt.Errorf("%s [col %d]", e, m.p)
@@ -1654,6 +1721,8 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 			output.timestampSet = true
 		}
 
+//line rfc5424/machine.go.rl:242
+
 		m.err = fmt.Errorf(ErrParse+ColumnPositionTemplate, m.p)
 		(m.p)--
 
@@ -1663,6 +1732,7 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 
 		goto st0
 	tr645:
+//line rfc5424/machine.go.rl:199
 
 		m.err = fmt.Errorf(ErrStructuredData+ColumnPositionTemplate, m.p)
 		(m.p)--
@@ -1670,6 +1740,8 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		{
 			goto st607
 		}
+
+//line rfc5424/machine.go.rl:242
 
 		m.err = fmt.Errorf(ErrParse+ColumnPositionTemplate, m.p)
 		(m.p)--
@@ -1679,15 +1751,16 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		}
 
 		goto st0
-	stCase0:
+//line rfc5424/machine.go:1692
+	st_case_0:
 	st0:
 		m.cs = 0
 		goto _out
 	st2:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof2
+			goto _test_eof2
 		}
-	stCase2:
+	st_case_2:
 		switch (m.data)[(m.p)] {
 		case 48:
 			goto tr3
@@ -1699,45 +1772,51 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		}
 		goto tr2
 	tr3:
+//line rfc5424/machine.go.rl:58
 
 		m.pb = m.p
 
 		goto st3
 	st3:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof3
+			goto _test_eof3
 		}
-	stCase3:
+	st_case_3:
+//line rfc5424/machine.go.rl:66
 
 		output.priority = uint8(common.UnsafeUTF8DecimalCodePointsToInt(m.text()))
 		output.prioritySet = true
 
+//line rfc5424/machine.go:1728
 		if (m.data)[(m.p)] == 62 {
 			goto st4
 		}
 		goto tr2
 	st4:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof4
+			goto _test_eof4
 		}
-	stCase4:
+	st_case_4:
 		if 49 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 57 {
 			goto tr8
 		}
 		goto tr7
 	tr8:
+//line rfc5424/machine.go.rl:58
 
 		m.pb = m.p
 
 		goto st5
 	st5:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof5
+			goto _test_eof5
 		}
-	stCase5:
+	st_case_5:
+//line rfc5424/machine.go.rl:71
 
 		output.version = uint16(common.UnsafeUTF8DecimalCodePointsToInt(m.text()))
 
+//line rfc5424/machine.go:1757
 		if (m.data)[(m.p)] == 32 {
 			goto st6
 		}
@@ -1747,9 +1826,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr9
 	st6:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof6
+			goto _test_eof6
 		}
-	stCase6:
+	st_case_6:
 		if (m.data)[(m.p)] == 45 {
 			goto st7
 		}
@@ -1759,14 +1838,15 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr12
 	st7:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof7
+			goto _test_eof7
 		}
-	stCase7:
+	st_case_7:
 		if (m.data)[(m.p)] == 32 {
 			goto st8
 		}
 		goto tr9
 	tr620:
+//line rfc5424/machine.go.rl:75
 
 		if t, e := time.Parse(RFC3339MICRO, string(m.text())); e != nil {
 			m.err = fmt.Errorf("%s [col %d]", e, m.p)
@@ -1783,23 +1863,26 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto st8
 	st8:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof8
+			goto _test_eof8
 		}
-	stCase8:
+	st_case_8:
+//line rfc5424/machine.go:1805
 		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto tr17
 		}
 		goto tr16
 	tr17:
+//line rfc5424/machine.go.rl:58
 
 		m.pb = m.p
 
 		goto st9
 	st9:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof9
+			goto _test_eof9
 		}
-	stCase9:
+	st_case_9:
+//line rfc5424/machine.go:1821
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -1808,29 +1891,33 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		}
 		goto tr16
 	tr18:
+//line rfc5424/machine.go.rl:86
 
 		output.hostname = string(m.text())
 
 		goto st10
 	st10:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof10
+			goto _test_eof10
 		}
-	stCase10:
+	st_case_10:
+//line rfc5424/machine.go:1840
 		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto tr21
 		}
 		goto tr20
 	tr21:
+//line rfc5424/machine.go.rl:58
 
 		m.pb = m.p
 
 		goto st11
 	st11:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof11
+			goto _test_eof11
 		}
-	stCase11:
+	st_case_11:
+//line rfc5424/machine.go:1856
 		if (m.data)[(m.p)] == 32 {
 			goto tr22
 		}
@@ -1839,29 +1926,33 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		}
 		goto tr20
 	tr22:
+//line rfc5424/machine.go.rl:90
 
 		output.appname = string(m.text())
 
 		goto st12
 	st12:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof12
+			goto _test_eof12
 		}
-	stCase12:
+	st_case_12:
+//line rfc5424/machine.go:1875
 		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto tr25
 		}
 		goto tr24
 	tr25:
+//line rfc5424/machine.go.rl:58
 
 		m.pb = m.p
 
 		goto st13
 	st13:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof13
+			goto _test_eof13
 		}
-	stCase13:
+	st_case_13:
+//line rfc5424/machine.go:1891
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -1870,29 +1961,33 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		}
 		goto tr24
 	tr26:
+//line rfc5424/machine.go.rl:94
 
 		output.procID = string(m.text())
 
 		goto st14
 	st14:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof14
+			goto _test_eof14
 		}
-	stCase14:
+	st_case_14:
+//line rfc5424/machine.go:1910
 		if 33 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
 			goto tr29
 		}
 		goto tr28
 	tr29:
+//line rfc5424/machine.go.rl:58
 
 		m.pb = m.p
 
 		goto st15
 	st15:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof15
+			goto _test_eof15
 		}
-	stCase15:
+	st_case_15:
+//line rfc5424/machine.go:1926
 		if (m.data)[(m.p)] == 32 {
 			goto tr31
 		}
@@ -1901,15 +1996,17 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		}
 		goto tr30
 	tr31:
+//line rfc5424/machine.go.rl:98
 
 		output.msgID = string(m.text())
 
 		goto st16
 	st16:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof16
+			goto _test_eof16
 		}
-	stCase16:
+	st_case_16:
+//line rfc5424/machine.go:1945
 		switch (m.data)[(m.p)] {
 		case 45:
 			goto st603
@@ -1919,18 +2016,18 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr33
 	st603:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof603
+			goto _test_eof603
 		}
-	stCase603:
+	st_case_603:
 		if (m.data)[(m.p)] == 32 {
 			goto st604
 		}
 		goto tr9
 	st604:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof604
+			goto _test_eof604
 		}
-	stCase604:
+	st_case_604:
 		switch (m.data)[(m.p)] {
 		case 224:
 			goto tr634
@@ -1965,17 +2062,21 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		}
 		goto tr632
 	tr632:
+//line rfc5424/machine.go.rl:58
 
 		m.pb = m.p
+
+//line rfc5424/machine.go.rl:62
 
 		m.msgat = m.p
 
 		goto st605
 	st605:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof605
+			goto _test_eof605
 		}
-	stCase605:
+	st_case_605:
+//line rfc5424/machine.go:2015
 		switch (m.data)[(m.p)] {
 		case 224:
 			goto st18
@@ -2010,127 +2111,157 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		}
 		goto st605
 	tr633:
+//line rfc5424/machine.go.rl:58
 
 		m.pb = m.p
+
+//line rfc5424/machine.go.rl:62
 
 		m.msgat = m.p
 
 		goto st17
 	st17:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof17
+			goto _test_eof17
 		}
-	stCase17:
+	st_case_17:
+//line rfc5424/machine.go:2064
 		if 128 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 191 {
 			goto st605
 		}
 		goto tr36
 	tr634:
+//line rfc5424/machine.go.rl:58
 
 		m.pb = m.p
+
+//line rfc5424/machine.go.rl:62
 
 		m.msgat = m.p
 
 		goto st18
 	st18:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof18
+			goto _test_eof18
 		}
-	stCase18:
+	st_case_18:
+//line rfc5424/machine.go:2084
 		if 160 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 191 {
 			goto st17
 		}
 		goto tr36
 	tr635:
+//line rfc5424/machine.go.rl:58
 
 		m.pb = m.p
+
+//line rfc5424/machine.go.rl:62
 
 		m.msgat = m.p
 
 		goto st19
 	st19:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof19
+			goto _test_eof19
 		}
-	stCase19:
+	st_case_19:
+//line rfc5424/machine.go:2104
 		if 128 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 191 {
 			goto st17
 		}
 		goto tr36
 	tr636:
+//line rfc5424/machine.go.rl:58
 
 		m.pb = m.p
+
+//line rfc5424/machine.go.rl:62
 
 		m.msgat = m.p
 
 		goto st20
 	st20:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof20
+			goto _test_eof20
 		}
-	stCase20:
+	st_case_20:
+//line rfc5424/machine.go:2124
 		if 128 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 159 {
 			goto st17
 		}
 		goto tr36
 	tr637:
+//line rfc5424/machine.go.rl:58
 
 		m.pb = m.p
+
+//line rfc5424/machine.go.rl:62
 
 		m.msgat = m.p
 
 		goto st21
 	st21:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof21
+			goto _test_eof21
 		}
-	stCase21:
+	st_case_21:
+//line rfc5424/machine.go:2144
 		if 144 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 191 {
 			goto st19
 		}
 		goto tr36
 	tr638:
+//line rfc5424/machine.go.rl:58
 
 		m.pb = m.p
+
+//line rfc5424/machine.go.rl:62
 
 		m.msgat = m.p
 
 		goto st22
 	st22:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof22
+			goto _test_eof22
 		}
-	stCase22:
+	st_case_22:
+//line rfc5424/machine.go:2164
 		if 128 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 191 {
 			goto st19
 		}
 		goto tr36
 	tr639:
+//line rfc5424/machine.go.rl:58
 
 		m.pb = m.p
+
+//line rfc5424/machine.go.rl:62
 
 		m.msgat = m.p
 
 		goto st23
 	st23:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof23
+			goto _test_eof23
 		}
-	stCase23:
+	st_case_23:
+//line rfc5424/machine.go:2184
 		if 128 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 143 {
 			goto st19
 		}
 		goto tr36
 	tr35:
+//line rfc5424/machine.go.rl:102
 
 		output.structuredData = map[string]map[string]string{}
 
 		goto st24
 	st24:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof24
+			goto _test_eof24
 		}
-	stCase24:
+	st_case_24:
+//line rfc5424/machine.go:2200
 		if (m.data)[(m.p)] == 33 {
 			goto tr41
 		}
@@ -2148,15 +2279,17 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		}
 		goto tr40
 	tr41:
+//line rfc5424/machine.go.rl:58
 
 		m.pb = m.p
 
 		goto st25
 	st25:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof25
+			goto _test_eof25
 		}
-	stCase25:
+	st_case_25:
+//line rfc5424/machine.go:2228
 		switch (m.data)[(m.p)] {
 		case 32:
 			goto tr43
@@ -2175,6 +2308,7 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		}
 		goto tr42
 	tr43:
+//line rfc5424/machine.go.rl:106
 
 		if _, ok := output.structuredData[string(m.text())]; ok {
 			// As per RFC5424 section 6.3.2 SD-ID MUST NOT exist more than once in a message
@@ -2194,9 +2328,10 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto st26
 	st26:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof26
+			goto _test_eof26
 		}
-	stCase26:
+	st_case_26:
+//line rfc5424/machine.go:2268
 		if (m.data)[(m.p)] == 33 {
 			goto tr47
 		}
@@ -2214,17 +2349,21 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		}
 		goto tr46
 	tr47:
+//line rfc5424/machine.go.rl:120
 
 		m.backslashat = []int{}
+
+//line rfc5424/machine.go.rl:58
 
 		m.pb = m.p
 
 		goto st27
 	st27:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof27
+			goto _test_eof27
 		}
-	stCase27:
+	st_case_27:
+//line rfc5424/machine.go:2300
 		switch (m.data)[(m.p)] {
 		case 33:
 			goto st28
@@ -2242,9 +2381,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr46
 	st28:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof28
+			goto _test_eof28
 		}
-	stCase28:
+	st_case_28:
 		switch (m.data)[(m.p)] {
 		case 33:
 			goto st29
@@ -2262,9 +2401,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr46
 	st29:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof29
+			goto _test_eof29
 		}
-	stCase29:
+	st_case_29:
 		switch (m.data)[(m.p)] {
 		case 33:
 			goto st30
@@ -2282,9 +2421,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr46
 	st30:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof30
+			goto _test_eof30
 		}
-	stCase30:
+	st_case_30:
 		switch (m.data)[(m.p)] {
 		case 33:
 			goto st31
@@ -2302,9 +2441,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr46
 	st31:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof31
+			goto _test_eof31
 		}
-	stCase31:
+	st_case_31:
 		switch (m.data)[(m.p)] {
 		case 33:
 			goto st32
@@ -2322,9 +2461,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr46
 	st32:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof32
+			goto _test_eof32
 		}
-	stCase32:
+	st_case_32:
 		switch (m.data)[(m.p)] {
 		case 33:
 			goto st33
@@ -2342,9 +2481,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr46
 	st33:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof33
+			goto _test_eof33
 		}
-	stCase33:
+	st_case_33:
 		switch (m.data)[(m.p)] {
 		case 33:
 			goto st34
@@ -2362,9 +2501,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr46
 	st34:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof34
+			goto _test_eof34
 		}
-	stCase34:
+	st_case_34:
 		switch (m.data)[(m.p)] {
 		case 33:
 			goto st35
@@ -2382,9 +2521,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr46
 	st35:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof35
+			goto _test_eof35
 		}
-	stCase35:
+	st_case_35:
 		switch (m.data)[(m.p)] {
 		case 33:
 			goto st36
@@ -2402,9 +2541,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr46
 	st36:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof36
+			goto _test_eof36
 		}
-	stCase36:
+	st_case_36:
 		switch (m.data)[(m.p)] {
 		case 33:
 			goto st37
@@ -2422,9 +2561,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr46
 	st37:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof37
+			goto _test_eof37
 		}
-	stCase37:
+	st_case_37:
 		switch (m.data)[(m.p)] {
 		case 33:
 			goto st38
@@ -2442,9 +2581,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr46
 	st38:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof38
+			goto _test_eof38
 		}
-	stCase38:
+	st_case_38:
 		switch (m.data)[(m.p)] {
 		case 33:
 			goto st39
@@ -2462,9 +2601,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr46
 	st39:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof39
+			goto _test_eof39
 		}
-	stCase39:
+	st_case_39:
 		switch (m.data)[(m.p)] {
 		case 33:
 			goto st40
@@ -2482,9 +2621,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr46
 	st40:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof40
+			goto _test_eof40
 		}
-	stCase40:
+	st_case_40:
 		switch (m.data)[(m.p)] {
 		case 33:
 			goto st41
@@ -2502,9 +2641,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr46
 	st41:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof41
+			goto _test_eof41
 		}
-	stCase41:
+	st_case_41:
 		switch (m.data)[(m.p)] {
 		case 33:
 			goto st42
@@ -2522,9 +2661,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr46
 	st42:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof42
+			goto _test_eof42
 		}
-	stCase42:
+	st_case_42:
 		switch (m.data)[(m.p)] {
 		case 33:
 			goto st43
@@ -2542,9 +2681,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr46
 	st43:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof43
+			goto _test_eof43
 		}
-	stCase43:
+	st_case_43:
 		switch (m.data)[(m.p)] {
 		case 33:
 			goto st44
@@ -2562,9 +2701,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr46
 	st44:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof44
+			goto _test_eof44
 		}
-	stCase44:
+	st_case_44:
 		switch (m.data)[(m.p)] {
 		case 33:
 			goto st45
@@ -2582,9 +2721,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr46
 	st45:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof45
+			goto _test_eof45
 		}
-	stCase45:
+	st_case_45:
 		switch (m.data)[(m.p)] {
 		case 33:
 			goto st46
@@ -2602,9 +2741,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr46
 	st46:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof46
+			goto _test_eof46
 		}
-	stCase46:
+	st_case_46:
 		switch (m.data)[(m.p)] {
 		case 33:
 			goto st47
@@ -2622,9 +2761,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr46
 	st47:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof47
+			goto _test_eof47
 		}
-	stCase47:
+	st_case_47:
 		switch (m.data)[(m.p)] {
 		case 33:
 			goto st48
@@ -2642,9 +2781,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr46
 	st48:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof48
+			goto _test_eof48
 		}
-	stCase48:
+	st_case_48:
 		switch (m.data)[(m.p)] {
 		case 33:
 			goto st49
@@ -2662,9 +2801,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr46
 	st49:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof49
+			goto _test_eof49
 		}
-	stCase49:
+	st_case_49:
 		switch (m.data)[(m.p)] {
 		case 33:
 			goto st50
@@ -2682,9 +2821,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr46
 	st50:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof50
+			goto _test_eof50
 		}
-	stCase50:
+	st_case_50:
 		switch (m.data)[(m.p)] {
 		case 33:
 			goto st51
@@ -2702,9 +2841,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr46
 	st51:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof51
+			goto _test_eof51
 		}
-	stCase51:
+	st_case_51:
 		switch (m.data)[(m.p)] {
 		case 33:
 			goto st52
@@ -2722,9 +2861,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr46
 	st52:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof52
+			goto _test_eof52
 		}
-	stCase52:
+	st_case_52:
 		switch (m.data)[(m.p)] {
 		case 33:
 			goto st53
@@ -2742,9 +2881,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr46
 	st53:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof53
+			goto _test_eof53
 		}
-	stCase53:
+	st_case_53:
 		switch (m.data)[(m.p)] {
 		case 33:
 			goto st54
@@ -2762,9 +2901,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr46
 	st54:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof54
+			goto _test_eof54
 		}
-	stCase54:
+	st_case_54:
 		switch (m.data)[(m.p)] {
 		case 33:
 			goto st55
@@ -2782,9 +2921,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr46
 	st55:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof55
+			goto _test_eof55
 		}
-	stCase55:
+	st_case_55:
 		switch (m.data)[(m.p)] {
 		case 33:
 			goto st56
@@ -2802,9 +2941,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr46
 	st56:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof56
+			goto _test_eof56
 		}
-	stCase56:
+	st_case_56:
 		switch (m.data)[(m.p)] {
 		case 33:
 			goto st57
@@ -2822,9 +2961,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr46
 	st57:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof57
+			goto _test_eof57
 		}
-	stCase57:
+	st_case_57:
 		switch (m.data)[(m.p)] {
 		case 33:
 			goto st58
@@ -2842,32 +2981,34 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr46
 	st58:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof58
+			goto _test_eof58
 		}
-	stCase58:
+	st_case_58:
 		if (m.data)[(m.p)] == 61 {
 			goto tr49
 		}
 		goto tr46
 	tr49:
+//line rfc5424/machine.go.rl:128
 
 		m.currentparam = string(m.text())
 
 		goto st59
 	st59:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof59
+			goto _test_eof59
 		}
-	stCase59:
+	st_case_59:
+//line rfc5424/machine.go:2936
 		if (m.data)[(m.p)] == 34 {
 			goto st60
 		}
 		goto tr46
 	st60:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof60
+			goto _test_eof60
 		}
-	stCase60:
+	st_case_60:
 		switch (m.data)[(m.p)] {
 		case 34:
 			goto tr82
@@ -2908,15 +3049,17 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		}
 		goto tr81
 	tr81:
+//line rfc5424/machine.go.rl:58
 
 		m.pb = m.p
 
 		goto st61
 	st61:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof61
+			goto _test_eof61
 		}
-	stCase61:
+	st_case_61:
+//line rfc5424/machine.go:2996
 		switch (m.data)[(m.p)] {
 		case 34:
 			goto tr93
@@ -2957,8 +3100,11 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		}
 		goto st61
 	tr82:
+//line rfc5424/machine.go.rl:58
 
 		m.pb = m.p
+
+//line rfc5424/machine.go.rl:132
 
 		if output.hasElements {
 			// (fixme) > what if SD-PARAM-NAME already exist for the current element (ie., current SD-ID)?
@@ -2975,6 +3121,7 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 
 		goto st62
 	tr93:
+//line rfc5424/machine.go.rl:132
 
 		if output.hasElements {
 			// (fixme) > what if SD-PARAM-NAME already exist for the current element (ie., current SD-ID)?
@@ -2992,9 +3139,10 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto st62
 	st62:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof62
+			goto _test_eof62
 		}
-	stCase62:
+	st_case_62:
+//line rfc5424/machine.go:3079
 		switch (m.data)[(m.p)] {
 		case 32:
 			goto st26
@@ -3003,6 +3151,7 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		}
 		goto tr46
 	tr45:
+//line rfc5424/machine.go.rl:106
 
 		if _, ok := output.structuredData[string(m.text())]; ok {
 			// As per RFC5424 section 6.3.2 SD-ID MUST NOT exist more than once in a message
@@ -3022,9 +3171,10 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto st606
 	st606:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof606
+			goto _test_eof606
 		}
-	stCase606:
+	st_case_606:
+//line rfc5424/machine.go:3109
 		switch (m.data)[(m.p)] {
 		case 32:
 			goto st604
@@ -3033,22 +3183,27 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		}
 		goto tr645
 	tr83:
+//line rfc5424/machine.go.rl:58
 
 		m.pb = m.p
+
+//line rfc5424/machine.go.rl:124
 
 		m.backslashat = append(m.backslashat, m.p)
 
 		goto st63
 	tr94:
+//line rfc5424/machine.go.rl:124
 
 		m.backslashat = append(m.backslashat, m.p)
 
 		goto st63
 	st63:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof63
+			goto _test_eof63
 		}
-	stCase63:
+	st_case_63:
+//line rfc5424/machine.go:3138
 		if (m.data)[(m.p)] == 34 {
 			goto st61
 		}
@@ -3057,108 +3212,122 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		}
 		goto tr84
 	tr85:
+//line rfc5424/machine.go.rl:58
 
 		m.pb = m.p
 
 		goto st64
 	st64:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof64
+			goto _test_eof64
 		}
-	stCase64:
+	st_case_64:
+//line rfc5424/machine.go:3157
 		if 128 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 191 {
 			goto st61
 		}
 		goto tr46
 	tr86:
+//line rfc5424/machine.go.rl:58
 
 		m.pb = m.p
 
 		goto st65
 	st65:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof65
+			goto _test_eof65
 		}
-	stCase65:
+	st_case_65:
+//line rfc5424/machine.go:3173
 		if 160 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 191 {
 			goto st64
 		}
 		goto tr46
 	tr87:
+//line rfc5424/machine.go.rl:58
 
 		m.pb = m.p
 
 		goto st66
 	st66:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof66
+			goto _test_eof66
 		}
-	stCase66:
+	st_case_66:
+//line rfc5424/machine.go:3189
 		if 128 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 191 {
 			goto st64
 		}
 		goto tr46
 	tr88:
+//line rfc5424/machine.go.rl:58
 
 		m.pb = m.p
 
 		goto st67
 	st67:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof67
+			goto _test_eof67
 		}
-	stCase67:
+	st_case_67:
+//line rfc5424/machine.go:3205
 		if 128 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 159 {
 			goto st64
 		}
 		goto tr46
 	tr89:
+//line rfc5424/machine.go.rl:58
 
 		m.pb = m.p
 
 		goto st68
 	st68:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof68
+			goto _test_eof68
 		}
-	stCase68:
+	st_case_68:
+//line rfc5424/machine.go:3221
 		if 144 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 191 {
 			goto st66
 		}
 		goto tr46
 	tr90:
+//line rfc5424/machine.go.rl:58
 
 		m.pb = m.p
 
 		goto st69
 	st69:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof69
+			goto _test_eof69
 		}
-	stCase69:
+	st_case_69:
+//line rfc5424/machine.go:3237
 		if 128 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 191 {
 			goto st66
 		}
 		goto tr46
 	tr91:
+//line rfc5424/machine.go.rl:58
 
 		m.pb = m.p
 
 		goto st70
 	st70:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof70
+			goto _test_eof70
 		}
-	stCase70:
+	st_case_70:
+//line rfc5424/machine.go:3253
 		if 128 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 143 {
 			goto st66
 		}
 		goto tr46
 	st71:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof71
+			goto _test_eof71
 		}
-	stCase71:
+	st_case_71:
 		switch (m.data)[(m.p)] {
 		case 32:
 			goto tr43
@@ -3178,9 +3347,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr42
 	st72:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof72
+			goto _test_eof72
 		}
-	stCase72:
+	st_case_72:
 		switch (m.data)[(m.p)] {
 		case 32:
 			goto tr43
@@ -3200,9 +3369,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr42
 	st73:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof73
+			goto _test_eof73
 		}
-	stCase73:
+	st_case_73:
 		switch (m.data)[(m.p)] {
 		case 32:
 			goto tr43
@@ -3222,9 +3391,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr42
 	st74:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof74
+			goto _test_eof74
 		}
-	stCase74:
+	st_case_74:
 		switch (m.data)[(m.p)] {
 		case 32:
 			goto tr43
@@ -3244,9 +3413,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr42
 	st75:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof75
+			goto _test_eof75
 		}
-	stCase75:
+	st_case_75:
 		switch (m.data)[(m.p)] {
 		case 32:
 			goto tr43
@@ -3266,9 +3435,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr42
 	st76:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof76
+			goto _test_eof76
 		}
-	stCase76:
+	st_case_76:
 		switch (m.data)[(m.p)] {
 		case 32:
 			goto tr43
@@ -3288,9 +3457,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr42
 	st77:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof77
+			goto _test_eof77
 		}
-	stCase77:
+	st_case_77:
 		switch (m.data)[(m.p)] {
 		case 32:
 			goto tr43
@@ -3310,9 +3479,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr42
 	st78:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof78
+			goto _test_eof78
 		}
-	stCase78:
+	st_case_78:
 		switch (m.data)[(m.p)] {
 		case 32:
 			goto tr43
@@ -3332,9 +3501,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr42
 	st79:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof79
+			goto _test_eof79
 		}
-	stCase79:
+	st_case_79:
 		switch (m.data)[(m.p)] {
 		case 32:
 			goto tr43
@@ -3354,9 +3523,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr42
 	st80:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof80
+			goto _test_eof80
 		}
-	stCase80:
+	st_case_80:
 		switch (m.data)[(m.p)] {
 		case 32:
 			goto tr43
@@ -3376,9 +3545,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr42
 	st81:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof81
+			goto _test_eof81
 		}
-	stCase81:
+	st_case_81:
 		switch (m.data)[(m.p)] {
 		case 32:
 			goto tr43
@@ -3398,9 +3567,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr42
 	st82:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof82
+			goto _test_eof82
 		}
-	stCase82:
+	st_case_82:
 		switch (m.data)[(m.p)] {
 		case 32:
 			goto tr43
@@ -3420,9 +3589,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr42
 	st83:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof83
+			goto _test_eof83
 		}
-	stCase83:
+	st_case_83:
 		switch (m.data)[(m.p)] {
 		case 32:
 			goto tr43
@@ -3442,9 +3611,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr42
 	st84:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof84
+			goto _test_eof84
 		}
-	stCase84:
+	st_case_84:
 		switch (m.data)[(m.p)] {
 		case 32:
 			goto tr43
@@ -3464,9 +3633,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr42
 	st85:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof85
+			goto _test_eof85
 		}
-	stCase85:
+	st_case_85:
 		switch (m.data)[(m.p)] {
 		case 32:
 			goto tr43
@@ -3486,9 +3655,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr42
 	st86:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof86
+			goto _test_eof86
 		}
-	stCase86:
+	st_case_86:
 		switch (m.data)[(m.p)] {
 		case 32:
 			goto tr43
@@ -3508,9 +3677,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr42
 	st87:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof87
+			goto _test_eof87
 		}
-	stCase87:
+	st_case_87:
 		switch (m.data)[(m.p)] {
 		case 32:
 			goto tr43
@@ -3530,9 +3699,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr42
 	st88:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof88
+			goto _test_eof88
 		}
-	stCase88:
+	st_case_88:
 		switch (m.data)[(m.p)] {
 		case 32:
 			goto tr43
@@ -3552,9 +3721,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr42
 	st89:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof89
+			goto _test_eof89
 		}
-	stCase89:
+	st_case_89:
 		switch (m.data)[(m.p)] {
 		case 32:
 			goto tr43
@@ -3574,9 +3743,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr42
 	st90:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof90
+			goto _test_eof90
 		}
-	stCase90:
+	st_case_90:
 		switch (m.data)[(m.p)] {
 		case 32:
 			goto tr43
@@ -3596,9 +3765,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr42
 	st91:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof91
+			goto _test_eof91
 		}
-	stCase91:
+	st_case_91:
 		switch (m.data)[(m.p)] {
 		case 32:
 			goto tr43
@@ -3618,9 +3787,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr42
 	st92:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof92
+			goto _test_eof92
 		}
-	stCase92:
+	st_case_92:
 		switch (m.data)[(m.p)] {
 		case 32:
 			goto tr43
@@ -3640,9 +3809,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr42
 	st93:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof93
+			goto _test_eof93
 		}
-	stCase93:
+	st_case_93:
 		switch (m.data)[(m.p)] {
 		case 32:
 			goto tr43
@@ -3662,9 +3831,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr42
 	st94:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof94
+			goto _test_eof94
 		}
-	stCase94:
+	st_case_94:
 		switch (m.data)[(m.p)] {
 		case 32:
 			goto tr43
@@ -3684,9 +3853,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr42
 	st95:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof95
+			goto _test_eof95
 		}
-	stCase95:
+	st_case_95:
 		switch (m.data)[(m.p)] {
 		case 32:
 			goto tr43
@@ -3706,9 +3875,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr42
 	st96:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof96
+			goto _test_eof96
 		}
-	stCase96:
+	st_case_96:
 		switch (m.data)[(m.p)] {
 		case 32:
 			goto tr43
@@ -3728,9 +3897,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr42
 	st97:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof97
+			goto _test_eof97
 		}
-	stCase97:
+	st_case_97:
 		switch (m.data)[(m.p)] {
 		case 32:
 			goto tr43
@@ -3750,9 +3919,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr42
 	st98:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof98
+			goto _test_eof98
 		}
-	stCase98:
+	st_case_98:
 		switch (m.data)[(m.p)] {
 		case 32:
 			goto tr43
@@ -3772,9 +3941,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr42
 	st99:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof99
+			goto _test_eof99
 		}
-	stCase99:
+	st_case_99:
 		switch (m.data)[(m.p)] {
 		case 32:
 			goto tr43
@@ -3794,9 +3963,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr42
 	st100:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof100
+			goto _test_eof100
 		}
-	stCase100:
+	st_case_100:
 		switch (m.data)[(m.p)] {
 		case 32:
 			goto tr43
@@ -3816,9 +3985,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr42
 	st101:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof101
+			goto _test_eof101
 		}
-	stCase101:
+	st_case_101:
 		switch (m.data)[(m.p)] {
 		case 32:
 			goto tr43
@@ -3828,9 +3997,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr42
 	st102:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof102
+			goto _test_eof102
 		}
-	stCase102:
+	st_case_102:
 		if (m.data)[(m.p)] == 32 {
 			goto tr31
 		}
@@ -3840,9 +4009,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr30
 	st103:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof103
+			goto _test_eof103
 		}
-	stCase103:
+	st_case_103:
 		if (m.data)[(m.p)] == 32 {
 			goto tr31
 		}
@@ -3852,9 +4021,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr30
 	st104:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof104
+			goto _test_eof104
 		}
-	stCase104:
+	st_case_104:
 		if (m.data)[(m.p)] == 32 {
 			goto tr31
 		}
@@ -3864,9 +4033,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr30
 	st105:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof105
+			goto _test_eof105
 		}
-	stCase105:
+	st_case_105:
 		if (m.data)[(m.p)] == 32 {
 			goto tr31
 		}
@@ -3876,9 +4045,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr30
 	st106:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof106
+			goto _test_eof106
 		}
-	stCase106:
+	st_case_106:
 		if (m.data)[(m.p)] == 32 {
 			goto tr31
 		}
@@ -3888,9 +4057,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr30
 	st107:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof107
+			goto _test_eof107
 		}
-	stCase107:
+	st_case_107:
 		if (m.data)[(m.p)] == 32 {
 			goto tr31
 		}
@@ -3900,9 +4069,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr30
 	st108:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof108
+			goto _test_eof108
 		}
-	stCase108:
+	st_case_108:
 		if (m.data)[(m.p)] == 32 {
 			goto tr31
 		}
@@ -3912,9 +4081,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr30
 	st109:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof109
+			goto _test_eof109
 		}
-	stCase109:
+	st_case_109:
 		if (m.data)[(m.p)] == 32 {
 			goto tr31
 		}
@@ -3924,9 +4093,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr30
 	st110:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof110
+			goto _test_eof110
 		}
-	stCase110:
+	st_case_110:
 		if (m.data)[(m.p)] == 32 {
 			goto tr31
 		}
@@ -3936,9 +4105,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr30
 	st111:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof111
+			goto _test_eof111
 		}
-	stCase111:
+	st_case_111:
 		if (m.data)[(m.p)] == 32 {
 			goto tr31
 		}
@@ -3948,9 +4117,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr30
 	st112:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof112
+			goto _test_eof112
 		}
-	stCase112:
+	st_case_112:
 		if (m.data)[(m.p)] == 32 {
 			goto tr31
 		}
@@ -3960,9 +4129,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr30
 	st113:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof113
+			goto _test_eof113
 		}
-	stCase113:
+	st_case_113:
 		if (m.data)[(m.p)] == 32 {
 			goto tr31
 		}
@@ -3972,9 +4141,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr30
 	st114:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof114
+			goto _test_eof114
 		}
-	stCase114:
+	st_case_114:
 		if (m.data)[(m.p)] == 32 {
 			goto tr31
 		}
@@ -3984,9 +4153,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr30
 	st115:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof115
+			goto _test_eof115
 		}
-	stCase115:
+	st_case_115:
 		if (m.data)[(m.p)] == 32 {
 			goto tr31
 		}
@@ -3996,9 +4165,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr30
 	st116:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof116
+			goto _test_eof116
 		}
-	stCase116:
+	st_case_116:
 		if (m.data)[(m.p)] == 32 {
 			goto tr31
 		}
@@ -4008,9 +4177,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr30
 	st117:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof117
+			goto _test_eof117
 		}
-	stCase117:
+	st_case_117:
 		if (m.data)[(m.p)] == 32 {
 			goto tr31
 		}
@@ -4020,9 +4189,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr30
 	st118:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof118
+			goto _test_eof118
 		}
-	stCase118:
+	st_case_118:
 		if (m.data)[(m.p)] == 32 {
 			goto tr31
 		}
@@ -4032,9 +4201,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr30
 	st119:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof119
+			goto _test_eof119
 		}
-	stCase119:
+	st_case_119:
 		if (m.data)[(m.p)] == 32 {
 			goto tr31
 		}
@@ -4044,9 +4213,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr30
 	st120:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof120
+			goto _test_eof120
 		}
-	stCase120:
+	st_case_120:
 		if (m.data)[(m.p)] == 32 {
 			goto tr31
 		}
@@ -4056,9 +4225,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr30
 	st121:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof121
+			goto _test_eof121
 		}
-	stCase121:
+	st_case_121:
 		if (m.data)[(m.p)] == 32 {
 			goto tr31
 		}
@@ -4068,9 +4237,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr30
 	st122:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof122
+			goto _test_eof122
 		}
-	stCase122:
+	st_case_122:
 		if (m.data)[(m.p)] == 32 {
 			goto tr31
 		}
@@ -4080,9 +4249,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr30
 	st123:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof123
+			goto _test_eof123
 		}
-	stCase123:
+	st_case_123:
 		if (m.data)[(m.p)] == 32 {
 			goto tr31
 		}
@@ -4092,9 +4261,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr30
 	st124:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof124
+			goto _test_eof124
 		}
-	stCase124:
+	st_case_124:
 		if (m.data)[(m.p)] == 32 {
 			goto tr31
 		}
@@ -4104,9 +4273,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr30
 	st125:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof125
+			goto _test_eof125
 		}
-	stCase125:
+	st_case_125:
 		if (m.data)[(m.p)] == 32 {
 			goto tr31
 		}
@@ -4116,9 +4285,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr30
 	st126:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof126
+			goto _test_eof126
 		}
-	stCase126:
+	st_case_126:
 		if (m.data)[(m.p)] == 32 {
 			goto tr31
 		}
@@ -4128,9 +4297,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr30
 	st127:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof127
+			goto _test_eof127
 		}
-	stCase127:
+	st_case_127:
 		if (m.data)[(m.p)] == 32 {
 			goto tr31
 		}
@@ -4140,9 +4309,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr30
 	st128:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof128
+			goto _test_eof128
 		}
-	stCase128:
+	st_case_128:
 		if (m.data)[(m.p)] == 32 {
 			goto tr31
 		}
@@ -4152,9 +4321,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr30
 	st129:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof129
+			goto _test_eof129
 		}
-	stCase129:
+	st_case_129:
 		if (m.data)[(m.p)] == 32 {
 			goto tr31
 		}
@@ -4164,9 +4333,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr30
 	st130:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof130
+			goto _test_eof130
 		}
-	stCase130:
+	st_case_130:
 		if (m.data)[(m.p)] == 32 {
 			goto tr31
 		}
@@ -4176,9 +4345,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr30
 	st131:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof131
+			goto _test_eof131
 		}
-	stCase131:
+	st_case_131:
 		if (m.data)[(m.p)] == 32 {
 			goto tr31
 		}
@@ -4188,18 +4357,18 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr30
 	st132:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof132
+			goto _test_eof132
 		}
-	stCase132:
+	st_case_132:
 		if (m.data)[(m.p)] == 32 {
 			goto tr31
 		}
 		goto tr30
 	st133:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof133
+			goto _test_eof133
 		}
-	stCase133:
+	st_case_133:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -4209,9 +4378,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st134:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof134
+			goto _test_eof134
 		}
-	stCase134:
+	st_case_134:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -4221,9 +4390,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st135:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof135
+			goto _test_eof135
 		}
-	stCase135:
+	st_case_135:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -4233,9 +4402,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st136:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof136
+			goto _test_eof136
 		}
-	stCase136:
+	st_case_136:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -4245,9 +4414,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st137:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof137
+			goto _test_eof137
 		}
-	stCase137:
+	st_case_137:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -4257,9 +4426,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st138:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof138
+			goto _test_eof138
 		}
-	stCase138:
+	st_case_138:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -4269,9 +4438,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st139:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof139
+			goto _test_eof139
 		}
-	stCase139:
+	st_case_139:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -4281,9 +4450,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st140:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof140
+			goto _test_eof140
 		}
-	stCase140:
+	st_case_140:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -4293,9 +4462,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st141:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof141
+			goto _test_eof141
 		}
-	stCase141:
+	st_case_141:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -4305,9 +4474,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st142:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof142
+			goto _test_eof142
 		}
-	stCase142:
+	st_case_142:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -4317,9 +4486,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st143:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof143
+			goto _test_eof143
 		}
-	stCase143:
+	st_case_143:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -4329,9 +4498,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st144:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof144
+			goto _test_eof144
 		}
-	stCase144:
+	st_case_144:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -4341,9 +4510,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st145:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof145
+			goto _test_eof145
 		}
-	stCase145:
+	st_case_145:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -4353,9 +4522,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st146:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof146
+			goto _test_eof146
 		}
-	stCase146:
+	st_case_146:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -4365,9 +4534,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st147:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof147
+			goto _test_eof147
 		}
-	stCase147:
+	st_case_147:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -4377,9 +4546,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st148:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof148
+			goto _test_eof148
 		}
-	stCase148:
+	st_case_148:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -4389,9 +4558,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st149:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof149
+			goto _test_eof149
 		}
-	stCase149:
+	st_case_149:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -4401,9 +4570,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st150:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof150
+			goto _test_eof150
 		}
-	stCase150:
+	st_case_150:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -4413,9 +4582,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st151:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof151
+			goto _test_eof151
 		}
-	stCase151:
+	st_case_151:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -4425,9 +4594,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st152:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof152
+			goto _test_eof152
 		}
-	stCase152:
+	st_case_152:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -4437,9 +4606,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st153:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof153
+			goto _test_eof153
 		}
-	stCase153:
+	st_case_153:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -4449,9 +4618,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st154:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof154
+			goto _test_eof154
 		}
-	stCase154:
+	st_case_154:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -4461,9 +4630,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st155:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof155
+			goto _test_eof155
 		}
-	stCase155:
+	st_case_155:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -4473,9 +4642,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st156:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof156
+			goto _test_eof156
 		}
-	stCase156:
+	st_case_156:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -4485,9 +4654,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st157:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof157
+			goto _test_eof157
 		}
-	stCase157:
+	st_case_157:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -4497,9 +4666,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st158:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof158
+			goto _test_eof158
 		}
-	stCase158:
+	st_case_158:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -4509,9 +4678,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st159:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof159
+			goto _test_eof159
 		}
-	stCase159:
+	st_case_159:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -4521,9 +4690,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st160:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof160
+			goto _test_eof160
 		}
-	stCase160:
+	st_case_160:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -4533,9 +4702,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st161:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof161
+			goto _test_eof161
 		}
-	stCase161:
+	st_case_161:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -4545,9 +4714,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st162:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof162
+			goto _test_eof162
 		}
-	stCase162:
+	st_case_162:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -4557,9 +4726,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st163:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof163
+			goto _test_eof163
 		}
-	stCase163:
+	st_case_163:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -4569,9 +4738,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st164:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof164
+			goto _test_eof164
 		}
-	stCase164:
+	st_case_164:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -4581,9 +4750,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st165:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof165
+			goto _test_eof165
 		}
-	stCase165:
+	st_case_165:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -4593,9 +4762,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st166:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof166
+			goto _test_eof166
 		}
-	stCase166:
+	st_case_166:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -4605,9 +4774,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st167:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof167
+			goto _test_eof167
 		}
-	stCase167:
+	st_case_167:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -4617,9 +4786,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st168:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof168
+			goto _test_eof168
 		}
-	stCase168:
+	st_case_168:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -4629,9 +4798,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st169:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof169
+			goto _test_eof169
 		}
-	stCase169:
+	st_case_169:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -4641,9 +4810,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st170:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof170
+			goto _test_eof170
 		}
-	stCase170:
+	st_case_170:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -4653,9 +4822,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st171:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof171
+			goto _test_eof171
 		}
-	stCase171:
+	st_case_171:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -4665,9 +4834,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st172:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof172
+			goto _test_eof172
 		}
-	stCase172:
+	st_case_172:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -4677,9 +4846,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st173:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof173
+			goto _test_eof173
 		}
-	stCase173:
+	st_case_173:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -4689,9 +4858,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st174:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof174
+			goto _test_eof174
 		}
-	stCase174:
+	st_case_174:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -4701,9 +4870,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st175:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof175
+			goto _test_eof175
 		}
-	stCase175:
+	st_case_175:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -4713,9 +4882,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st176:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof176
+			goto _test_eof176
 		}
-	stCase176:
+	st_case_176:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -4725,9 +4894,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st177:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof177
+			goto _test_eof177
 		}
-	stCase177:
+	st_case_177:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -4737,9 +4906,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st178:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof178
+			goto _test_eof178
 		}
-	stCase178:
+	st_case_178:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -4749,9 +4918,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st179:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof179
+			goto _test_eof179
 		}
-	stCase179:
+	st_case_179:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -4761,9 +4930,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st180:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof180
+			goto _test_eof180
 		}
-	stCase180:
+	st_case_180:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -4773,9 +4942,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st181:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof181
+			goto _test_eof181
 		}
-	stCase181:
+	st_case_181:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -4785,9 +4954,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st182:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof182
+			goto _test_eof182
 		}
-	stCase182:
+	st_case_182:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -4797,9 +4966,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st183:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof183
+			goto _test_eof183
 		}
-	stCase183:
+	st_case_183:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -4809,9 +4978,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st184:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof184
+			goto _test_eof184
 		}
-	stCase184:
+	st_case_184:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -4821,9 +4990,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st185:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof185
+			goto _test_eof185
 		}
-	stCase185:
+	st_case_185:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -4833,9 +5002,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st186:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof186
+			goto _test_eof186
 		}
-	stCase186:
+	st_case_186:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -4845,9 +5014,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st187:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof187
+			goto _test_eof187
 		}
-	stCase187:
+	st_case_187:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -4857,9 +5026,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st188:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof188
+			goto _test_eof188
 		}
-	stCase188:
+	st_case_188:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -4869,9 +5038,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st189:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof189
+			goto _test_eof189
 		}
-	stCase189:
+	st_case_189:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -4881,9 +5050,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st190:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof190
+			goto _test_eof190
 		}
-	stCase190:
+	st_case_190:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -4893,9 +5062,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st191:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof191
+			goto _test_eof191
 		}
-	stCase191:
+	st_case_191:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -4905,9 +5074,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st192:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof192
+			goto _test_eof192
 		}
-	stCase192:
+	st_case_192:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -4917,9 +5086,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st193:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof193
+			goto _test_eof193
 		}
-	stCase193:
+	st_case_193:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -4929,9 +5098,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st194:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof194
+			goto _test_eof194
 		}
-	stCase194:
+	st_case_194:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -4941,9 +5110,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st195:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof195
+			goto _test_eof195
 		}
-	stCase195:
+	st_case_195:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -4953,9 +5122,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st196:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof196
+			goto _test_eof196
 		}
-	stCase196:
+	st_case_196:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -4965,9 +5134,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st197:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof197
+			goto _test_eof197
 		}
-	stCase197:
+	st_case_197:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -4977,9 +5146,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st198:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof198
+			goto _test_eof198
 		}
-	stCase198:
+	st_case_198:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -4989,9 +5158,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st199:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof199
+			goto _test_eof199
 		}
-	stCase199:
+	st_case_199:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -5001,9 +5170,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st200:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof200
+			goto _test_eof200
 		}
-	stCase200:
+	st_case_200:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -5013,9 +5182,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st201:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof201
+			goto _test_eof201
 		}
-	stCase201:
+	st_case_201:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -5025,9 +5194,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st202:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof202
+			goto _test_eof202
 		}
-	stCase202:
+	st_case_202:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -5037,9 +5206,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st203:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof203
+			goto _test_eof203
 		}
-	stCase203:
+	st_case_203:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -5049,9 +5218,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st204:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof204
+			goto _test_eof204
 		}
-	stCase204:
+	st_case_204:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -5061,9 +5230,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st205:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof205
+			goto _test_eof205
 		}
-	stCase205:
+	st_case_205:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -5073,9 +5242,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st206:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof206
+			goto _test_eof206
 		}
-	stCase206:
+	st_case_206:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -5085,9 +5254,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st207:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof207
+			goto _test_eof207
 		}
-	stCase207:
+	st_case_207:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -5097,9 +5266,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st208:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof208
+			goto _test_eof208
 		}
-	stCase208:
+	st_case_208:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -5109,9 +5278,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st209:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof209
+			goto _test_eof209
 		}
-	stCase209:
+	st_case_209:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -5121,9 +5290,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st210:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof210
+			goto _test_eof210
 		}
-	stCase210:
+	st_case_210:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -5133,9 +5302,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st211:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof211
+			goto _test_eof211
 		}
-	stCase211:
+	st_case_211:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -5145,9 +5314,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st212:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof212
+			goto _test_eof212
 		}
-	stCase212:
+	st_case_212:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -5157,9 +5326,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st213:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof213
+			goto _test_eof213
 		}
-	stCase213:
+	st_case_213:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -5169,9 +5338,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st214:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof214
+			goto _test_eof214
 		}
-	stCase214:
+	st_case_214:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -5181,9 +5350,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st215:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof215
+			goto _test_eof215
 		}
-	stCase215:
+	st_case_215:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -5193,9 +5362,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st216:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof216
+			goto _test_eof216
 		}
-	stCase216:
+	st_case_216:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -5205,9 +5374,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st217:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof217
+			goto _test_eof217
 		}
-	stCase217:
+	st_case_217:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -5217,9 +5386,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st218:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof218
+			goto _test_eof218
 		}
-	stCase218:
+	st_case_218:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -5229,9 +5398,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st219:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof219
+			goto _test_eof219
 		}
-	stCase219:
+	st_case_219:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -5241,9 +5410,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st220:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof220
+			goto _test_eof220
 		}
-	stCase220:
+	st_case_220:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -5253,9 +5422,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st221:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof221
+			goto _test_eof221
 		}
-	stCase221:
+	st_case_221:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -5265,9 +5434,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st222:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof222
+			goto _test_eof222
 		}
-	stCase222:
+	st_case_222:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -5277,9 +5446,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st223:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof223
+			goto _test_eof223
 		}
-	stCase223:
+	st_case_223:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -5289,9 +5458,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st224:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof224
+			goto _test_eof224
 		}
-	stCase224:
+	st_case_224:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -5301,9 +5470,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st225:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof225
+			goto _test_eof225
 		}
-	stCase225:
+	st_case_225:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -5313,9 +5482,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st226:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof226
+			goto _test_eof226
 		}
-	stCase226:
+	st_case_226:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -5325,9 +5494,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st227:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof227
+			goto _test_eof227
 		}
-	stCase227:
+	st_case_227:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -5337,9 +5506,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st228:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof228
+			goto _test_eof228
 		}
-	stCase228:
+	st_case_228:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -5349,9 +5518,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st229:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof229
+			goto _test_eof229
 		}
-	stCase229:
+	st_case_229:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -5361,9 +5530,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st230:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof230
+			goto _test_eof230
 		}
-	stCase230:
+	st_case_230:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -5373,9 +5542,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st231:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof231
+			goto _test_eof231
 		}
-	stCase231:
+	st_case_231:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -5385,9 +5554,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st232:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof232
+			goto _test_eof232
 		}
-	stCase232:
+	st_case_232:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -5397,9 +5566,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st233:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof233
+			goto _test_eof233
 		}
-	stCase233:
+	st_case_233:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -5409,9 +5578,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st234:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof234
+			goto _test_eof234
 		}
-	stCase234:
+	st_case_234:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -5421,9 +5590,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st235:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof235
+			goto _test_eof235
 		}
-	stCase235:
+	st_case_235:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -5433,9 +5602,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st236:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof236
+			goto _test_eof236
 		}
-	stCase236:
+	st_case_236:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -5445,9 +5614,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st237:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof237
+			goto _test_eof237
 		}
-	stCase237:
+	st_case_237:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -5457,9 +5626,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st238:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof238
+			goto _test_eof238
 		}
-	stCase238:
+	st_case_238:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -5469,9 +5638,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st239:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof239
+			goto _test_eof239
 		}
-	stCase239:
+	st_case_239:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -5481,9 +5650,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st240:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof240
+			goto _test_eof240
 		}
-	stCase240:
+	st_case_240:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -5493,9 +5662,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st241:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof241
+			goto _test_eof241
 		}
-	stCase241:
+	st_case_241:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -5505,9 +5674,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st242:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof242
+			goto _test_eof242
 		}
-	stCase242:
+	st_case_242:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -5517,9 +5686,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st243:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof243
+			goto _test_eof243
 		}
-	stCase243:
+	st_case_243:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -5529,9 +5698,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st244:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof244
+			goto _test_eof244
 		}
-	stCase244:
+	st_case_244:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -5541,9 +5710,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st245:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof245
+			goto _test_eof245
 		}
-	stCase245:
+	st_case_245:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -5553,9 +5722,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st246:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof246
+			goto _test_eof246
 		}
-	stCase246:
+	st_case_246:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -5565,9 +5734,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st247:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof247
+			goto _test_eof247
 		}
-	stCase247:
+	st_case_247:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -5577,9 +5746,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st248:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof248
+			goto _test_eof248
 		}
-	stCase248:
+	st_case_248:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -5589,9 +5758,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st249:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof249
+			goto _test_eof249
 		}
-	stCase249:
+	st_case_249:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -5601,9 +5770,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st250:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof250
+			goto _test_eof250
 		}
-	stCase250:
+	st_case_250:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -5613,9 +5782,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st251:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof251
+			goto _test_eof251
 		}
-	stCase251:
+	st_case_251:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -5625,9 +5794,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st252:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof252
+			goto _test_eof252
 		}
-	stCase252:
+	st_case_252:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -5637,9 +5806,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st253:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof253
+			goto _test_eof253
 		}
-	stCase253:
+	st_case_253:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -5649,9 +5818,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st254:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof254
+			goto _test_eof254
 		}
-	stCase254:
+	st_case_254:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -5661,9 +5830,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st255:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof255
+			goto _test_eof255
 		}
-	stCase255:
+	st_case_255:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -5673,9 +5842,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st256:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof256
+			goto _test_eof256
 		}
-	stCase256:
+	st_case_256:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -5685,9 +5854,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st257:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof257
+			goto _test_eof257
 		}
-	stCase257:
+	st_case_257:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -5697,9 +5866,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st258:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof258
+			goto _test_eof258
 		}
-	stCase258:
+	st_case_258:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
@@ -5709,18 +5878,18 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr24
 	st259:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof259
+			goto _test_eof259
 		}
-	stCase259:
+	st_case_259:
 		if (m.data)[(m.p)] == 32 {
 			goto tr26
 		}
 		goto tr24
 	st260:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof260
+			goto _test_eof260
 		}
-	stCase260:
+	st_case_260:
 		if (m.data)[(m.p)] == 32 {
 			goto tr22
 		}
@@ -5730,9 +5899,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr20
 	st261:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof261
+			goto _test_eof261
 		}
-	stCase261:
+	st_case_261:
 		if (m.data)[(m.p)] == 32 {
 			goto tr22
 		}
@@ -5742,9 +5911,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr20
 	st262:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof262
+			goto _test_eof262
 		}
-	stCase262:
+	st_case_262:
 		if (m.data)[(m.p)] == 32 {
 			goto tr22
 		}
@@ -5754,9 +5923,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr20
 	st263:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof263
+			goto _test_eof263
 		}
-	stCase263:
+	st_case_263:
 		if (m.data)[(m.p)] == 32 {
 			goto tr22
 		}
@@ -5766,9 +5935,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr20
 	st264:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof264
+			goto _test_eof264
 		}
-	stCase264:
+	st_case_264:
 		if (m.data)[(m.p)] == 32 {
 			goto tr22
 		}
@@ -5778,9 +5947,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr20
 	st265:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof265
+			goto _test_eof265
 		}
-	stCase265:
+	st_case_265:
 		if (m.data)[(m.p)] == 32 {
 			goto tr22
 		}
@@ -5790,9 +5959,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr20
 	st266:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof266
+			goto _test_eof266
 		}
-	stCase266:
+	st_case_266:
 		if (m.data)[(m.p)] == 32 {
 			goto tr22
 		}
@@ -5802,9 +5971,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr20
 	st267:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof267
+			goto _test_eof267
 		}
-	stCase267:
+	st_case_267:
 		if (m.data)[(m.p)] == 32 {
 			goto tr22
 		}
@@ -5814,9 +5983,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr20
 	st268:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof268
+			goto _test_eof268
 		}
-	stCase268:
+	st_case_268:
 		if (m.data)[(m.p)] == 32 {
 			goto tr22
 		}
@@ -5826,9 +5995,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr20
 	st269:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof269
+			goto _test_eof269
 		}
-	stCase269:
+	st_case_269:
 		if (m.data)[(m.p)] == 32 {
 			goto tr22
 		}
@@ -5838,9 +6007,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr20
 	st270:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof270
+			goto _test_eof270
 		}
-	stCase270:
+	st_case_270:
 		if (m.data)[(m.p)] == 32 {
 			goto tr22
 		}
@@ -5850,9 +6019,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr20
 	st271:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof271
+			goto _test_eof271
 		}
-	stCase271:
+	st_case_271:
 		if (m.data)[(m.p)] == 32 {
 			goto tr22
 		}
@@ -5862,9 +6031,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr20
 	st272:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof272
+			goto _test_eof272
 		}
-	stCase272:
+	st_case_272:
 		if (m.data)[(m.p)] == 32 {
 			goto tr22
 		}
@@ -5874,9 +6043,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr20
 	st273:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof273
+			goto _test_eof273
 		}
-	stCase273:
+	st_case_273:
 		if (m.data)[(m.p)] == 32 {
 			goto tr22
 		}
@@ -5886,9 +6055,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr20
 	st274:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof274
+			goto _test_eof274
 		}
-	stCase274:
+	st_case_274:
 		if (m.data)[(m.p)] == 32 {
 			goto tr22
 		}
@@ -5898,9 +6067,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr20
 	st275:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof275
+			goto _test_eof275
 		}
-	stCase275:
+	st_case_275:
 		if (m.data)[(m.p)] == 32 {
 			goto tr22
 		}
@@ -5910,9 +6079,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr20
 	st276:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof276
+			goto _test_eof276
 		}
-	stCase276:
+	st_case_276:
 		if (m.data)[(m.p)] == 32 {
 			goto tr22
 		}
@@ -5922,9 +6091,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr20
 	st277:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof277
+			goto _test_eof277
 		}
-	stCase277:
+	st_case_277:
 		if (m.data)[(m.p)] == 32 {
 			goto tr22
 		}
@@ -5934,9 +6103,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr20
 	st278:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof278
+			goto _test_eof278
 		}
-	stCase278:
+	st_case_278:
 		if (m.data)[(m.p)] == 32 {
 			goto tr22
 		}
@@ -5946,9 +6115,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr20
 	st279:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof279
+			goto _test_eof279
 		}
-	stCase279:
+	st_case_279:
 		if (m.data)[(m.p)] == 32 {
 			goto tr22
 		}
@@ -5958,9 +6127,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr20
 	st280:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof280
+			goto _test_eof280
 		}
-	stCase280:
+	st_case_280:
 		if (m.data)[(m.p)] == 32 {
 			goto tr22
 		}
@@ -5970,9 +6139,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr20
 	st281:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof281
+			goto _test_eof281
 		}
-	stCase281:
+	st_case_281:
 		if (m.data)[(m.p)] == 32 {
 			goto tr22
 		}
@@ -5982,9 +6151,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr20
 	st282:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof282
+			goto _test_eof282
 		}
-	stCase282:
+	st_case_282:
 		if (m.data)[(m.p)] == 32 {
 			goto tr22
 		}
@@ -5994,9 +6163,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr20
 	st283:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof283
+			goto _test_eof283
 		}
-	stCase283:
+	st_case_283:
 		if (m.data)[(m.p)] == 32 {
 			goto tr22
 		}
@@ -6006,9 +6175,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr20
 	st284:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof284
+			goto _test_eof284
 		}
-	stCase284:
+	st_case_284:
 		if (m.data)[(m.p)] == 32 {
 			goto tr22
 		}
@@ -6018,9 +6187,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr20
 	st285:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof285
+			goto _test_eof285
 		}
-	stCase285:
+	st_case_285:
 		if (m.data)[(m.p)] == 32 {
 			goto tr22
 		}
@@ -6030,9 +6199,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr20
 	st286:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof286
+			goto _test_eof286
 		}
-	stCase286:
+	st_case_286:
 		if (m.data)[(m.p)] == 32 {
 			goto tr22
 		}
@@ -6042,9 +6211,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr20
 	st287:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof287
+			goto _test_eof287
 		}
-	stCase287:
+	st_case_287:
 		if (m.data)[(m.p)] == 32 {
 			goto tr22
 		}
@@ -6054,9 +6223,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr20
 	st288:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof288
+			goto _test_eof288
 		}
-	stCase288:
+	st_case_288:
 		if (m.data)[(m.p)] == 32 {
 			goto tr22
 		}
@@ -6066,9 +6235,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr20
 	st289:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof289
+			goto _test_eof289
 		}
-	stCase289:
+	st_case_289:
 		if (m.data)[(m.p)] == 32 {
 			goto tr22
 		}
@@ -6078,9 +6247,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr20
 	st290:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof290
+			goto _test_eof290
 		}
-	stCase290:
+	st_case_290:
 		if (m.data)[(m.p)] == 32 {
 			goto tr22
 		}
@@ -6090,9 +6259,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr20
 	st291:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof291
+			goto _test_eof291
 		}
-	stCase291:
+	st_case_291:
 		if (m.data)[(m.p)] == 32 {
 			goto tr22
 		}
@@ -6102,9 +6271,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr20
 	st292:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof292
+			goto _test_eof292
 		}
-	stCase292:
+	st_case_292:
 		if (m.data)[(m.p)] == 32 {
 			goto tr22
 		}
@@ -6114,9 +6283,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr20
 	st293:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof293
+			goto _test_eof293
 		}
-	stCase293:
+	st_case_293:
 		if (m.data)[(m.p)] == 32 {
 			goto tr22
 		}
@@ -6126,9 +6295,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr20
 	st294:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof294
+			goto _test_eof294
 		}
-	stCase294:
+	st_case_294:
 		if (m.data)[(m.p)] == 32 {
 			goto tr22
 		}
@@ -6138,9 +6307,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr20
 	st295:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof295
+			goto _test_eof295
 		}
-	stCase295:
+	st_case_295:
 		if (m.data)[(m.p)] == 32 {
 			goto tr22
 		}
@@ -6150,9 +6319,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr20
 	st296:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof296
+			goto _test_eof296
 		}
-	stCase296:
+	st_case_296:
 		if (m.data)[(m.p)] == 32 {
 			goto tr22
 		}
@@ -6162,9 +6331,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr20
 	st297:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof297
+			goto _test_eof297
 		}
-	stCase297:
+	st_case_297:
 		if (m.data)[(m.p)] == 32 {
 			goto tr22
 		}
@@ -6174,9 +6343,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr20
 	st298:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof298
+			goto _test_eof298
 		}
-	stCase298:
+	st_case_298:
 		if (m.data)[(m.p)] == 32 {
 			goto tr22
 		}
@@ -6186,9 +6355,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr20
 	st299:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof299
+			goto _test_eof299
 		}
-	stCase299:
+	st_case_299:
 		if (m.data)[(m.p)] == 32 {
 			goto tr22
 		}
@@ -6198,9 +6367,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr20
 	st300:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof300
+			goto _test_eof300
 		}
-	stCase300:
+	st_case_300:
 		if (m.data)[(m.p)] == 32 {
 			goto tr22
 		}
@@ -6210,9 +6379,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr20
 	st301:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof301
+			goto _test_eof301
 		}
-	stCase301:
+	st_case_301:
 		if (m.data)[(m.p)] == 32 {
 			goto tr22
 		}
@@ -6222,9 +6391,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr20
 	st302:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof302
+			goto _test_eof302
 		}
-	stCase302:
+	st_case_302:
 		if (m.data)[(m.p)] == 32 {
 			goto tr22
 		}
@@ -6234,9 +6403,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr20
 	st303:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof303
+			goto _test_eof303
 		}
-	stCase303:
+	st_case_303:
 		if (m.data)[(m.p)] == 32 {
 			goto tr22
 		}
@@ -6246,9 +6415,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr20
 	st304:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof304
+			goto _test_eof304
 		}
-	stCase304:
+	st_case_304:
 		if (m.data)[(m.p)] == 32 {
 			goto tr22
 		}
@@ -6258,9 +6427,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr20
 	st305:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof305
+			goto _test_eof305
 		}
-	stCase305:
+	st_case_305:
 		if (m.data)[(m.p)] == 32 {
 			goto tr22
 		}
@@ -6270,18 +6439,18 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr20
 	st306:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof306
+			goto _test_eof306
 		}
-	stCase306:
+	st_case_306:
 		if (m.data)[(m.p)] == 32 {
 			goto tr22
 		}
 		goto tr20
 	st307:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof307
+			goto _test_eof307
 		}
-	stCase307:
+	st_case_307:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -6291,9 +6460,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st308:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof308
+			goto _test_eof308
 		}
-	stCase308:
+	st_case_308:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -6303,9 +6472,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st309:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof309
+			goto _test_eof309
 		}
-	stCase309:
+	st_case_309:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -6315,9 +6484,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st310:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof310
+			goto _test_eof310
 		}
-	stCase310:
+	st_case_310:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -6327,9 +6496,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st311:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof311
+			goto _test_eof311
 		}
-	stCase311:
+	st_case_311:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -6339,9 +6508,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st312:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof312
+			goto _test_eof312
 		}
-	stCase312:
+	st_case_312:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -6351,9 +6520,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st313:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof313
+			goto _test_eof313
 		}
-	stCase313:
+	st_case_313:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -6363,9 +6532,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st314:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof314
+			goto _test_eof314
 		}
-	stCase314:
+	st_case_314:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -6375,9 +6544,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st315:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof315
+			goto _test_eof315
 		}
-	stCase315:
+	st_case_315:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -6387,9 +6556,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st316:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof316
+			goto _test_eof316
 		}
-	stCase316:
+	st_case_316:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -6399,9 +6568,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st317:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof317
+			goto _test_eof317
 		}
-	stCase317:
+	st_case_317:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -6411,9 +6580,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st318:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof318
+			goto _test_eof318
 		}
-	stCase318:
+	st_case_318:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -6423,9 +6592,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st319:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof319
+			goto _test_eof319
 		}
-	stCase319:
+	st_case_319:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -6435,9 +6604,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st320:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof320
+			goto _test_eof320
 		}
-	stCase320:
+	st_case_320:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -6447,9 +6616,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st321:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof321
+			goto _test_eof321
 		}
-	stCase321:
+	st_case_321:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -6459,9 +6628,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st322:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof322
+			goto _test_eof322
 		}
-	stCase322:
+	st_case_322:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -6471,9 +6640,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st323:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof323
+			goto _test_eof323
 		}
-	stCase323:
+	st_case_323:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -6483,9 +6652,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st324:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof324
+			goto _test_eof324
 		}
-	stCase324:
+	st_case_324:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -6495,9 +6664,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st325:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof325
+			goto _test_eof325
 		}
-	stCase325:
+	st_case_325:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -6507,9 +6676,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st326:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof326
+			goto _test_eof326
 		}
-	stCase326:
+	st_case_326:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -6519,9 +6688,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st327:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof327
+			goto _test_eof327
 		}
-	stCase327:
+	st_case_327:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -6531,9 +6700,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st328:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof328
+			goto _test_eof328
 		}
-	stCase328:
+	st_case_328:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -6543,9 +6712,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st329:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof329
+			goto _test_eof329
 		}
-	stCase329:
+	st_case_329:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -6555,9 +6724,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st330:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof330
+			goto _test_eof330
 		}
-	stCase330:
+	st_case_330:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -6567,9 +6736,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st331:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof331
+			goto _test_eof331
 		}
-	stCase331:
+	st_case_331:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -6579,9 +6748,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st332:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof332
+			goto _test_eof332
 		}
-	stCase332:
+	st_case_332:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -6591,9 +6760,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st333:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof333
+			goto _test_eof333
 		}
-	stCase333:
+	st_case_333:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -6603,9 +6772,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st334:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof334
+			goto _test_eof334
 		}
-	stCase334:
+	st_case_334:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -6615,9 +6784,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st335:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof335
+			goto _test_eof335
 		}
-	stCase335:
+	st_case_335:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -6627,9 +6796,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st336:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof336
+			goto _test_eof336
 		}
-	stCase336:
+	st_case_336:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -6639,9 +6808,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st337:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof337
+			goto _test_eof337
 		}
-	stCase337:
+	st_case_337:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -6651,9 +6820,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st338:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof338
+			goto _test_eof338
 		}
-	stCase338:
+	st_case_338:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -6663,9 +6832,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st339:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof339
+			goto _test_eof339
 		}
-	stCase339:
+	st_case_339:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -6675,9 +6844,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st340:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof340
+			goto _test_eof340
 		}
-	stCase340:
+	st_case_340:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -6687,9 +6856,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st341:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof341
+			goto _test_eof341
 		}
-	stCase341:
+	st_case_341:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -6699,9 +6868,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st342:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof342
+			goto _test_eof342
 		}
-	stCase342:
+	st_case_342:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -6711,9 +6880,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st343:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof343
+			goto _test_eof343
 		}
-	stCase343:
+	st_case_343:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -6723,9 +6892,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st344:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof344
+			goto _test_eof344
 		}
-	stCase344:
+	st_case_344:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -6735,9 +6904,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st345:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof345
+			goto _test_eof345
 		}
-	stCase345:
+	st_case_345:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -6747,9 +6916,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st346:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof346
+			goto _test_eof346
 		}
-	stCase346:
+	st_case_346:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -6759,9 +6928,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st347:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof347
+			goto _test_eof347
 		}
-	stCase347:
+	st_case_347:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -6771,9 +6940,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st348:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof348
+			goto _test_eof348
 		}
-	stCase348:
+	st_case_348:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -6783,9 +6952,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st349:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof349
+			goto _test_eof349
 		}
-	stCase349:
+	st_case_349:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -6795,9 +6964,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st350:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof350
+			goto _test_eof350
 		}
-	stCase350:
+	st_case_350:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -6807,9 +6976,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st351:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof351
+			goto _test_eof351
 		}
-	stCase351:
+	st_case_351:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -6819,9 +6988,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st352:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof352
+			goto _test_eof352
 		}
-	stCase352:
+	st_case_352:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -6831,9 +7000,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st353:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof353
+			goto _test_eof353
 		}
-	stCase353:
+	st_case_353:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -6843,9 +7012,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st354:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof354
+			goto _test_eof354
 		}
-	stCase354:
+	st_case_354:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -6855,9 +7024,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st355:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof355
+			goto _test_eof355
 		}
-	stCase355:
+	st_case_355:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -6867,9 +7036,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st356:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof356
+			goto _test_eof356
 		}
-	stCase356:
+	st_case_356:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -6879,9 +7048,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st357:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof357
+			goto _test_eof357
 		}
-	stCase357:
+	st_case_357:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -6891,9 +7060,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st358:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof358
+			goto _test_eof358
 		}
-	stCase358:
+	st_case_358:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -6903,9 +7072,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st359:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof359
+			goto _test_eof359
 		}
-	stCase359:
+	st_case_359:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -6915,9 +7084,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st360:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof360
+			goto _test_eof360
 		}
-	stCase360:
+	st_case_360:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -6927,9 +7096,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st361:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof361
+			goto _test_eof361
 		}
-	stCase361:
+	st_case_361:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -6939,9 +7108,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st362:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof362
+			goto _test_eof362
 		}
-	stCase362:
+	st_case_362:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -6951,9 +7120,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st363:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof363
+			goto _test_eof363
 		}
-	stCase363:
+	st_case_363:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -6963,9 +7132,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st364:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof364
+			goto _test_eof364
 		}
-	stCase364:
+	st_case_364:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -6975,9 +7144,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st365:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof365
+			goto _test_eof365
 		}
-	stCase365:
+	st_case_365:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -6987,9 +7156,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st366:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof366
+			goto _test_eof366
 		}
-	stCase366:
+	st_case_366:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -6999,9 +7168,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st367:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof367
+			goto _test_eof367
 		}
-	stCase367:
+	st_case_367:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -7011,9 +7180,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st368:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof368
+			goto _test_eof368
 		}
-	stCase368:
+	st_case_368:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -7023,9 +7192,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st369:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof369
+			goto _test_eof369
 		}
-	stCase369:
+	st_case_369:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -7035,9 +7204,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st370:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof370
+			goto _test_eof370
 		}
-	stCase370:
+	st_case_370:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -7047,9 +7216,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st371:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof371
+			goto _test_eof371
 		}
-	stCase371:
+	st_case_371:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -7059,9 +7228,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st372:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof372
+			goto _test_eof372
 		}
-	stCase372:
+	st_case_372:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -7071,9 +7240,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st373:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof373
+			goto _test_eof373
 		}
-	stCase373:
+	st_case_373:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -7083,9 +7252,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st374:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof374
+			goto _test_eof374
 		}
-	stCase374:
+	st_case_374:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -7095,9 +7264,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st375:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof375
+			goto _test_eof375
 		}
-	stCase375:
+	st_case_375:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -7107,9 +7276,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st376:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof376
+			goto _test_eof376
 		}
-	stCase376:
+	st_case_376:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -7119,9 +7288,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st377:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof377
+			goto _test_eof377
 		}
-	stCase377:
+	st_case_377:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -7131,9 +7300,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st378:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof378
+			goto _test_eof378
 		}
-	stCase378:
+	st_case_378:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -7143,9 +7312,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st379:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof379
+			goto _test_eof379
 		}
-	stCase379:
+	st_case_379:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -7155,9 +7324,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st380:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof380
+			goto _test_eof380
 		}
-	stCase380:
+	st_case_380:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -7167,9 +7336,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st381:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof381
+			goto _test_eof381
 		}
-	stCase381:
+	st_case_381:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -7179,9 +7348,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st382:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof382
+			goto _test_eof382
 		}
-	stCase382:
+	st_case_382:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -7191,9 +7360,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st383:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof383
+			goto _test_eof383
 		}
-	stCase383:
+	st_case_383:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -7203,9 +7372,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st384:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof384
+			goto _test_eof384
 		}
-	stCase384:
+	st_case_384:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -7215,9 +7384,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st385:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof385
+			goto _test_eof385
 		}
-	stCase385:
+	st_case_385:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -7227,9 +7396,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st386:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof386
+			goto _test_eof386
 		}
-	stCase386:
+	st_case_386:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -7239,9 +7408,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st387:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof387
+			goto _test_eof387
 		}
-	stCase387:
+	st_case_387:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -7251,9 +7420,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st388:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof388
+			goto _test_eof388
 		}
-	stCase388:
+	st_case_388:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -7263,9 +7432,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st389:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof389
+			goto _test_eof389
 		}
-	stCase389:
+	st_case_389:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -7275,9 +7444,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st390:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof390
+			goto _test_eof390
 		}
-	stCase390:
+	st_case_390:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -7287,9 +7456,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st391:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof391
+			goto _test_eof391
 		}
-	stCase391:
+	st_case_391:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -7299,9 +7468,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st392:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof392
+			goto _test_eof392
 		}
-	stCase392:
+	st_case_392:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -7311,9 +7480,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st393:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof393
+			goto _test_eof393
 		}
-	stCase393:
+	st_case_393:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -7323,9 +7492,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st394:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof394
+			goto _test_eof394
 		}
-	stCase394:
+	st_case_394:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -7335,9 +7504,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st395:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof395
+			goto _test_eof395
 		}
-	stCase395:
+	st_case_395:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -7347,9 +7516,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st396:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof396
+			goto _test_eof396
 		}
-	stCase396:
+	st_case_396:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -7359,9 +7528,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st397:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof397
+			goto _test_eof397
 		}
-	stCase397:
+	st_case_397:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -7371,9 +7540,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st398:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof398
+			goto _test_eof398
 		}
-	stCase398:
+	st_case_398:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -7383,9 +7552,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st399:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof399
+			goto _test_eof399
 		}
-	stCase399:
+	st_case_399:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -7395,9 +7564,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st400:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof400
+			goto _test_eof400
 		}
-	stCase400:
+	st_case_400:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -7407,9 +7576,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st401:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof401
+			goto _test_eof401
 		}
-	stCase401:
+	st_case_401:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -7419,9 +7588,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st402:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof402
+			goto _test_eof402
 		}
-	stCase402:
+	st_case_402:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -7431,9 +7600,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st403:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof403
+			goto _test_eof403
 		}
-	stCase403:
+	st_case_403:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -7443,9 +7612,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st404:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof404
+			goto _test_eof404
 		}
-	stCase404:
+	st_case_404:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -7455,9 +7624,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st405:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof405
+			goto _test_eof405
 		}
-	stCase405:
+	st_case_405:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -7467,9 +7636,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st406:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof406
+			goto _test_eof406
 		}
-	stCase406:
+	st_case_406:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -7479,9 +7648,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st407:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof407
+			goto _test_eof407
 		}
-	stCase407:
+	st_case_407:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -7491,9 +7660,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st408:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof408
+			goto _test_eof408
 		}
-	stCase408:
+	st_case_408:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -7503,9 +7672,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st409:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof409
+			goto _test_eof409
 		}
-	stCase409:
+	st_case_409:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -7515,9 +7684,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st410:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof410
+			goto _test_eof410
 		}
-	stCase410:
+	st_case_410:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -7527,9 +7696,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st411:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof411
+			goto _test_eof411
 		}
-	stCase411:
+	st_case_411:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -7539,9 +7708,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st412:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof412
+			goto _test_eof412
 		}
-	stCase412:
+	st_case_412:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -7551,9 +7720,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st413:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof413
+			goto _test_eof413
 		}
-	stCase413:
+	st_case_413:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -7563,9 +7732,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st414:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof414
+			goto _test_eof414
 		}
-	stCase414:
+	st_case_414:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -7575,9 +7744,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st415:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof415
+			goto _test_eof415
 		}
-	stCase415:
+	st_case_415:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -7587,9 +7756,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st416:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof416
+			goto _test_eof416
 		}
-	stCase416:
+	st_case_416:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -7599,9 +7768,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st417:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof417
+			goto _test_eof417
 		}
-	stCase417:
+	st_case_417:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -7611,9 +7780,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st418:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof418
+			goto _test_eof418
 		}
-	stCase418:
+	st_case_418:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -7623,9 +7792,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st419:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof419
+			goto _test_eof419
 		}
-	stCase419:
+	st_case_419:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -7635,9 +7804,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st420:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof420
+			goto _test_eof420
 		}
-	stCase420:
+	st_case_420:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -7647,9 +7816,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st421:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof421
+			goto _test_eof421
 		}
-	stCase421:
+	st_case_421:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -7659,9 +7828,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st422:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof422
+			goto _test_eof422
 		}
-	stCase422:
+	st_case_422:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -7671,9 +7840,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st423:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof423
+			goto _test_eof423
 		}
-	stCase423:
+	st_case_423:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -7683,9 +7852,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st424:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof424
+			goto _test_eof424
 		}
-	stCase424:
+	st_case_424:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -7695,9 +7864,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st425:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof425
+			goto _test_eof425
 		}
-	stCase425:
+	st_case_425:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -7707,9 +7876,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st426:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof426
+			goto _test_eof426
 		}
-	stCase426:
+	st_case_426:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -7719,9 +7888,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st427:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof427
+			goto _test_eof427
 		}
-	stCase427:
+	st_case_427:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -7731,9 +7900,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st428:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof428
+			goto _test_eof428
 		}
-	stCase428:
+	st_case_428:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -7743,9 +7912,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st429:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof429
+			goto _test_eof429
 		}
-	stCase429:
+	st_case_429:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -7755,9 +7924,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st430:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof430
+			goto _test_eof430
 		}
-	stCase430:
+	st_case_430:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -7767,9 +7936,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st431:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof431
+			goto _test_eof431
 		}
-	stCase431:
+	st_case_431:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -7779,9 +7948,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st432:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof432
+			goto _test_eof432
 		}
-	stCase432:
+	st_case_432:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -7791,9 +7960,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st433:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof433
+			goto _test_eof433
 		}
-	stCase433:
+	st_case_433:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -7803,9 +7972,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st434:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof434
+			goto _test_eof434
 		}
-	stCase434:
+	st_case_434:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -7815,9 +7984,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st435:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof435
+			goto _test_eof435
 		}
-	stCase435:
+	st_case_435:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -7827,9 +7996,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st436:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof436
+			goto _test_eof436
 		}
-	stCase436:
+	st_case_436:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -7839,9 +8008,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st437:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof437
+			goto _test_eof437
 		}
-	stCase437:
+	st_case_437:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -7851,9 +8020,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st438:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof438
+			goto _test_eof438
 		}
-	stCase438:
+	st_case_438:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -7863,9 +8032,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st439:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof439
+			goto _test_eof439
 		}
-	stCase439:
+	st_case_439:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -7875,9 +8044,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st440:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof440
+			goto _test_eof440
 		}
-	stCase440:
+	st_case_440:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -7887,9 +8056,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st441:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof441
+			goto _test_eof441
 		}
-	stCase441:
+	st_case_441:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -7899,9 +8068,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st442:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof442
+			goto _test_eof442
 		}
-	stCase442:
+	st_case_442:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -7911,9 +8080,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st443:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof443
+			goto _test_eof443
 		}
-	stCase443:
+	st_case_443:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -7923,9 +8092,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st444:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof444
+			goto _test_eof444
 		}
-	stCase444:
+	st_case_444:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -7935,9 +8104,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st445:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof445
+			goto _test_eof445
 		}
-	stCase445:
+	st_case_445:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -7947,9 +8116,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st446:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof446
+			goto _test_eof446
 		}
-	stCase446:
+	st_case_446:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -7959,9 +8128,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st447:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof447
+			goto _test_eof447
 		}
-	stCase447:
+	st_case_447:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -7971,9 +8140,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st448:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof448
+			goto _test_eof448
 		}
-	stCase448:
+	st_case_448:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -7983,9 +8152,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st449:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof449
+			goto _test_eof449
 		}
-	stCase449:
+	st_case_449:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -7995,9 +8164,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st450:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof450
+			goto _test_eof450
 		}
-	stCase450:
+	st_case_450:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -8007,9 +8176,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st451:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof451
+			goto _test_eof451
 		}
-	stCase451:
+	st_case_451:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -8019,9 +8188,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st452:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof452
+			goto _test_eof452
 		}
-	stCase452:
+	st_case_452:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -8031,9 +8200,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st453:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof453
+			goto _test_eof453
 		}
-	stCase453:
+	st_case_453:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -8043,9 +8212,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st454:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof454
+			goto _test_eof454
 		}
-	stCase454:
+	st_case_454:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -8055,9 +8224,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st455:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof455
+			goto _test_eof455
 		}
-	stCase455:
+	st_case_455:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -8067,9 +8236,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st456:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof456
+			goto _test_eof456
 		}
-	stCase456:
+	st_case_456:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -8079,9 +8248,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st457:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof457
+			goto _test_eof457
 		}
-	stCase457:
+	st_case_457:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -8091,9 +8260,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st458:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof458
+			goto _test_eof458
 		}
-	stCase458:
+	st_case_458:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -8103,9 +8272,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st459:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof459
+			goto _test_eof459
 		}
-	stCase459:
+	st_case_459:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -8115,9 +8284,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st460:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof460
+			goto _test_eof460
 		}
-	stCase460:
+	st_case_460:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -8127,9 +8296,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st461:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof461
+			goto _test_eof461
 		}
-	stCase461:
+	st_case_461:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -8139,9 +8308,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st462:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof462
+			goto _test_eof462
 		}
-	stCase462:
+	st_case_462:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -8151,9 +8320,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st463:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof463
+			goto _test_eof463
 		}
-	stCase463:
+	st_case_463:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -8163,9 +8332,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st464:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof464
+			goto _test_eof464
 		}
-	stCase464:
+	st_case_464:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -8175,9 +8344,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st465:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof465
+			goto _test_eof465
 		}
-	stCase465:
+	st_case_465:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -8187,9 +8356,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st466:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof466
+			goto _test_eof466
 		}
-	stCase466:
+	st_case_466:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -8199,9 +8368,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st467:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof467
+			goto _test_eof467
 		}
-	stCase467:
+	st_case_467:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -8211,9 +8380,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st468:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof468
+			goto _test_eof468
 		}
-	stCase468:
+	st_case_468:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -8223,9 +8392,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st469:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof469
+			goto _test_eof469
 		}
-	stCase469:
+	st_case_469:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -8235,9 +8404,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st470:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof470
+			goto _test_eof470
 		}
-	stCase470:
+	st_case_470:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -8247,9 +8416,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st471:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof471
+			goto _test_eof471
 		}
-	stCase471:
+	st_case_471:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -8259,9 +8428,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st472:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof472
+			goto _test_eof472
 		}
-	stCase472:
+	st_case_472:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -8271,9 +8440,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st473:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof473
+			goto _test_eof473
 		}
-	stCase473:
+	st_case_473:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -8283,9 +8452,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st474:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof474
+			goto _test_eof474
 		}
-	stCase474:
+	st_case_474:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -8295,9 +8464,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st475:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof475
+			goto _test_eof475
 		}
-	stCase475:
+	st_case_475:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -8307,9 +8476,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st476:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof476
+			goto _test_eof476
 		}
-	stCase476:
+	st_case_476:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -8319,9 +8488,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st477:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof477
+			goto _test_eof477
 		}
-	stCase477:
+	st_case_477:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -8331,9 +8500,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st478:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof478
+			goto _test_eof478
 		}
-	stCase478:
+	st_case_478:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -8343,9 +8512,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st479:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof479
+			goto _test_eof479
 		}
-	stCase479:
+	st_case_479:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -8355,9 +8524,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st480:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof480
+			goto _test_eof480
 		}
-	stCase480:
+	st_case_480:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -8367,9 +8536,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st481:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof481
+			goto _test_eof481
 		}
-	stCase481:
+	st_case_481:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -8379,9 +8548,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st482:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof482
+			goto _test_eof482
 		}
-	stCase482:
+	st_case_482:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -8391,9 +8560,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st483:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof483
+			goto _test_eof483
 		}
-	stCase483:
+	st_case_483:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -8403,9 +8572,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st484:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof484
+			goto _test_eof484
 		}
-	stCase484:
+	st_case_484:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -8415,9 +8584,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st485:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof485
+			goto _test_eof485
 		}
-	stCase485:
+	st_case_485:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -8427,9 +8596,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st486:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof486
+			goto _test_eof486
 		}
-	stCase486:
+	st_case_486:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -8439,9 +8608,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st487:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof487
+			goto _test_eof487
 		}
-	stCase487:
+	st_case_487:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -8451,9 +8620,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st488:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof488
+			goto _test_eof488
 		}
-	stCase488:
+	st_case_488:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -8463,9 +8632,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st489:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof489
+			goto _test_eof489
 		}
-	stCase489:
+	st_case_489:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -8475,9 +8644,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st490:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof490
+			goto _test_eof490
 		}
-	stCase490:
+	st_case_490:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -8487,9 +8656,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st491:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof491
+			goto _test_eof491
 		}
-	stCase491:
+	st_case_491:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -8499,9 +8668,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st492:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof492
+			goto _test_eof492
 		}
-	stCase492:
+	st_case_492:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -8511,9 +8680,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st493:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof493
+			goto _test_eof493
 		}
-	stCase493:
+	st_case_493:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -8523,9 +8692,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st494:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof494
+			goto _test_eof494
 		}
-	stCase494:
+	st_case_494:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -8535,9 +8704,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st495:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof495
+			goto _test_eof495
 		}
-	stCase495:
+	st_case_495:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -8547,9 +8716,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st496:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof496
+			goto _test_eof496
 		}
-	stCase496:
+	st_case_496:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -8559,9 +8728,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st497:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof497
+			goto _test_eof497
 		}
-	stCase497:
+	st_case_497:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -8571,9 +8740,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st498:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof498
+			goto _test_eof498
 		}
-	stCase498:
+	st_case_498:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -8583,9 +8752,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st499:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof499
+			goto _test_eof499
 		}
-	stCase499:
+	st_case_499:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -8595,9 +8764,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st500:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof500
+			goto _test_eof500
 		}
-	stCase500:
+	st_case_500:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -8607,9 +8776,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st501:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof501
+			goto _test_eof501
 		}
-	stCase501:
+	st_case_501:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -8619,9 +8788,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st502:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof502
+			goto _test_eof502
 		}
-	stCase502:
+	st_case_502:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -8631,9 +8800,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st503:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof503
+			goto _test_eof503
 		}
-	stCase503:
+	st_case_503:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -8643,9 +8812,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st504:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof504
+			goto _test_eof504
 		}
-	stCase504:
+	st_case_504:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -8655,9 +8824,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st505:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof505
+			goto _test_eof505
 		}
-	stCase505:
+	st_case_505:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -8667,9 +8836,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st506:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof506
+			goto _test_eof506
 		}
-	stCase506:
+	st_case_506:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -8679,9 +8848,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st507:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof507
+			goto _test_eof507
 		}
-	stCase507:
+	st_case_507:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -8691,9 +8860,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st508:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof508
+			goto _test_eof508
 		}
-	stCase508:
+	st_case_508:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -8703,9 +8872,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st509:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof509
+			goto _test_eof509
 		}
-	stCase509:
+	st_case_509:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -8715,9 +8884,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st510:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof510
+			goto _test_eof510
 		}
-	stCase510:
+	st_case_510:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -8727,9 +8896,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st511:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof511
+			goto _test_eof511
 		}
-	stCase511:
+	st_case_511:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -8739,9 +8908,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st512:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof512
+			goto _test_eof512
 		}
-	stCase512:
+	st_case_512:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -8751,9 +8920,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st513:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof513
+			goto _test_eof513
 		}
-	stCase513:
+	st_case_513:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -8763,9 +8932,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st514:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof514
+			goto _test_eof514
 		}
-	stCase514:
+	st_case_514:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -8775,9 +8944,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st515:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof515
+			goto _test_eof515
 		}
-	stCase515:
+	st_case_515:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -8787,9 +8956,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st516:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof516
+			goto _test_eof516
 		}
-	stCase516:
+	st_case_516:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -8799,9 +8968,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st517:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof517
+			goto _test_eof517
 		}
-	stCase517:
+	st_case_517:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -8811,9 +8980,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st518:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof518
+			goto _test_eof518
 		}
-	stCase518:
+	st_case_518:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -8823,9 +8992,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st519:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof519
+			goto _test_eof519
 		}
-	stCase519:
+	st_case_519:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -8835,9 +9004,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st520:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof520
+			goto _test_eof520
 		}
-	stCase520:
+	st_case_520:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -8847,9 +9016,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st521:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof521
+			goto _test_eof521
 		}
-	stCase521:
+	st_case_521:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -8859,9 +9028,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st522:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof522
+			goto _test_eof522
 		}
-	stCase522:
+	st_case_522:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -8871,9 +9040,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st523:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof523
+			goto _test_eof523
 		}
-	stCase523:
+	st_case_523:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -8883,9 +9052,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st524:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof524
+			goto _test_eof524
 		}
-	stCase524:
+	st_case_524:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -8895,9 +9064,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st525:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof525
+			goto _test_eof525
 		}
-	stCase525:
+	st_case_525:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -8907,9 +9076,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st526:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof526
+			goto _test_eof526
 		}
-	stCase526:
+	st_case_526:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -8919,9 +9088,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st527:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof527
+			goto _test_eof527
 		}
-	stCase527:
+	st_case_527:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -8931,9 +9100,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st528:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof528
+			goto _test_eof528
 		}
-	stCase528:
+	st_case_528:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -8943,9 +9112,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st529:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof529
+			goto _test_eof529
 		}
-	stCase529:
+	st_case_529:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -8955,9 +9124,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st530:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof530
+			goto _test_eof530
 		}
-	stCase530:
+	st_case_530:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -8967,9 +9136,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st531:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof531
+			goto _test_eof531
 		}
-	stCase531:
+	st_case_531:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -8979,9 +9148,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st532:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof532
+			goto _test_eof532
 		}
-	stCase532:
+	st_case_532:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -8991,9 +9160,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st533:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof533
+			goto _test_eof533
 		}
-	stCase533:
+	st_case_533:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -9003,9 +9172,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st534:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof534
+			goto _test_eof534
 		}
-	stCase534:
+	st_case_534:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -9015,9 +9184,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st535:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof535
+			goto _test_eof535
 		}
-	stCase535:
+	st_case_535:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -9027,9 +9196,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st536:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof536
+			goto _test_eof536
 		}
-	stCase536:
+	st_case_536:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -9039,9 +9208,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st537:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof537
+			goto _test_eof537
 		}
-	stCase537:
+	st_case_537:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -9051,9 +9220,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st538:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof538
+			goto _test_eof538
 		}
-	stCase538:
+	st_case_538:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -9063,9 +9232,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st539:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof539
+			goto _test_eof539
 		}
-	stCase539:
+	st_case_539:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -9075,9 +9244,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st540:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof540
+			goto _test_eof540
 		}
-	stCase540:
+	st_case_540:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -9087,9 +9256,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st541:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof541
+			goto _test_eof541
 		}
-	stCase541:
+	st_case_541:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -9099,9 +9268,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st542:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof542
+			goto _test_eof542
 		}
-	stCase542:
+	st_case_542:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -9111,9 +9280,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st543:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof543
+			goto _test_eof543
 		}
-	stCase543:
+	st_case_543:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -9123,9 +9292,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st544:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof544
+			goto _test_eof544
 		}
-	stCase544:
+	st_case_544:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -9135,9 +9304,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st545:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof545
+			goto _test_eof545
 		}
-	stCase545:
+	st_case_545:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -9147,9 +9316,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st546:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof546
+			goto _test_eof546
 		}
-	stCase546:
+	st_case_546:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -9159,9 +9328,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st547:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof547
+			goto _test_eof547
 		}
-	stCase547:
+	st_case_547:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -9171,9 +9340,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st548:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof548
+			goto _test_eof548
 		}
-	stCase548:
+	st_case_548:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -9183,9 +9352,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st549:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof549
+			goto _test_eof549
 		}
-	stCase549:
+	st_case_549:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -9195,9 +9364,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st550:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof550
+			goto _test_eof550
 		}
-	stCase550:
+	st_case_550:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -9207,9 +9376,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st551:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof551
+			goto _test_eof551
 		}
-	stCase551:
+	st_case_551:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -9219,9 +9388,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st552:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof552
+			goto _test_eof552
 		}
-	stCase552:
+	st_case_552:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -9231,9 +9400,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st553:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof553
+			goto _test_eof553
 		}
-	stCase553:
+	st_case_553:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -9243,9 +9412,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st554:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof554
+			goto _test_eof554
 		}
-	stCase554:
+	st_case_554:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -9255,9 +9424,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st555:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof555
+			goto _test_eof555
 		}
-	stCase555:
+	st_case_555:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -9267,9 +9436,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st556:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof556
+			goto _test_eof556
 		}
-	stCase556:
+	st_case_556:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -9279,9 +9448,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st557:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof557
+			goto _test_eof557
 		}
-	stCase557:
+	st_case_557:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -9291,9 +9460,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st558:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof558
+			goto _test_eof558
 		}
-	stCase558:
+	st_case_558:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -9303,9 +9472,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st559:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof559
+			goto _test_eof559
 		}
-	stCase559:
+	st_case_559:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
@@ -9315,59 +9484,61 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr16
 	st560:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof560
+			goto _test_eof560
 		}
-	stCase560:
+	st_case_560:
 		if (m.data)[(m.p)] == 32 {
 			goto tr18
 		}
 		goto tr16
 	tr14:
+//line rfc5424/machine.go.rl:58
 
 		m.pb = m.p
 
 		goto st561
 	st561:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof561
+			goto _test_eof561
 		}
-	stCase561:
+	st_case_561:
+//line rfc5424/machine.go:9437
 		if 48 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 57 {
 			goto st562
 		}
 		goto tr12
 	st562:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof562
+			goto _test_eof562
 		}
-	stCase562:
+	st_case_562:
 		if 48 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 57 {
 			goto st563
 		}
 		goto tr12
 	st563:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof563
+			goto _test_eof563
 		}
-	stCase563:
+	st_case_563:
 		if 48 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 57 {
 			goto st564
 		}
 		goto tr12
 	st564:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof564
+			goto _test_eof564
 		}
-	stCase564:
+	st_case_564:
 		if (m.data)[(m.p)] == 45 {
 			goto st565
 		}
 		goto tr12
 	st565:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof565
+			goto _test_eof565
 		}
-	stCase565:
+	st_case_565:
 		switch (m.data)[(m.p)] {
 		case 48:
 			goto st566
@@ -9377,27 +9548,27 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr12
 	st566:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof566
+			goto _test_eof566
 		}
-	stCase566:
+	st_case_566:
 		if 49 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 57 {
 			goto st567
 		}
 		goto tr12
 	st567:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof567
+			goto _test_eof567
 		}
-	stCase567:
+	st_case_567:
 		if (m.data)[(m.p)] == 45 {
 			goto st568
 		}
 		goto tr12
 	st568:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof568
+			goto _test_eof568
 		}
-	stCase568:
+	st_case_568:
 		switch (m.data)[(m.p)] {
 		case 48:
 			goto st569
@@ -9410,27 +9581,27 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr12
 	st569:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof569
+			goto _test_eof569
 		}
-	stCase569:
+	st_case_569:
 		if 49 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 57 {
 			goto st570
 		}
 		goto tr12
 	st570:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof570
+			goto _test_eof570
 		}
-	stCase570:
+	st_case_570:
 		if (m.data)[(m.p)] == 84 {
 			goto st571
 		}
 		goto tr12
 	st571:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof571
+			goto _test_eof571
 		}
-	stCase571:
+	st_case_571:
 		if (m.data)[(m.p)] == 50 {
 			goto st594
 		}
@@ -9440,72 +9611,72 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr12
 	st572:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof572
+			goto _test_eof572
 		}
-	stCase572:
+	st_case_572:
 		if 48 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 57 {
 			goto st573
 		}
 		goto tr12
 	st573:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof573
+			goto _test_eof573
 		}
-	stCase573:
+	st_case_573:
 		if (m.data)[(m.p)] == 58 {
 			goto st574
 		}
 		goto tr12
 	st574:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof574
+			goto _test_eof574
 		}
-	stCase574:
+	st_case_574:
 		if 48 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 53 {
 			goto st575
 		}
 		goto tr12
 	st575:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof575
+			goto _test_eof575
 		}
-	stCase575:
+	st_case_575:
 		if 48 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 57 {
 			goto st576
 		}
 		goto tr12
 	st576:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof576
+			goto _test_eof576
 		}
-	stCase576:
+	st_case_576:
 		if (m.data)[(m.p)] == 58 {
 			goto st577
 		}
 		goto tr12
 	st577:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof577
+			goto _test_eof577
 		}
-	stCase577:
+	st_case_577:
 		if 48 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 53 {
 			goto st578
 		}
 		goto tr12
 	st578:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof578
+			goto _test_eof578
 		}
-	stCase578:
+	st_case_578:
 		if 48 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 57 {
 			goto st579
 		}
 		goto tr12
 	st579:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof579
+			goto _test_eof579
 		}
-	stCase579:
+	st_case_579:
 		switch (m.data)[(m.p)] {
 		case 43:
 			goto st580
@@ -9519,9 +9690,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr12
 	st580:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof580
+			goto _test_eof580
 		}
-	stCase580:
+	st_case_580:
 		if (m.data)[(m.p)] == 50 {
 			goto st586
 		}
@@ -9531,72 +9702,72 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr12
 	st581:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof581
+			goto _test_eof581
 		}
-	stCase581:
+	st_case_581:
 		if 48 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 57 {
 			goto st582
 		}
 		goto tr12
 	st582:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof582
+			goto _test_eof582
 		}
-	stCase582:
+	st_case_582:
 		if (m.data)[(m.p)] == 58 {
 			goto st583
 		}
 		goto tr12
 	st583:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof583
+			goto _test_eof583
 		}
-	stCase583:
+	st_case_583:
 		if 48 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 53 {
 			goto st584
 		}
 		goto tr12
 	st584:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof584
+			goto _test_eof584
 		}
-	stCase584:
+	st_case_584:
 		if 48 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 57 {
 			goto st585
 		}
 		goto tr12
 	st585:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof585
+			goto _test_eof585
 		}
-	stCase585:
+	st_case_585:
 		if (m.data)[(m.p)] == 32 {
 			goto tr620
 		}
 		goto tr619
 	st586:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof586
+			goto _test_eof586
 		}
-	stCase586:
+	st_case_586:
 		if 48 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 51 {
 			goto st582
 		}
 		goto tr12
 	st587:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof587
+			goto _test_eof587
 		}
-	stCase587:
+	st_case_587:
 		if 48 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 57 {
 			goto st588
 		}
 		goto tr12
 	st588:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof588
+			goto _test_eof588
 		}
-	stCase588:
+	st_case_588:
 		switch (m.data)[(m.p)] {
 		case 43:
 			goto st580
@@ -9611,9 +9782,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr12
 	st589:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof589
+			goto _test_eof589
 		}
-	stCase589:
+	st_case_589:
 		switch (m.data)[(m.p)] {
 		case 43:
 			goto st580
@@ -9628,9 +9799,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr12
 	st590:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof590
+			goto _test_eof590
 		}
-	stCase590:
+	st_case_590:
 		switch (m.data)[(m.p)] {
 		case 43:
 			goto st580
@@ -9645,9 +9816,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr12
 	st591:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof591
+			goto _test_eof591
 		}
-	stCase591:
+	st_case_591:
 		switch (m.data)[(m.p)] {
 		case 43:
 			goto st580
@@ -9662,9 +9833,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr12
 	st592:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof592
+			goto _test_eof592
 		}
-	stCase592:
+	st_case_592:
 		switch (m.data)[(m.p)] {
 		case 43:
 			goto st580
@@ -9679,9 +9850,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr12
 	st593:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof593
+			goto _test_eof593
 		}
-	stCase593:
+	st_case_593:
 		switch (m.data)[(m.p)] {
 		case 43:
 			goto st580
@@ -9693,48 +9864,50 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr12
 	st594:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof594
+			goto _test_eof594
 		}
-	stCase594:
+	st_case_594:
 		if 48 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 51 {
 			goto st573
 		}
 		goto tr12
 	st595:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof595
+			goto _test_eof595
 		}
-	stCase595:
+	st_case_595:
 		if 48 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 57 {
 			goto st570
 		}
 		goto tr12
 	st596:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof596
+			goto _test_eof596
 		}
-	stCase596:
+	st_case_596:
 		if 48 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 49 {
 			goto st570
 		}
 		goto tr12
 	st597:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof597
+			goto _test_eof597
 		}
-	stCase597:
+	st_case_597:
 		if 48 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 50 {
 			goto st567
 		}
 		goto tr12
 	st598:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof598
+			goto _test_eof598
 		}
-	stCase598:
+	st_case_598:
+//line rfc5424/machine.go.rl:71
 
 		output.version = uint16(common.UnsafeUTF8DecimalCodePointsToInt(m.text()))
 
+//line rfc5424/machine.go:9842
 		if (m.data)[(m.p)] == 32 {
 			goto st6
 		}
@@ -9744,30 +9917,35 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr7
 	st599:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof599
+			goto _test_eof599
 		}
-	stCase599:
+	st_case_599:
+//line rfc5424/machine.go.rl:71
 
 		output.version = uint16(common.UnsafeUTF8DecimalCodePointsToInt(m.text()))
 
+//line rfc5424/machine.go:9859
 		if (m.data)[(m.p)] == 32 {
 			goto st6
 		}
 		goto tr7
 	tr4:
+//line rfc5424/machine.go.rl:58
 
 		m.pb = m.p
 
 		goto st600
 	st600:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof600
+			goto _test_eof600
 		}
-	stCase600:
+	st_case_600:
+//line rfc5424/machine.go.rl:66
 
 		output.priority = uint8(common.UnsafeUTF8DecimalCodePointsToInt(m.text()))
 		output.prioritySet = true
 
+//line rfc5424/machine.go:9880
 		switch (m.data)[(m.p)] {
 		case 57:
 			goto st602
@@ -9779,19 +9957,22 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		}
 		goto tr2
 	tr5:
+//line rfc5424/machine.go.rl:58
 
 		m.pb = m.p
 
 		goto st601
 	st601:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof601
+			goto _test_eof601
 		}
-	stCase601:
+	st_case_601:
+//line rfc5424/machine.go.rl:66
 
 		output.priority = uint8(common.UnsafeUTF8DecimalCodePointsToInt(m.text()))
 		output.prioritySet = true
 
+//line rfc5424/machine.go:9907
 		if (m.data)[(m.p)] == 62 {
 			goto st4
 		}
@@ -9801,13 +9982,15 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr2
 	st602:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof602
+			goto _test_eof602
 		}
-	stCase602:
+	st_case_602:
+//line rfc5424/machine.go.rl:66
 
 		output.priority = uint8(common.UnsafeUTF8DecimalCodePointsToInt(m.text()))
 		output.prioritySet = true
 
+//line rfc5424/machine.go:9925
 		if (m.data)[(m.p)] == 62 {
 			goto st4
 		}
@@ -9817,9 +10000,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		goto tr2
 	st607:
 		if (m.p)++; (m.p) == (m.pe) {
-			goto _testEof607
+			goto _test_eof607
 		}
-	stCase607:
+	st_case_607:
 		switch (m.data)[(m.p)] {
 		case 10:
 			goto st0
@@ -9827,1836 +10010,1838 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 			goto st0
 		}
 		goto st607
-	stOut:
-	_testEof2:
+	st_out:
+	_test_eof2:
 		m.cs = 2
-		goto _testEof
-	_testEof3:
+		goto _test_eof
+	_test_eof3:
 		m.cs = 3
-		goto _testEof
-	_testEof4:
+		goto _test_eof
+	_test_eof4:
 		m.cs = 4
-		goto _testEof
-	_testEof5:
+		goto _test_eof
+	_test_eof5:
 		m.cs = 5
-		goto _testEof
-	_testEof6:
+		goto _test_eof
+	_test_eof6:
 		m.cs = 6
-		goto _testEof
-	_testEof7:
+		goto _test_eof
+	_test_eof7:
 		m.cs = 7
-		goto _testEof
-	_testEof8:
+		goto _test_eof
+	_test_eof8:
 		m.cs = 8
-		goto _testEof
-	_testEof9:
+		goto _test_eof
+	_test_eof9:
 		m.cs = 9
-		goto _testEof
-	_testEof10:
+		goto _test_eof
+	_test_eof10:
 		m.cs = 10
-		goto _testEof
-	_testEof11:
+		goto _test_eof
+	_test_eof11:
 		m.cs = 11
-		goto _testEof
-	_testEof12:
+		goto _test_eof
+	_test_eof12:
 		m.cs = 12
-		goto _testEof
-	_testEof13:
+		goto _test_eof
+	_test_eof13:
 		m.cs = 13
-		goto _testEof
-	_testEof14:
+		goto _test_eof
+	_test_eof14:
 		m.cs = 14
-		goto _testEof
-	_testEof15:
+		goto _test_eof
+	_test_eof15:
 		m.cs = 15
-		goto _testEof
-	_testEof16:
+		goto _test_eof
+	_test_eof16:
 		m.cs = 16
-		goto _testEof
-	_testEof603:
+		goto _test_eof
+	_test_eof603:
 		m.cs = 603
-		goto _testEof
-	_testEof604:
+		goto _test_eof
+	_test_eof604:
 		m.cs = 604
-		goto _testEof
-	_testEof605:
+		goto _test_eof
+	_test_eof605:
 		m.cs = 605
-		goto _testEof
-	_testEof17:
+		goto _test_eof
+	_test_eof17:
 		m.cs = 17
-		goto _testEof
-	_testEof18:
+		goto _test_eof
+	_test_eof18:
 		m.cs = 18
-		goto _testEof
-	_testEof19:
+		goto _test_eof
+	_test_eof19:
 		m.cs = 19
-		goto _testEof
-	_testEof20:
+		goto _test_eof
+	_test_eof20:
 		m.cs = 20
-		goto _testEof
-	_testEof21:
+		goto _test_eof
+	_test_eof21:
 		m.cs = 21
-		goto _testEof
-	_testEof22:
+		goto _test_eof
+	_test_eof22:
 		m.cs = 22
-		goto _testEof
-	_testEof23:
+		goto _test_eof
+	_test_eof23:
 		m.cs = 23
-		goto _testEof
-	_testEof24:
+		goto _test_eof
+	_test_eof24:
 		m.cs = 24
-		goto _testEof
-	_testEof25:
+		goto _test_eof
+	_test_eof25:
 		m.cs = 25
-		goto _testEof
-	_testEof26:
+		goto _test_eof
+	_test_eof26:
 		m.cs = 26
-		goto _testEof
-	_testEof27:
+		goto _test_eof
+	_test_eof27:
 		m.cs = 27
-		goto _testEof
-	_testEof28:
+		goto _test_eof
+	_test_eof28:
 		m.cs = 28
-		goto _testEof
-	_testEof29:
+		goto _test_eof
+	_test_eof29:
 		m.cs = 29
-		goto _testEof
-	_testEof30:
+		goto _test_eof
+	_test_eof30:
 		m.cs = 30
-		goto _testEof
-	_testEof31:
+		goto _test_eof
+	_test_eof31:
 		m.cs = 31
-		goto _testEof
-	_testEof32:
+		goto _test_eof
+	_test_eof32:
 		m.cs = 32
-		goto _testEof
-	_testEof33:
+		goto _test_eof
+	_test_eof33:
 		m.cs = 33
-		goto _testEof
-	_testEof34:
+		goto _test_eof
+	_test_eof34:
 		m.cs = 34
-		goto _testEof
-	_testEof35:
+		goto _test_eof
+	_test_eof35:
 		m.cs = 35
-		goto _testEof
-	_testEof36:
+		goto _test_eof
+	_test_eof36:
 		m.cs = 36
-		goto _testEof
-	_testEof37:
+		goto _test_eof
+	_test_eof37:
 		m.cs = 37
-		goto _testEof
-	_testEof38:
+		goto _test_eof
+	_test_eof38:
 		m.cs = 38
-		goto _testEof
-	_testEof39:
+		goto _test_eof
+	_test_eof39:
 		m.cs = 39
-		goto _testEof
-	_testEof40:
+		goto _test_eof
+	_test_eof40:
 		m.cs = 40
-		goto _testEof
-	_testEof41:
+		goto _test_eof
+	_test_eof41:
 		m.cs = 41
-		goto _testEof
-	_testEof42:
+		goto _test_eof
+	_test_eof42:
 		m.cs = 42
-		goto _testEof
-	_testEof43:
+		goto _test_eof
+	_test_eof43:
 		m.cs = 43
-		goto _testEof
-	_testEof44:
+		goto _test_eof
+	_test_eof44:
 		m.cs = 44
-		goto _testEof
-	_testEof45:
+		goto _test_eof
+	_test_eof45:
 		m.cs = 45
-		goto _testEof
-	_testEof46:
+		goto _test_eof
+	_test_eof46:
 		m.cs = 46
-		goto _testEof
-	_testEof47:
+		goto _test_eof
+	_test_eof47:
 		m.cs = 47
-		goto _testEof
-	_testEof48:
+		goto _test_eof
+	_test_eof48:
 		m.cs = 48
-		goto _testEof
-	_testEof49:
+		goto _test_eof
+	_test_eof49:
 		m.cs = 49
-		goto _testEof
-	_testEof50:
+		goto _test_eof
+	_test_eof50:
 		m.cs = 50
-		goto _testEof
-	_testEof51:
+		goto _test_eof
+	_test_eof51:
 		m.cs = 51
-		goto _testEof
-	_testEof52:
+		goto _test_eof
+	_test_eof52:
 		m.cs = 52
-		goto _testEof
-	_testEof53:
+		goto _test_eof
+	_test_eof53:
 		m.cs = 53
-		goto _testEof
-	_testEof54:
+		goto _test_eof
+	_test_eof54:
 		m.cs = 54
-		goto _testEof
-	_testEof55:
+		goto _test_eof
+	_test_eof55:
 		m.cs = 55
-		goto _testEof
-	_testEof56:
+		goto _test_eof
+	_test_eof56:
 		m.cs = 56
-		goto _testEof
-	_testEof57:
+		goto _test_eof
+	_test_eof57:
 		m.cs = 57
-		goto _testEof
-	_testEof58:
+		goto _test_eof
+	_test_eof58:
 		m.cs = 58
-		goto _testEof
-	_testEof59:
+		goto _test_eof
+	_test_eof59:
 		m.cs = 59
-		goto _testEof
-	_testEof60:
+		goto _test_eof
+	_test_eof60:
 		m.cs = 60
-		goto _testEof
-	_testEof61:
+		goto _test_eof
+	_test_eof61:
 		m.cs = 61
-		goto _testEof
-	_testEof62:
+		goto _test_eof
+	_test_eof62:
 		m.cs = 62
-		goto _testEof
-	_testEof606:
+		goto _test_eof
+	_test_eof606:
 		m.cs = 606
-		goto _testEof
-	_testEof63:
+		goto _test_eof
+	_test_eof63:
 		m.cs = 63
-		goto _testEof
-	_testEof64:
+		goto _test_eof
+	_test_eof64:
 		m.cs = 64
-		goto _testEof
-	_testEof65:
+		goto _test_eof
+	_test_eof65:
 		m.cs = 65
-		goto _testEof
-	_testEof66:
+		goto _test_eof
+	_test_eof66:
 		m.cs = 66
-		goto _testEof
-	_testEof67:
+		goto _test_eof
+	_test_eof67:
 		m.cs = 67
-		goto _testEof
-	_testEof68:
+		goto _test_eof
+	_test_eof68:
 		m.cs = 68
-		goto _testEof
-	_testEof69:
+		goto _test_eof
+	_test_eof69:
 		m.cs = 69
-		goto _testEof
-	_testEof70:
+		goto _test_eof
+	_test_eof70:
 		m.cs = 70
-		goto _testEof
-	_testEof71:
+		goto _test_eof
+	_test_eof71:
 		m.cs = 71
-		goto _testEof
-	_testEof72:
+		goto _test_eof
+	_test_eof72:
 		m.cs = 72
-		goto _testEof
-	_testEof73:
+		goto _test_eof
+	_test_eof73:
 		m.cs = 73
-		goto _testEof
-	_testEof74:
+		goto _test_eof
+	_test_eof74:
 		m.cs = 74
-		goto _testEof
-	_testEof75:
+		goto _test_eof
+	_test_eof75:
 		m.cs = 75
-		goto _testEof
-	_testEof76:
+		goto _test_eof
+	_test_eof76:
 		m.cs = 76
-		goto _testEof
-	_testEof77:
+		goto _test_eof
+	_test_eof77:
 		m.cs = 77
-		goto _testEof
-	_testEof78:
+		goto _test_eof
+	_test_eof78:
 		m.cs = 78
-		goto _testEof
-	_testEof79:
+		goto _test_eof
+	_test_eof79:
 		m.cs = 79
-		goto _testEof
-	_testEof80:
+		goto _test_eof
+	_test_eof80:
 		m.cs = 80
-		goto _testEof
-	_testEof81:
+		goto _test_eof
+	_test_eof81:
 		m.cs = 81
-		goto _testEof
-	_testEof82:
+		goto _test_eof
+	_test_eof82:
 		m.cs = 82
-		goto _testEof
-	_testEof83:
+		goto _test_eof
+	_test_eof83:
 		m.cs = 83
-		goto _testEof
-	_testEof84:
+		goto _test_eof
+	_test_eof84:
 		m.cs = 84
-		goto _testEof
-	_testEof85:
+		goto _test_eof
+	_test_eof85:
 		m.cs = 85
-		goto _testEof
-	_testEof86:
+		goto _test_eof
+	_test_eof86:
 		m.cs = 86
-		goto _testEof
-	_testEof87:
+		goto _test_eof
+	_test_eof87:
 		m.cs = 87
-		goto _testEof
-	_testEof88:
+		goto _test_eof
+	_test_eof88:
 		m.cs = 88
-		goto _testEof
-	_testEof89:
+		goto _test_eof
+	_test_eof89:
 		m.cs = 89
-		goto _testEof
-	_testEof90:
+		goto _test_eof
+	_test_eof90:
 		m.cs = 90
-		goto _testEof
-	_testEof91:
+		goto _test_eof
+	_test_eof91:
 		m.cs = 91
-		goto _testEof
-	_testEof92:
+		goto _test_eof
+	_test_eof92:
 		m.cs = 92
-		goto _testEof
-	_testEof93:
+		goto _test_eof
+	_test_eof93:
 		m.cs = 93
-		goto _testEof
-	_testEof94:
+		goto _test_eof
+	_test_eof94:
 		m.cs = 94
-		goto _testEof
-	_testEof95:
+		goto _test_eof
+	_test_eof95:
 		m.cs = 95
-		goto _testEof
-	_testEof96:
+		goto _test_eof
+	_test_eof96:
 		m.cs = 96
-		goto _testEof
-	_testEof97:
+		goto _test_eof
+	_test_eof97:
 		m.cs = 97
-		goto _testEof
-	_testEof98:
+		goto _test_eof
+	_test_eof98:
 		m.cs = 98
-		goto _testEof
-	_testEof99:
+		goto _test_eof
+	_test_eof99:
 		m.cs = 99
-		goto _testEof
-	_testEof100:
+		goto _test_eof
+	_test_eof100:
 		m.cs = 100
-		goto _testEof
-	_testEof101:
+		goto _test_eof
+	_test_eof101:
 		m.cs = 101
-		goto _testEof
-	_testEof102:
+		goto _test_eof
+	_test_eof102:
 		m.cs = 102
-		goto _testEof
-	_testEof103:
+		goto _test_eof
+	_test_eof103:
 		m.cs = 103
-		goto _testEof
-	_testEof104:
+		goto _test_eof
+	_test_eof104:
 		m.cs = 104
-		goto _testEof
-	_testEof105:
+		goto _test_eof
+	_test_eof105:
 		m.cs = 105
-		goto _testEof
-	_testEof106:
+		goto _test_eof
+	_test_eof106:
 		m.cs = 106
-		goto _testEof
-	_testEof107:
+		goto _test_eof
+	_test_eof107:
 		m.cs = 107
-		goto _testEof
-	_testEof108:
+		goto _test_eof
+	_test_eof108:
 		m.cs = 108
-		goto _testEof
-	_testEof109:
+		goto _test_eof
+	_test_eof109:
 		m.cs = 109
-		goto _testEof
-	_testEof110:
+		goto _test_eof
+	_test_eof110:
 		m.cs = 110
-		goto _testEof
-	_testEof111:
+		goto _test_eof
+	_test_eof111:
 		m.cs = 111
-		goto _testEof
-	_testEof112:
+		goto _test_eof
+	_test_eof112:
 		m.cs = 112
-		goto _testEof
-	_testEof113:
+		goto _test_eof
+	_test_eof113:
 		m.cs = 113
-		goto _testEof
-	_testEof114:
+		goto _test_eof
+	_test_eof114:
 		m.cs = 114
-		goto _testEof
-	_testEof115:
+		goto _test_eof
+	_test_eof115:
 		m.cs = 115
-		goto _testEof
-	_testEof116:
+		goto _test_eof
+	_test_eof116:
 		m.cs = 116
-		goto _testEof
-	_testEof117:
+		goto _test_eof
+	_test_eof117:
 		m.cs = 117
-		goto _testEof
-	_testEof118:
+		goto _test_eof
+	_test_eof118:
 		m.cs = 118
-		goto _testEof
-	_testEof119:
+		goto _test_eof
+	_test_eof119:
 		m.cs = 119
-		goto _testEof
-	_testEof120:
+		goto _test_eof
+	_test_eof120:
 		m.cs = 120
-		goto _testEof
-	_testEof121:
+		goto _test_eof
+	_test_eof121:
 		m.cs = 121
-		goto _testEof
-	_testEof122:
+		goto _test_eof
+	_test_eof122:
 		m.cs = 122
-		goto _testEof
-	_testEof123:
+		goto _test_eof
+	_test_eof123:
 		m.cs = 123
-		goto _testEof
-	_testEof124:
+		goto _test_eof
+	_test_eof124:
 		m.cs = 124
-		goto _testEof
-	_testEof125:
+		goto _test_eof
+	_test_eof125:
 		m.cs = 125
-		goto _testEof
-	_testEof126:
+		goto _test_eof
+	_test_eof126:
 		m.cs = 126
-		goto _testEof
-	_testEof127:
+		goto _test_eof
+	_test_eof127:
 		m.cs = 127
-		goto _testEof
-	_testEof128:
+		goto _test_eof
+	_test_eof128:
 		m.cs = 128
-		goto _testEof
-	_testEof129:
+		goto _test_eof
+	_test_eof129:
 		m.cs = 129
-		goto _testEof
-	_testEof130:
+		goto _test_eof
+	_test_eof130:
 		m.cs = 130
-		goto _testEof
-	_testEof131:
+		goto _test_eof
+	_test_eof131:
 		m.cs = 131
-		goto _testEof
-	_testEof132:
+		goto _test_eof
+	_test_eof132:
 		m.cs = 132
-		goto _testEof
-	_testEof133:
+		goto _test_eof
+	_test_eof133:
 		m.cs = 133
-		goto _testEof
-	_testEof134:
+		goto _test_eof
+	_test_eof134:
 		m.cs = 134
-		goto _testEof
-	_testEof135:
+		goto _test_eof
+	_test_eof135:
 		m.cs = 135
-		goto _testEof
-	_testEof136:
+		goto _test_eof
+	_test_eof136:
 		m.cs = 136
-		goto _testEof
-	_testEof137:
+		goto _test_eof
+	_test_eof137:
 		m.cs = 137
-		goto _testEof
-	_testEof138:
+		goto _test_eof
+	_test_eof138:
 		m.cs = 138
-		goto _testEof
-	_testEof139:
+		goto _test_eof
+	_test_eof139:
 		m.cs = 139
-		goto _testEof
-	_testEof140:
+		goto _test_eof
+	_test_eof140:
 		m.cs = 140
-		goto _testEof
-	_testEof141:
+		goto _test_eof
+	_test_eof141:
 		m.cs = 141
-		goto _testEof
-	_testEof142:
+		goto _test_eof
+	_test_eof142:
 		m.cs = 142
-		goto _testEof
-	_testEof143:
+		goto _test_eof
+	_test_eof143:
 		m.cs = 143
-		goto _testEof
-	_testEof144:
+		goto _test_eof
+	_test_eof144:
 		m.cs = 144
-		goto _testEof
-	_testEof145:
+		goto _test_eof
+	_test_eof145:
 		m.cs = 145
-		goto _testEof
-	_testEof146:
+		goto _test_eof
+	_test_eof146:
 		m.cs = 146
-		goto _testEof
-	_testEof147:
+		goto _test_eof
+	_test_eof147:
 		m.cs = 147
-		goto _testEof
-	_testEof148:
+		goto _test_eof
+	_test_eof148:
 		m.cs = 148
-		goto _testEof
-	_testEof149:
+		goto _test_eof
+	_test_eof149:
 		m.cs = 149
-		goto _testEof
-	_testEof150:
+		goto _test_eof
+	_test_eof150:
 		m.cs = 150
-		goto _testEof
-	_testEof151:
+		goto _test_eof
+	_test_eof151:
 		m.cs = 151
-		goto _testEof
-	_testEof152:
+		goto _test_eof
+	_test_eof152:
 		m.cs = 152
-		goto _testEof
-	_testEof153:
+		goto _test_eof
+	_test_eof153:
 		m.cs = 153
-		goto _testEof
-	_testEof154:
+		goto _test_eof
+	_test_eof154:
 		m.cs = 154
-		goto _testEof
-	_testEof155:
+		goto _test_eof
+	_test_eof155:
 		m.cs = 155
-		goto _testEof
-	_testEof156:
+		goto _test_eof
+	_test_eof156:
 		m.cs = 156
-		goto _testEof
-	_testEof157:
+		goto _test_eof
+	_test_eof157:
 		m.cs = 157
-		goto _testEof
-	_testEof158:
+		goto _test_eof
+	_test_eof158:
 		m.cs = 158
-		goto _testEof
-	_testEof159:
+		goto _test_eof
+	_test_eof159:
 		m.cs = 159
-		goto _testEof
-	_testEof160:
+		goto _test_eof
+	_test_eof160:
 		m.cs = 160
-		goto _testEof
-	_testEof161:
+		goto _test_eof
+	_test_eof161:
 		m.cs = 161
-		goto _testEof
-	_testEof162:
+		goto _test_eof
+	_test_eof162:
 		m.cs = 162
-		goto _testEof
-	_testEof163:
+		goto _test_eof
+	_test_eof163:
 		m.cs = 163
-		goto _testEof
-	_testEof164:
+		goto _test_eof
+	_test_eof164:
 		m.cs = 164
-		goto _testEof
-	_testEof165:
+		goto _test_eof
+	_test_eof165:
 		m.cs = 165
-		goto _testEof
-	_testEof166:
+		goto _test_eof
+	_test_eof166:
 		m.cs = 166
-		goto _testEof
-	_testEof167:
+		goto _test_eof
+	_test_eof167:
 		m.cs = 167
-		goto _testEof
-	_testEof168:
+		goto _test_eof
+	_test_eof168:
 		m.cs = 168
-		goto _testEof
-	_testEof169:
+		goto _test_eof
+	_test_eof169:
 		m.cs = 169
-		goto _testEof
-	_testEof170:
+		goto _test_eof
+	_test_eof170:
 		m.cs = 170
-		goto _testEof
-	_testEof171:
+		goto _test_eof
+	_test_eof171:
 		m.cs = 171
-		goto _testEof
-	_testEof172:
+		goto _test_eof
+	_test_eof172:
 		m.cs = 172
-		goto _testEof
-	_testEof173:
+		goto _test_eof
+	_test_eof173:
 		m.cs = 173
-		goto _testEof
-	_testEof174:
+		goto _test_eof
+	_test_eof174:
 		m.cs = 174
-		goto _testEof
-	_testEof175:
+		goto _test_eof
+	_test_eof175:
 		m.cs = 175
-		goto _testEof
-	_testEof176:
+		goto _test_eof
+	_test_eof176:
 		m.cs = 176
-		goto _testEof
-	_testEof177:
+		goto _test_eof
+	_test_eof177:
 		m.cs = 177
-		goto _testEof
-	_testEof178:
+		goto _test_eof
+	_test_eof178:
 		m.cs = 178
-		goto _testEof
-	_testEof179:
+		goto _test_eof
+	_test_eof179:
 		m.cs = 179
-		goto _testEof
-	_testEof180:
+		goto _test_eof
+	_test_eof180:
 		m.cs = 180
-		goto _testEof
-	_testEof181:
+		goto _test_eof
+	_test_eof181:
 		m.cs = 181
-		goto _testEof
-	_testEof182:
+		goto _test_eof
+	_test_eof182:
 		m.cs = 182
-		goto _testEof
-	_testEof183:
+		goto _test_eof
+	_test_eof183:
 		m.cs = 183
-		goto _testEof
-	_testEof184:
+		goto _test_eof
+	_test_eof184:
 		m.cs = 184
-		goto _testEof
-	_testEof185:
+		goto _test_eof
+	_test_eof185:
 		m.cs = 185
-		goto _testEof
-	_testEof186:
+		goto _test_eof
+	_test_eof186:
 		m.cs = 186
-		goto _testEof
-	_testEof187:
+		goto _test_eof
+	_test_eof187:
 		m.cs = 187
-		goto _testEof
-	_testEof188:
+		goto _test_eof
+	_test_eof188:
 		m.cs = 188
-		goto _testEof
-	_testEof189:
+		goto _test_eof
+	_test_eof189:
 		m.cs = 189
-		goto _testEof
-	_testEof190:
+		goto _test_eof
+	_test_eof190:
 		m.cs = 190
-		goto _testEof
-	_testEof191:
+		goto _test_eof
+	_test_eof191:
 		m.cs = 191
-		goto _testEof
-	_testEof192:
+		goto _test_eof
+	_test_eof192:
 		m.cs = 192
-		goto _testEof
-	_testEof193:
+		goto _test_eof
+	_test_eof193:
 		m.cs = 193
-		goto _testEof
-	_testEof194:
+		goto _test_eof
+	_test_eof194:
 		m.cs = 194
-		goto _testEof
-	_testEof195:
+		goto _test_eof
+	_test_eof195:
 		m.cs = 195
-		goto _testEof
-	_testEof196:
+		goto _test_eof
+	_test_eof196:
 		m.cs = 196
-		goto _testEof
-	_testEof197:
+		goto _test_eof
+	_test_eof197:
 		m.cs = 197
-		goto _testEof
-	_testEof198:
+		goto _test_eof
+	_test_eof198:
 		m.cs = 198
-		goto _testEof
-	_testEof199:
+		goto _test_eof
+	_test_eof199:
 		m.cs = 199
-		goto _testEof
-	_testEof200:
+		goto _test_eof
+	_test_eof200:
 		m.cs = 200
-		goto _testEof
-	_testEof201:
+		goto _test_eof
+	_test_eof201:
 		m.cs = 201
-		goto _testEof
-	_testEof202:
+		goto _test_eof
+	_test_eof202:
 		m.cs = 202
-		goto _testEof
-	_testEof203:
+		goto _test_eof
+	_test_eof203:
 		m.cs = 203
-		goto _testEof
-	_testEof204:
+		goto _test_eof
+	_test_eof204:
 		m.cs = 204
-		goto _testEof
-	_testEof205:
+		goto _test_eof
+	_test_eof205:
 		m.cs = 205
-		goto _testEof
-	_testEof206:
+		goto _test_eof
+	_test_eof206:
 		m.cs = 206
-		goto _testEof
-	_testEof207:
+		goto _test_eof
+	_test_eof207:
 		m.cs = 207
-		goto _testEof
-	_testEof208:
+		goto _test_eof
+	_test_eof208:
 		m.cs = 208
-		goto _testEof
-	_testEof209:
+		goto _test_eof
+	_test_eof209:
 		m.cs = 209
-		goto _testEof
-	_testEof210:
+		goto _test_eof
+	_test_eof210:
 		m.cs = 210
-		goto _testEof
-	_testEof211:
+		goto _test_eof
+	_test_eof211:
 		m.cs = 211
-		goto _testEof
-	_testEof212:
+		goto _test_eof
+	_test_eof212:
 		m.cs = 212
-		goto _testEof
-	_testEof213:
+		goto _test_eof
+	_test_eof213:
 		m.cs = 213
-		goto _testEof
-	_testEof214:
+		goto _test_eof
+	_test_eof214:
 		m.cs = 214
-		goto _testEof
-	_testEof215:
+		goto _test_eof
+	_test_eof215:
 		m.cs = 215
-		goto _testEof
-	_testEof216:
+		goto _test_eof
+	_test_eof216:
 		m.cs = 216
-		goto _testEof
-	_testEof217:
+		goto _test_eof
+	_test_eof217:
 		m.cs = 217
-		goto _testEof
-	_testEof218:
+		goto _test_eof
+	_test_eof218:
 		m.cs = 218
-		goto _testEof
-	_testEof219:
+		goto _test_eof
+	_test_eof219:
 		m.cs = 219
-		goto _testEof
-	_testEof220:
+		goto _test_eof
+	_test_eof220:
 		m.cs = 220
-		goto _testEof
-	_testEof221:
+		goto _test_eof
+	_test_eof221:
 		m.cs = 221
-		goto _testEof
-	_testEof222:
+		goto _test_eof
+	_test_eof222:
 		m.cs = 222
-		goto _testEof
-	_testEof223:
+		goto _test_eof
+	_test_eof223:
 		m.cs = 223
-		goto _testEof
-	_testEof224:
+		goto _test_eof
+	_test_eof224:
 		m.cs = 224
-		goto _testEof
-	_testEof225:
+		goto _test_eof
+	_test_eof225:
 		m.cs = 225
-		goto _testEof
-	_testEof226:
+		goto _test_eof
+	_test_eof226:
 		m.cs = 226
-		goto _testEof
-	_testEof227:
+		goto _test_eof
+	_test_eof227:
 		m.cs = 227
-		goto _testEof
-	_testEof228:
+		goto _test_eof
+	_test_eof228:
 		m.cs = 228
-		goto _testEof
-	_testEof229:
+		goto _test_eof
+	_test_eof229:
 		m.cs = 229
-		goto _testEof
-	_testEof230:
+		goto _test_eof
+	_test_eof230:
 		m.cs = 230
-		goto _testEof
-	_testEof231:
+		goto _test_eof
+	_test_eof231:
 		m.cs = 231
-		goto _testEof
-	_testEof232:
+		goto _test_eof
+	_test_eof232:
 		m.cs = 232
-		goto _testEof
-	_testEof233:
+		goto _test_eof
+	_test_eof233:
 		m.cs = 233
-		goto _testEof
-	_testEof234:
+		goto _test_eof
+	_test_eof234:
 		m.cs = 234
-		goto _testEof
-	_testEof235:
+		goto _test_eof
+	_test_eof235:
 		m.cs = 235
-		goto _testEof
-	_testEof236:
+		goto _test_eof
+	_test_eof236:
 		m.cs = 236
-		goto _testEof
-	_testEof237:
+		goto _test_eof
+	_test_eof237:
 		m.cs = 237
-		goto _testEof
-	_testEof238:
+		goto _test_eof
+	_test_eof238:
 		m.cs = 238
-		goto _testEof
-	_testEof239:
+		goto _test_eof
+	_test_eof239:
 		m.cs = 239
-		goto _testEof
-	_testEof240:
+		goto _test_eof
+	_test_eof240:
 		m.cs = 240
-		goto _testEof
-	_testEof241:
+		goto _test_eof
+	_test_eof241:
 		m.cs = 241
-		goto _testEof
-	_testEof242:
+		goto _test_eof
+	_test_eof242:
 		m.cs = 242
-		goto _testEof
-	_testEof243:
+		goto _test_eof
+	_test_eof243:
 		m.cs = 243
-		goto _testEof
-	_testEof244:
+		goto _test_eof
+	_test_eof244:
 		m.cs = 244
-		goto _testEof
-	_testEof245:
+		goto _test_eof
+	_test_eof245:
 		m.cs = 245
-		goto _testEof
-	_testEof246:
+		goto _test_eof
+	_test_eof246:
 		m.cs = 246
-		goto _testEof
-	_testEof247:
+		goto _test_eof
+	_test_eof247:
 		m.cs = 247
-		goto _testEof
-	_testEof248:
+		goto _test_eof
+	_test_eof248:
 		m.cs = 248
-		goto _testEof
-	_testEof249:
+		goto _test_eof
+	_test_eof249:
 		m.cs = 249
-		goto _testEof
-	_testEof250:
+		goto _test_eof
+	_test_eof250:
 		m.cs = 250
-		goto _testEof
-	_testEof251:
+		goto _test_eof
+	_test_eof251:
 		m.cs = 251
-		goto _testEof
-	_testEof252:
+		goto _test_eof
+	_test_eof252:
 		m.cs = 252
-		goto _testEof
-	_testEof253:
+		goto _test_eof
+	_test_eof253:
 		m.cs = 253
-		goto _testEof
-	_testEof254:
+		goto _test_eof
+	_test_eof254:
 		m.cs = 254
-		goto _testEof
-	_testEof255:
+		goto _test_eof
+	_test_eof255:
 		m.cs = 255
-		goto _testEof
-	_testEof256:
+		goto _test_eof
+	_test_eof256:
 		m.cs = 256
-		goto _testEof
-	_testEof257:
+		goto _test_eof
+	_test_eof257:
 		m.cs = 257
-		goto _testEof
-	_testEof258:
+		goto _test_eof
+	_test_eof258:
 		m.cs = 258
-		goto _testEof
-	_testEof259:
+		goto _test_eof
+	_test_eof259:
 		m.cs = 259
-		goto _testEof
-	_testEof260:
+		goto _test_eof
+	_test_eof260:
 		m.cs = 260
-		goto _testEof
-	_testEof261:
+		goto _test_eof
+	_test_eof261:
 		m.cs = 261
-		goto _testEof
-	_testEof262:
+		goto _test_eof
+	_test_eof262:
 		m.cs = 262
-		goto _testEof
-	_testEof263:
+		goto _test_eof
+	_test_eof263:
 		m.cs = 263
-		goto _testEof
-	_testEof264:
+		goto _test_eof
+	_test_eof264:
 		m.cs = 264
-		goto _testEof
-	_testEof265:
+		goto _test_eof
+	_test_eof265:
 		m.cs = 265
-		goto _testEof
-	_testEof266:
+		goto _test_eof
+	_test_eof266:
 		m.cs = 266
-		goto _testEof
-	_testEof267:
+		goto _test_eof
+	_test_eof267:
 		m.cs = 267
-		goto _testEof
-	_testEof268:
+		goto _test_eof
+	_test_eof268:
 		m.cs = 268
-		goto _testEof
-	_testEof269:
+		goto _test_eof
+	_test_eof269:
 		m.cs = 269
-		goto _testEof
-	_testEof270:
+		goto _test_eof
+	_test_eof270:
 		m.cs = 270
-		goto _testEof
-	_testEof271:
+		goto _test_eof
+	_test_eof271:
 		m.cs = 271
-		goto _testEof
-	_testEof272:
+		goto _test_eof
+	_test_eof272:
 		m.cs = 272
-		goto _testEof
-	_testEof273:
+		goto _test_eof
+	_test_eof273:
 		m.cs = 273
-		goto _testEof
-	_testEof274:
+		goto _test_eof
+	_test_eof274:
 		m.cs = 274
-		goto _testEof
-	_testEof275:
+		goto _test_eof
+	_test_eof275:
 		m.cs = 275
-		goto _testEof
-	_testEof276:
+		goto _test_eof
+	_test_eof276:
 		m.cs = 276
-		goto _testEof
-	_testEof277:
+		goto _test_eof
+	_test_eof277:
 		m.cs = 277
-		goto _testEof
-	_testEof278:
+		goto _test_eof
+	_test_eof278:
 		m.cs = 278
-		goto _testEof
-	_testEof279:
+		goto _test_eof
+	_test_eof279:
 		m.cs = 279
-		goto _testEof
-	_testEof280:
+		goto _test_eof
+	_test_eof280:
 		m.cs = 280
-		goto _testEof
-	_testEof281:
+		goto _test_eof
+	_test_eof281:
 		m.cs = 281
-		goto _testEof
-	_testEof282:
+		goto _test_eof
+	_test_eof282:
 		m.cs = 282
-		goto _testEof
-	_testEof283:
+		goto _test_eof
+	_test_eof283:
 		m.cs = 283
-		goto _testEof
-	_testEof284:
+		goto _test_eof
+	_test_eof284:
 		m.cs = 284
-		goto _testEof
-	_testEof285:
+		goto _test_eof
+	_test_eof285:
 		m.cs = 285
-		goto _testEof
-	_testEof286:
+		goto _test_eof
+	_test_eof286:
 		m.cs = 286
-		goto _testEof
-	_testEof287:
+		goto _test_eof
+	_test_eof287:
 		m.cs = 287
-		goto _testEof
-	_testEof288:
+		goto _test_eof
+	_test_eof288:
 		m.cs = 288
-		goto _testEof
-	_testEof289:
+		goto _test_eof
+	_test_eof289:
 		m.cs = 289
-		goto _testEof
-	_testEof290:
+		goto _test_eof
+	_test_eof290:
 		m.cs = 290
-		goto _testEof
-	_testEof291:
+		goto _test_eof
+	_test_eof291:
 		m.cs = 291
-		goto _testEof
-	_testEof292:
+		goto _test_eof
+	_test_eof292:
 		m.cs = 292
-		goto _testEof
-	_testEof293:
+		goto _test_eof
+	_test_eof293:
 		m.cs = 293
-		goto _testEof
-	_testEof294:
+		goto _test_eof
+	_test_eof294:
 		m.cs = 294
-		goto _testEof
-	_testEof295:
+		goto _test_eof
+	_test_eof295:
 		m.cs = 295
-		goto _testEof
-	_testEof296:
+		goto _test_eof
+	_test_eof296:
 		m.cs = 296
-		goto _testEof
-	_testEof297:
+		goto _test_eof
+	_test_eof297:
 		m.cs = 297
-		goto _testEof
-	_testEof298:
+		goto _test_eof
+	_test_eof298:
 		m.cs = 298
-		goto _testEof
-	_testEof299:
+		goto _test_eof
+	_test_eof299:
 		m.cs = 299
-		goto _testEof
-	_testEof300:
+		goto _test_eof
+	_test_eof300:
 		m.cs = 300
-		goto _testEof
-	_testEof301:
+		goto _test_eof
+	_test_eof301:
 		m.cs = 301
-		goto _testEof
-	_testEof302:
+		goto _test_eof
+	_test_eof302:
 		m.cs = 302
-		goto _testEof
-	_testEof303:
+		goto _test_eof
+	_test_eof303:
 		m.cs = 303
-		goto _testEof
-	_testEof304:
+		goto _test_eof
+	_test_eof304:
 		m.cs = 304
-		goto _testEof
-	_testEof305:
+		goto _test_eof
+	_test_eof305:
 		m.cs = 305
-		goto _testEof
-	_testEof306:
+		goto _test_eof
+	_test_eof306:
 		m.cs = 306
-		goto _testEof
-	_testEof307:
+		goto _test_eof
+	_test_eof307:
 		m.cs = 307
-		goto _testEof
-	_testEof308:
+		goto _test_eof
+	_test_eof308:
 		m.cs = 308
-		goto _testEof
-	_testEof309:
+		goto _test_eof
+	_test_eof309:
 		m.cs = 309
-		goto _testEof
-	_testEof310:
+		goto _test_eof
+	_test_eof310:
 		m.cs = 310
-		goto _testEof
-	_testEof311:
+		goto _test_eof
+	_test_eof311:
 		m.cs = 311
-		goto _testEof
-	_testEof312:
+		goto _test_eof
+	_test_eof312:
 		m.cs = 312
-		goto _testEof
-	_testEof313:
+		goto _test_eof
+	_test_eof313:
 		m.cs = 313
-		goto _testEof
-	_testEof314:
+		goto _test_eof
+	_test_eof314:
 		m.cs = 314
-		goto _testEof
-	_testEof315:
+		goto _test_eof
+	_test_eof315:
 		m.cs = 315
-		goto _testEof
-	_testEof316:
+		goto _test_eof
+	_test_eof316:
 		m.cs = 316
-		goto _testEof
-	_testEof317:
+		goto _test_eof
+	_test_eof317:
 		m.cs = 317
-		goto _testEof
-	_testEof318:
+		goto _test_eof
+	_test_eof318:
 		m.cs = 318
-		goto _testEof
-	_testEof319:
+		goto _test_eof
+	_test_eof319:
 		m.cs = 319
-		goto _testEof
-	_testEof320:
+		goto _test_eof
+	_test_eof320:
 		m.cs = 320
-		goto _testEof
-	_testEof321:
+		goto _test_eof
+	_test_eof321:
 		m.cs = 321
-		goto _testEof
-	_testEof322:
+		goto _test_eof
+	_test_eof322:
 		m.cs = 322
-		goto _testEof
-	_testEof323:
+		goto _test_eof
+	_test_eof323:
 		m.cs = 323
-		goto _testEof
-	_testEof324:
+		goto _test_eof
+	_test_eof324:
 		m.cs = 324
-		goto _testEof
-	_testEof325:
+		goto _test_eof
+	_test_eof325:
 		m.cs = 325
-		goto _testEof
-	_testEof326:
+		goto _test_eof
+	_test_eof326:
 		m.cs = 326
-		goto _testEof
-	_testEof327:
+		goto _test_eof
+	_test_eof327:
 		m.cs = 327
-		goto _testEof
-	_testEof328:
+		goto _test_eof
+	_test_eof328:
 		m.cs = 328
-		goto _testEof
-	_testEof329:
+		goto _test_eof
+	_test_eof329:
 		m.cs = 329
-		goto _testEof
-	_testEof330:
+		goto _test_eof
+	_test_eof330:
 		m.cs = 330
-		goto _testEof
-	_testEof331:
+		goto _test_eof
+	_test_eof331:
 		m.cs = 331
-		goto _testEof
-	_testEof332:
+		goto _test_eof
+	_test_eof332:
 		m.cs = 332
-		goto _testEof
-	_testEof333:
+		goto _test_eof
+	_test_eof333:
 		m.cs = 333
-		goto _testEof
-	_testEof334:
+		goto _test_eof
+	_test_eof334:
 		m.cs = 334
-		goto _testEof
-	_testEof335:
+		goto _test_eof
+	_test_eof335:
 		m.cs = 335
-		goto _testEof
-	_testEof336:
+		goto _test_eof
+	_test_eof336:
 		m.cs = 336
-		goto _testEof
-	_testEof337:
+		goto _test_eof
+	_test_eof337:
 		m.cs = 337
-		goto _testEof
-	_testEof338:
+		goto _test_eof
+	_test_eof338:
 		m.cs = 338
-		goto _testEof
-	_testEof339:
+		goto _test_eof
+	_test_eof339:
 		m.cs = 339
-		goto _testEof
-	_testEof340:
+		goto _test_eof
+	_test_eof340:
 		m.cs = 340
-		goto _testEof
-	_testEof341:
+		goto _test_eof
+	_test_eof341:
 		m.cs = 341
-		goto _testEof
-	_testEof342:
+		goto _test_eof
+	_test_eof342:
 		m.cs = 342
-		goto _testEof
-	_testEof343:
+		goto _test_eof
+	_test_eof343:
 		m.cs = 343
-		goto _testEof
-	_testEof344:
+		goto _test_eof
+	_test_eof344:
 		m.cs = 344
-		goto _testEof
-	_testEof345:
+		goto _test_eof
+	_test_eof345:
 		m.cs = 345
-		goto _testEof
-	_testEof346:
+		goto _test_eof
+	_test_eof346:
 		m.cs = 346
-		goto _testEof
-	_testEof347:
+		goto _test_eof
+	_test_eof347:
 		m.cs = 347
-		goto _testEof
-	_testEof348:
+		goto _test_eof
+	_test_eof348:
 		m.cs = 348
-		goto _testEof
-	_testEof349:
+		goto _test_eof
+	_test_eof349:
 		m.cs = 349
-		goto _testEof
-	_testEof350:
+		goto _test_eof
+	_test_eof350:
 		m.cs = 350
-		goto _testEof
-	_testEof351:
+		goto _test_eof
+	_test_eof351:
 		m.cs = 351
-		goto _testEof
-	_testEof352:
+		goto _test_eof
+	_test_eof352:
 		m.cs = 352
-		goto _testEof
-	_testEof353:
+		goto _test_eof
+	_test_eof353:
 		m.cs = 353
-		goto _testEof
-	_testEof354:
+		goto _test_eof
+	_test_eof354:
 		m.cs = 354
-		goto _testEof
-	_testEof355:
+		goto _test_eof
+	_test_eof355:
 		m.cs = 355
-		goto _testEof
-	_testEof356:
+		goto _test_eof
+	_test_eof356:
 		m.cs = 356
-		goto _testEof
-	_testEof357:
+		goto _test_eof
+	_test_eof357:
 		m.cs = 357
-		goto _testEof
-	_testEof358:
+		goto _test_eof
+	_test_eof358:
 		m.cs = 358
-		goto _testEof
-	_testEof359:
+		goto _test_eof
+	_test_eof359:
 		m.cs = 359
-		goto _testEof
-	_testEof360:
+		goto _test_eof
+	_test_eof360:
 		m.cs = 360
-		goto _testEof
-	_testEof361:
+		goto _test_eof
+	_test_eof361:
 		m.cs = 361
-		goto _testEof
-	_testEof362:
+		goto _test_eof
+	_test_eof362:
 		m.cs = 362
-		goto _testEof
-	_testEof363:
+		goto _test_eof
+	_test_eof363:
 		m.cs = 363
-		goto _testEof
-	_testEof364:
+		goto _test_eof
+	_test_eof364:
 		m.cs = 364
-		goto _testEof
-	_testEof365:
+		goto _test_eof
+	_test_eof365:
 		m.cs = 365
-		goto _testEof
-	_testEof366:
+		goto _test_eof
+	_test_eof366:
 		m.cs = 366
-		goto _testEof
-	_testEof367:
+		goto _test_eof
+	_test_eof367:
 		m.cs = 367
-		goto _testEof
-	_testEof368:
+		goto _test_eof
+	_test_eof368:
 		m.cs = 368
-		goto _testEof
-	_testEof369:
+		goto _test_eof
+	_test_eof369:
 		m.cs = 369
-		goto _testEof
-	_testEof370:
+		goto _test_eof
+	_test_eof370:
 		m.cs = 370
-		goto _testEof
-	_testEof371:
+		goto _test_eof
+	_test_eof371:
 		m.cs = 371
-		goto _testEof
-	_testEof372:
+		goto _test_eof
+	_test_eof372:
 		m.cs = 372
-		goto _testEof
-	_testEof373:
+		goto _test_eof
+	_test_eof373:
 		m.cs = 373
-		goto _testEof
-	_testEof374:
+		goto _test_eof
+	_test_eof374:
 		m.cs = 374
-		goto _testEof
-	_testEof375:
+		goto _test_eof
+	_test_eof375:
 		m.cs = 375
-		goto _testEof
-	_testEof376:
+		goto _test_eof
+	_test_eof376:
 		m.cs = 376
-		goto _testEof
-	_testEof377:
+		goto _test_eof
+	_test_eof377:
 		m.cs = 377
-		goto _testEof
-	_testEof378:
+		goto _test_eof
+	_test_eof378:
 		m.cs = 378
-		goto _testEof
-	_testEof379:
+		goto _test_eof
+	_test_eof379:
 		m.cs = 379
-		goto _testEof
-	_testEof380:
+		goto _test_eof
+	_test_eof380:
 		m.cs = 380
-		goto _testEof
-	_testEof381:
+		goto _test_eof
+	_test_eof381:
 		m.cs = 381
-		goto _testEof
-	_testEof382:
+		goto _test_eof
+	_test_eof382:
 		m.cs = 382
-		goto _testEof
-	_testEof383:
+		goto _test_eof
+	_test_eof383:
 		m.cs = 383
-		goto _testEof
-	_testEof384:
+		goto _test_eof
+	_test_eof384:
 		m.cs = 384
-		goto _testEof
-	_testEof385:
+		goto _test_eof
+	_test_eof385:
 		m.cs = 385
-		goto _testEof
-	_testEof386:
+		goto _test_eof
+	_test_eof386:
 		m.cs = 386
-		goto _testEof
-	_testEof387:
+		goto _test_eof
+	_test_eof387:
 		m.cs = 387
-		goto _testEof
-	_testEof388:
+		goto _test_eof
+	_test_eof388:
 		m.cs = 388
-		goto _testEof
-	_testEof389:
+		goto _test_eof
+	_test_eof389:
 		m.cs = 389
-		goto _testEof
-	_testEof390:
+		goto _test_eof
+	_test_eof390:
 		m.cs = 390
-		goto _testEof
-	_testEof391:
+		goto _test_eof
+	_test_eof391:
 		m.cs = 391
-		goto _testEof
-	_testEof392:
+		goto _test_eof
+	_test_eof392:
 		m.cs = 392
-		goto _testEof
-	_testEof393:
+		goto _test_eof
+	_test_eof393:
 		m.cs = 393
-		goto _testEof
-	_testEof394:
+		goto _test_eof
+	_test_eof394:
 		m.cs = 394
-		goto _testEof
-	_testEof395:
+		goto _test_eof
+	_test_eof395:
 		m.cs = 395
-		goto _testEof
-	_testEof396:
+		goto _test_eof
+	_test_eof396:
 		m.cs = 396
-		goto _testEof
-	_testEof397:
+		goto _test_eof
+	_test_eof397:
 		m.cs = 397
-		goto _testEof
-	_testEof398:
+		goto _test_eof
+	_test_eof398:
 		m.cs = 398
-		goto _testEof
-	_testEof399:
+		goto _test_eof
+	_test_eof399:
 		m.cs = 399
-		goto _testEof
-	_testEof400:
+		goto _test_eof
+	_test_eof400:
 		m.cs = 400
-		goto _testEof
-	_testEof401:
+		goto _test_eof
+	_test_eof401:
 		m.cs = 401
-		goto _testEof
-	_testEof402:
+		goto _test_eof
+	_test_eof402:
 		m.cs = 402
-		goto _testEof
-	_testEof403:
+		goto _test_eof
+	_test_eof403:
 		m.cs = 403
-		goto _testEof
-	_testEof404:
+		goto _test_eof
+	_test_eof404:
 		m.cs = 404
-		goto _testEof
-	_testEof405:
+		goto _test_eof
+	_test_eof405:
 		m.cs = 405
-		goto _testEof
-	_testEof406:
+		goto _test_eof
+	_test_eof406:
 		m.cs = 406
-		goto _testEof
-	_testEof407:
+		goto _test_eof
+	_test_eof407:
 		m.cs = 407
-		goto _testEof
-	_testEof408:
+		goto _test_eof
+	_test_eof408:
 		m.cs = 408
-		goto _testEof
-	_testEof409:
+		goto _test_eof
+	_test_eof409:
 		m.cs = 409
-		goto _testEof
-	_testEof410:
+		goto _test_eof
+	_test_eof410:
 		m.cs = 410
-		goto _testEof
-	_testEof411:
+		goto _test_eof
+	_test_eof411:
 		m.cs = 411
-		goto _testEof
-	_testEof412:
+		goto _test_eof
+	_test_eof412:
 		m.cs = 412
-		goto _testEof
-	_testEof413:
+		goto _test_eof
+	_test_eof413:
 		m.cs = 413
-		goto _testEof
-	_testEof414:
+		goto _test_eof
+	_test_eof414:
 		m.cs = 414
-		goto _testEof
-	_testEof415:
+		goto _test_eof
+	_test_eof415:
 		m.cs = 415
-		goto _testEof
-	_testEof416:
+		goto _test_eof
+	_test_eof416:
 		m.cs = 416
-		goto _testEof
-	_testEof417:
+		goto _test_eof
+	_test_eof417:
 		m.cs = 417
-		goto _testEof
-	_testEof418:
+		goto _test_eof
+	_test_eof418:
 		m.cs = 418
-		goto _testEof
-	_testEof419:
+		goto _test_eof
+	_test_eof419:
 		m.cs = 419
-		goto _testEof
-	_testEof420:
+		goto _test_eof
+	_test_eof420:
 		m.cs = 420
-		goto _testEof
-	_testEof421:
+		goto _test_eof
+	_test_eof421:
 		m.cs = 421
-		goto _testEof
-	_testEof422:
+		goto _test_eof
+	_test_eof422:
 		m.cs = 422
-		goto _testEof
-	_testEof423:
+		goto _test_eof
+	_test_eof423:
 		m.cs = 423
-		goto _testEof
-	_testEof424:
+		goto _test_eof
+	_test_eof424:
 		m.cs = 424
-		goto _testEof
-	_testEof425:
+		goto _test_eof
+	_test_eof425:
 		m.cs = 425
-		goto _testEof
-	_testEof426:
+		goto _test_eof
+	_test_eof426:
 		m.cs = 426
-		goto _testEof
-	_testEof427:
+		goto _test_eof
+	_test_eof427:
 		m.cs = 427
-		goto _testEof
-	_testEof428:
+		goto _test_eof
+	_test_eof428:
 		m.cs = 428
-		goto _testEof
-	_testEof429:
+		goto _test_eof
+	_test_eof429:
 		m.cs = 429
-		goto _testEof
-	_testEof430:
+		goto _test_eof
+	_test_eof430:
 		m.cs = 430
-		goto _testEof
-	_testEof431:
+		goto _test_eof
+	_test_eof431:
 		m.cs = 431
-		goto _testEof
-	_testEof432:
+		goto _test_eof
+	_test_eof432:
 		m.cs = 432
-		goto _testEof
-	_testEof433:
+		goto _test_eof
+	_test_eof433:
 		m.cs = 433
-		goto _testEof
-	_testEof434:
+		goto _test_eof
+	_test_eof434:
 		m.cs = 434
-		goto _testEof
-	_testEof435:
+		goto _test_eof
+	_test_eof435:
 		m.cs = 435
-		goto _testEof
-	_testEof436:
+		goto _test_eof
+	_test_eof436:
 		m.cs = 436
-		goto _testEof
-	_testEof437:
+		goto _test_eof
+	_test_eof437:
 		m.cs = 437
-		goto _testEof
-	_testEof438:
+		goto _test_eof
+	_test_eof438:
 		m.cs = 438
-		goto _testEof
-	_testEof439:
+		goto _test_eof
+	_test_eof439:
 		m.cs = 439
-		goto _testEof
-	_testEof440:
+		goto _test_eof
+	_test_eof440:
 		m.cs = 440
-		goto _testEof
-	_testEof441:
+		goto _test_eof
+	_test_eof441:
 		m.cs = 441
-		goto _testEof
-	_testEof442:
+		goto _test_eof
+	_test_eof442:
 		m.cs = 442
-		goto _testEof
-	_testEof443:
+		goto _test_eof
+	_test_eof443:
 		m.cs = 443
-		goto _testEof
-	_testEof444:
+		goto _test_eof
+	_test_eof444:
 		m.cs = 444
-		goto _testEof
-	_testEof445:
+		goto _test_eof
+	_test_eof445:
 		m.cs = 445
-		goto _testEof
-	_testEof446:
+		goto _test_eof
+	_test_eof446:
 		m.cs = 446
-		goto _testEof
-	_testEof447:
+		goto _test_eof
+	_test_eof447:
 		m.cs = 447
-		goto _testEof
-	_testEof448:
+		goto _test_eof
+	_test_eof448:
 		m.cs = 448
-		goto _testEof
-	_testEof449:
+		goto _test_eof
+	_test_eof449:
 		m.cs = 449
-		goto _testEof
-	_testEof450:
+		goto _test_eof
+	_test_eof450:
 		m.cs = 450
-		goto _testEof
-	_testEof451:
+		goto _test_eof
+	_test_eof451:
 		m.cs = 451
-		goto _testEof
-	_testEof452:
+		goto _test_eof
+	_test_eof452:
 		m.cs = 452
-		goto _testEof
-	_testEof453:
+		goto _test_eof
+	_test_eof453:
 		m.cs = 453
-		goto _testEof
-	_testEof454:
+		goto _test_eof
+	_test_eof454:
 		m.cs = 454
-		goto _testEof
-	_testEof455:
+		goto _test_eof
+	_test_eof455:
 		m.cs = 455
-		goto _testEof
-	_testEof456:
+		goto _test_eof
+	_test_eof456:
 		m.cs = 456
-		goto _testEof
-	_testEof457:
+		goto _test_eof
+	_test_eof457:
 		m.cs = 457
-		goto _testEof
-	_testEof458:
+		goto _test_eof
+	_test_eof458:
 		m.cs = 458
-		goto _testEof
-	_testEof459:
+		goto _test_eof
+	_test_eof459:
 		m.cs = 459
-		goto _testEof
-	_testEof460:
+		goto _test_eof
+	_test_eof460:
 		m.cs = 460
-		goto _testEof
-	_testEof461:
+		goto _test_eof
+	_test_eof461:
 		m.cs = 461
-		goto _testEof
-	_testEof462:
+		goto _test_eof
+	_test_eof462:
 		m.cs = 462
-		goto _testEof
-	_testEof463:
+		goto _test_eof
+	_test_eof463:
 		m.cs = 463
-		goto _testEof
-	_testEof464:
+		goto _test_eof
+	_test_eof464:
 		m.cs = 464
-		goto _testEof
-	_testEof465:
+		goto _test_eof
+	_test_eof465:
 		m.cs = 465
-		goto _testEof
-	_testEof466:
+		goto _test_eof
+	_test_eof466:
 		m.cs = 466
-		goto _testEof
-	_testEof467:
+		goto _test_eof
+	_test_eof467:
 		m.cs = 467
-		goto _testEof
-	_testEof468:
+		goto _test_eof
+	_test_eof468:
 		m.cs = 468
-		goto _testEof
-	_testEof469:
+		goto _test_eof
+	_test_eof469:
 		m.cs = 469
-		goto _testEof
-	_testEof470:
+		goto _test_eof
+	_test_eof470:
 		m.cs = 470
-		goto _testEof
-	_testEof471:
+		goto _test_eof
+	_test_eof471:
 		m.cs = 471
-		goto _testEof
-	_testEof472:
+		goto _test_eof
+	_test_eof472:
 		m.cs = 472
-		goto _testEof
-	_testEof473:
+		goto _test_eof
+	_test_eof473:
 		m.cs = 473
-		goto _testEof
-	_testEof474:
+		goto _test_eof
+	_test_eof474:
 		m.cs = 474
-		goto _testEof
-	_testEof475:
+		goto _test_eof
+	_test_eof475:
 		m.cs = 475
-		goto _testEof
-	_testEof476:
+		goto _test_eof
+	_test_eof476:
 		m.cs = 476
-		goto _testEof
-	_testEof477:
+		goto _test_eof
+	_test_eof477:
 		m.cs = 477
-		goto _testEof
-	_testEof478:
+		goto _test_eof
+	_test_eof478:
 		m.cs = 478
-		goto _testEof
-	_testEof479:
+		goto _test_eof
+	_test_eof479:
 		m.cs = 479
-		goto _testEof
-	_testEof480:
+		goto _test_eof
+	_test_eof480:
 		m.cs = 480
-		goto _testEof
-	_testEof481:
+		goto _test_eof
+	_test_eof481:
 		m.cs = 481
-		goto _testEof
-	_testEof482:
+		goto _test_eof
+	_test_eof482:
 		m.cs = 482
-		goto _testEof
-	_testEof483:
+		goto _test_eof
+	_test_eof483:
 		m.cs = 483
-		goto _testEof
-	_testEof484:
+		goto _test_eof
+	_test_eof484:
 		m.cs = 484
-		goto _testEof
-	_testEof485:
+		goto _test_eof
+	_test_eof485:
 		m.cs = 485
-		goto _testEof
-	_testEof486:
+		goto _test_eof
+	_test_eof486:
 		m.cs = 486
-		goto _testEof
-	_testEof487:
+		goto _test_eof
+	_test_eof487:
 		m.cs = 487
-		goto _testEof
-	_testEof488:
+		goto _test_eof
+	_test_eof488:
 		m.cs = 488
-		goto _testEof
-	_testEof489:
+		goto _test_eof
+	_test_eof489:
 		m.cs = 489
-		goto _testEof
-	_testEof490:
+		goto _test_eof
+	_test_eof490:
 		m.cs = 490
-		goto _testEof
-	_testEof491:
+		goto _test_eof
+	_test_eof491:
 		m.cs = 491
-		goto _testEof
-	_testEof492:
+		goto _test_eof
+	_test_eof492:
 		m.cs = 492
-		goto _testEof
-	_testEof493:
+		goto _test_eof
+	_test_eof493:
 		m.cs = 493
-		goto _testEof
-	_testEof494:
+		goto _test_eof
+	_test_eof494:
 		m.cs = 494
-		goto _testEof
-	_testEof495:
+		goto _test_eof
+	_test_eof495:
 		m.cs = 495
-		goto _testEof
-	_testEof496:
+		goto _test_eof
+	_test_eof496:
 		m.cs = 496
-		goto _testEof
-	_testEof497:
+		goto _test_eof
+	_test_eof497:
 		m.cs = 497
-		goto _testEof
-	_testEof498:
+		goto _test_eof
+	_test_eof498:
 		m.cs = 498
-		goto _testEof
-	_testEof499:
+		goto _test_eof
+	_test_eof499:
 		m.cs = 499
-		goto _testEof
-	_testEof500:
+		goto _test_eof
+	_test_eof500:
 		m.cs = 500
-		goto _testEof
-	_testEof501:
+		goto _test_eof
+	_test_eof501:
 		m.cs = 501
-		goto _testEof
-	_testEof502:
+		goto _test_eof
+	_test_eof502:
 		m.cs = 502
-		goto _testEof
-	_testEof503:
+		goto _test_eof
+	_test_eof503:
 		m.cs = 503
-		goto _testEof
-	_testEof504:
+		goto _test_eof
+	_test_eof504:
 		m.cs = 504
-		goto _testEof
-	_testEof505:
+		goto _test_eof
+	_test_eof505:
 		m.cs = 505
-		goto _testEof
-	_testEof506:
+		goto _test_eof
+	_test_eof506:
 		m.cs = 506
-		goto _testEof
-	_testEof507:
+		goto _test_eof
+	_test_eof507:
 		m.cs = 507
-		goto _testEof
-	_testEof508:
+		goto _test_eof
+	_test_eof508:
 		m.cs = 508
-		goto _testEof
-	_testEof509:
+		goto _test_eof
+	_test_eof509:
 		m.cs = 509
-		goto _testEof
-	_testEof510:
+		goto _test_eof
+	_test_eof510:
 		m.cs = 510
-		goto _testEof
-	_testEof511:
+		goto _test_eof
+	_test_eof511:
 		m.cs = 511
-		goto _testEof
-	_testEof512:
+		goto _test_eof
+	_test_eof512:
 		m.cs = 512
-		goto _testEof
-	_testEof513:
+		goto _test_eof
+	_test_eof513:
 		m.cs = 513
-		goto _testEof
-	_testEof514:
+		goto _test_eof
+	_test_eof514:
 		m.cs = 514
-		goto _testEof
-	_testEof515:
+		goto _test_eof
+	_test_eof515:
 		m.cs = 515
-		goto _testEof
-	_testEof516:
+		goto _test_eof
+	_test_eof516:
 		m.cs = 516
-		goto _testEof
-	_testEof517:
+		goto _test_eof
+	_test_eof517:
 		m.cs = 517
-		goto _testEof
-	_testEof518:
+		goto _test_eof
+	_test_eof518:
 		m.cs = 518
-		goto _testEof
-	_testEof519:
+		goto _test_eof
+	_test_eof519:
 		m.cs = 519
-		goto _testEof
-	_testEof520:
+		goto _test_eof
+	_test_eof520:
 		m.cs = 520
-		goto _testEof
-	_testEof521:
+		goto _test_eof
+	_test_eof521:
 		m.cs = 521
-		goto _testEof
-	_testEof522:
+		goto _test_eof
+	_test_eof522:
 		m.cs = 522
-		goto _testEof
-	_testEof523:
+		goto _test_eof
+	_test_eof523:
 		m.cs = 523
-		goto _testEof
-	_testEof524:
+		goto _test_eof
+	_test_eof524:
 		m.cs = 524
-		goto _testEof
-	_testEof525:
+		goto _test_eof
+	_test_eof525:
 		m.cs = 525
-		goto _testEof
-	_testEof526:
+		goto _test_eof
+	_test_eof526:
 		m.cs = 526
-		goto _testEof
-	_testEof527:
+		goto _test_eof
+	_test_eof527:
 		m.cs = 527
-		goto _testEof
-	_testEof528:
+		goto _test_eof
+	_test_eof528:
 		m.cs = 528
-		goto _testEof
-	_testEof529:
+		goto _test_eof
+	_test_eof529:
 		m.cs = 529
-		goto _testEof
-	_testEof530:
+		goto _test_eof
+	_test_eof530:
 		m.cs = 530
-		goto _testEof
-	_testEof531:
+		goto _test_eof
+	_test_eof531:
 		m.cs = 531
-		goto _testEof
-	_testEof532:
+		goto _test_eof
+	_test_eof532:
 		m.cs = 532
-		goto _testEof
-	_testEof533:
+		goto _test_eof
+	_test_eof533:
 		m.cs = 533
-		goto _testEof
-	_testEof534:
+		goto _test_eof
+	_test_eof534:
 		m.cs = 534
-		goto _testEof
-	_testEof535:
+		goto _test_eof
+	_test_eof535:
 		m.cs = 535
-		goto _testEof
-	_testEof536:
+		goto _test_eof
+	_test_eof536:
 		m.cs = 536
-		goto _testEof
-	_testEof537:
+		goto _test_eof
+	_test_eof537:
 		m.cs = 537
-		goto _testEof
-	_testEof538:
+		goto _test_eof
+	_test_eof538:
 		m.cs = 538
-		goto _testEof
-	_testEof539:
+		goto _test_eof
+	_test_eof539:
 		m.cs = 539
-		goto _testEof
-	_testEof540:
+		goto _test_eof
+	_test_eof540:
 		m.cs = 540
-		goto _testEof
-	_testEof541:
+		goto _test_eof
+	_test_eof541:
 		m.cs = 541
-		goto _testEof
-	_testEof542:
+		goto _test_eof
+	_test_eof542:
 		m.cs = 542
-		goto _testEof
-	_testEof543:
+		goto _test_eof
+	_test_eof543:
 		m.cs = 543
-		goto _testEof
-	_testEof544:
+		goto _test_eof
+	_test_eof544:
 		m.cs = 544
-		goto _testEof
-	_testEof545:
+		goto _test_eof
+	_test_eof545:
 		m.cs = 545
-		goto _testEof
-	_testEof546:
+		goto _test_eof
+	_test_eof546:
 		m.cs = 546
-		goto _testEof
-	_testEof547:
+		goto _test_eof
+	_test_eof547:
 		m.cs = 547
-		goto _testEof
-	_testEof548:
+		goto _test_eof
+	_test_eof548:
 		m.cs = 548
-		goto _testEof
-	_testEof549:
+		goto _test_eof
+	_test_eof549:
 		m.cs = 549
-		goto _testEof
-	_testEof550:
+		goto _test_eof
+	_test_eof550:
 		m.cs = 550
-		goto _testEof
-	_testEof551:
+		goto _test_eof
+	_test_eof551:
 		m.cs = 551
-		goto _testEof
-	_testEof552:
+		goto _test_eof
+	_test_eof552:
 		m.cs = 552
-		goto _testEof
-	_testEof553:
+		goto _test_eof
+	_test_eof553:
 		m.cs = 553
-		goto _testEof
-	_testEof554:
+		goto _test_eof
+	_test_eof554:
 		m.cs = 554
-		goto _testEof
-	_testEof555:
+		goto _test_eof
+	_test_eof555:
 		m.cs = 555
-		goto _testEof
-	_testEof556:
+		goto _test_eof
+	_test_eof556:
 		m.cs = 556
-		goto _testEof
-	_testEof557:
+		goto _test_eof
+	_test_eof557:
 		m.cs = 557
-		goto _testEof
-	_testEof558:
+		goto _test_eof
+	_test_eof558:
 		m.cs = 558
-		goto _testEof
-	_testEof559:
+		goto _test_eof
+	_test_eof559:
 		m.cs = 559
-		goto _testEof
-	_testEof560:
+		goto _test_eof
+	_test_eof560:
 		m.cs = 560
-		goto _testEof
-	_testEof561:
+		goto _test_eof
+	_test_eof561:
 		m.cs = 561
-		goto _testEof
-	_testEof562:
+		goto _test_eof
+	_test_eof562:
 		m.cs = 562
-		goto _testEof
-	_testEof563:
+		goto _test_eof
+	_test_eof563:
 		m.cs = 563
-		goto _testEof
-	_testEof564:
+		goto _test_eof
+	_test_eof564:
 		m.cs = 564
-		goto _testEof
-	_testEof565:
+		goto _test_eof
+	_test_eof565:
 		m.cs = 565
-		goto _testEof
-	_testEof566:
+		goto _test_eof
+	_test_eof566:
 		m.cs = 566
-		goto _testEof
-	_testEof567:
+		goto _test_eof
+	_test_eof567:
 		m.cs = 567
-		goto _testEof
-	_testEof568:
+		goto _test_eof
+	_test_eof568:
 		m.cs = 568
-		goto _testEof
-	_testEof569:
+		goto _test_eof
+	_test_eof569:
 		m.cs = 569
-		goto _testEof
-	_testEof570:
+		goto _test_eof
+	_test_eof570:
 		m.cs = 570
-		goto _testEof
-	_testEof571:
+		goto _test_eof
+	_test_eof571:
 		m.cs = 571
-		goto _testEof
-	_testEof572:
+		goto _test_eof
+	_test_eof572:
 		m.cs = 572
-		goto _testEof
-	_testEof573:
+		goto _test_eof
+	_test_eof573:
 		m.cs = 573
-		goto _testEof
-	_testEof574:
+		goto _test_eof
+	_test_eof574:
 		m.cs = 574
-		goto _testEof
-	_testEof575:
+		goto _test_eof
+	_test_eof575:
 		m.cs = 575
-		goto _testEof
-	_testEof576:
+		goto _test_eof
+	_test_eof576:
 		m.cs = 576
-		goto _testEof
-	_testEof577:
+		goto _test_eof
+	_test_eof577:
 		m.cs = 577
-		goto _testEof
-	_testEof578:
+		goto _test_eof
+	_test_eof578:
 		m.cs = 578
-		goto _testEof
-	_testEof579:
+		goto _test_eof
+	_test_eof579:
 		m.cs = 579
-		goto _testEof
-	_testEof580:
+		goto _test_eof
+	_test_eof580:
 		m.cs = 580
-		goto _testEof
-	_testEof581:
+		goto _test_eof
+	_test_eof581:
 		m.cs = 581
-		goto _testEof
-	_testEof582:
+		goto _test_eof
+	_test_eof582:
 		m.cs = 582
-		goto _testEof
-	_testEof583:
+		goto _test_eof
+	_test_eof583:
 		m.cs = 583
-		goto _testEof
-	_testEof584:
+		goto _test_eof
+	_test_eof584:
 		m.cs = 584
-		goto _testEof
-	_testEof585:
+		goto _test_eof
+	_test_eof585:
 		m.cs = 585
-		goto _testEof
-	_testEof586:
+		goto _test_eof
+	_test_eof586:
 		m.cs = 586
-		goto _testEof
-	_testEof587:
+		goto _test_eof
+	_test_eof587:
 		m.cs = 587
-		goto _testEof
-	_testEof588:
+		goto _test_eof
+	_test_eof588:
 		m.cs = 588
-		goto _testEof
-	_testEof589:
+		goto _test_eof
+	_test_eof589:
 		m.cs = 589
-		goto _testEof
-	_testEof590:
+		goto _test_eof
+	_test_eof590:
 		m.cs = 590
-		goto _testEof
-	_testEof591:
+		goto _test_eof
+	_test_eof591:
 		m.cs = 591
-		goto _testEof
-	_testEof592:
+		goto _test_eof
+	_test_eof592:
 		m.cs = 592
-		goto _testEof
-	_testEof593:
+		goto _test_eof
+	_test_eof593:
 		m.cs = 593
-		goto _testEof
-	_testEof594:
+		goto _test_eof
+	_test_eof594:
 		m.cs = 594
-		goto _testEof
-	_testEof595:
+		goto _test_eof
+	_test_eof595:
 		m.cs = 595
-		goto _testEof
-	_testEof596:
+		goto _test_eof
+	_test_eof596:
 		m.cs = 596
-		goto _testEof
-	_testEof597:
+		goto _test_eof
+	_test_eof597:
 		m.cs = 597
-		goto _testEof
-	_testEof598:
+		goto _test_eof
+	_test_eof598:
 		m.cs = 598
-		goto _testEof
-	_testEof599:
+		goto _test_eof
+	_test_eof599:
 		m.cs = 599
-		goto _testEof
-	_testEof600:
+		goto _test_eof
+	_test_eof600:
 		m.cs = 600
-		goto _testEof
-	_testEof601:
+		goto _test_eof
+	_test_eof601:
 		m.cs = 601
-		goto _testEof
-	_testEof602:
+		goto _test_eof
+	_test_eof602:
 		m.cs = 602
-		goto _testEof
-	_testEof607:
+		goto _test_eof
+	_test_eof607:
 		m.cs = 607
-		goto _testEof
+		goto _test_eof
 
-	_testEof:
+	_test_eof:
 		{
 		}
 		if (m.p) == (m.eof) {
 			switch m.cs {
 			case 605:
+//line rfc5424/machine.go.rl:147
 
 				output.message = string(m.text())
 
 			case 1:
+//line rfc5424/machine.go.rl:157
 
 				m.err = fmt.Errorf(ErrPri+ColumnPositionTemplate, m.p)
 				(m.p)--
@@ -11666,6 +11851,7 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 				}
 
 			case 15, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 124, 125, 126, 127, 128, 129, 130, 131, 132:
+//line rfc5424/machine.go.rl:193
 
 				m.err = fmt.Errorf(ErrMsgID+ColumnPositionTemplate, m.p)
 				(m.p)--
@@ -11675,6 +11861,7 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 				}
 
 			case 16:
+//line rfc5424/machine.go.rl:199
 
 				m.err = fmt.Errorf(ErrStructuredData+ColumnPositionTemplate, m.p)
 				(m.p)--
@@ -11684,6 +11871,7 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 				}
 
 			case 7:
+//line rfc5424/machine.go.rl:242
 
 				m.err = fmt.Errorf(ErrParse+ColumnPositionTemplate, m.p)
 				(m.p)--
@@ -11693,8 +11881,11 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 				}
 
 			case 5:
+//line rfc5424/machine.go.rl:71
 
 				output.version = uint16(common.UnsafeUTF8DecimalCodePointsToInt(m.text()))
+
+//line rfc5424/machine.go.rl:242
 
 				m.err = fmt.Errorf(ErrParse+ColumnPositionTemplate, m.p)
 				(m.p)--
@@ -11704,6 +11895,7 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 				}
 
 			case 585:
+//line rfc5424/machine.go.rl:75
 
 				if t, e := time.Parse(RFC3339MICRO, string(m.text())); e != nil {
 					m.err = fmt.Errorf("%s [col %d]", e, m.p)
@@ -11717,6 +11909,8 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 					output.timestampSet = true
 				}
 
+//line rfc5424/machine.go.rl:242
+
 				m.err = fmt.Errorf(ErrParse+ColumnPositionTemplate, m.p)
 				(m.p)--
 
@@ -11725,6 +11919,7 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 				}
 
 			case 4:
+//line rfc5424/machine.go.rl:163
 
 				m.err = fmt.Errorf(ErrVersion+ColumnPositionTemplate, m.p)
 				(m.p)--
@@ -11732,6 +11927,8 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 				{
 					goto st607
 				}
+
+//line rfc5424/machine.go.rl:242
 
 				m.err = fmt.Errorf(ErrParse+ColumnPositionTemplate, m.p)
 				(m.p)--
@@ -11741,6 +11938,7 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 				}
 
 			case 6, 561, 562, 563, 564, 565, 566, 567, 568, 569, 570, 571, 572, 573, 574, 575, 576, 577, 578, 579, 580, 581, 582, 583, 584, 586, 587, 588, 589, 590, 591, 592, 593, 594, 595, 596, 597:
+//line rfc5424/machine.go.rl:169
 
 				m.err = fmt.Errorf(ErrTimestamp+ColumnPositionTemplate, m.p)
 				(m.p)--
@@ -11748,6 +11946,8 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 				{
 					goto st607
 				}
+
+//line rfc5424/machine.go.rl:242
 
 				m.err = fmt.Errorf(ErrParse+ColumnPositionTemplate, m.p)
 				(m.p)--
@@ -11757,6 +11957,7 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 				}
 
 			case 8, 9, 307, 308, 309, 310, 311, 312, 313, 314, 315, 316, 317, 318, 319, 320, 321, 322, 323, 324, 325, 326, 327, 328, 329, 330, 331, 332, 333, 334, 335, 336, 337, 338, 339, 340, 341, 342, 343, 344, 345, 346, 347, 348, 349, 350, 351, 352, 353, 354, 355, 356, 357, 358, 359, 360, 361, 362, 363, 364, 365, 366, 367, 368, 369, 370, 371, 372, 373, 374, 375, 376, 377, 378, 379, 380, 381, 382, 383, 384, 385, 386, 387, 388, 389, 390, 391, 392, 393, 394, 395, 396, 397, 398, 399, 400, 401, 402, 403, 404, 405, 406, 407, 408, 409, 410, 411, 412, 413, 414, 415, 416, 417, 418, 419, 420, 421, 422, 423, 424, 425, 426, 427, 428, 429, 430, 431, 432, 433, 434, 435, 436, 437, 438, 439, 440, 441, 442, 443, 444, 445, 446, 447, 448, 449, 450, 451, 452, 453, 454, 455, 456, 457, 458, 459, 460, 461, 462, 463, 464, 465, 466, 467, 468, 469, 470, 471, 472, 473, 474, 475, 476, 477, 478, 479, 480, 481, 482, 483, 484, 485, 486, 487, 488, 489, 490, 491, 492, 493, 494, 495, 496, 497, 498, 499, 500, 501, 502, 503, 504, 505, 506, 507, 508, 509, 510, 511, 512, 513, 514, 515, 516, 517, 518, 519, 520, 521, 522, 523, 524, 525, 526, 527, 528, 529, 530, 531, 532, 533, 534, 535, 536, 537, 538, 539, 540, 541, 542, 543, 544, 545, 546, 547, 548, 549, 550, 551, 552, 553, 554, 555, 556, 557, 558, 559, 560:
+//line rfc5424/machine.go.rl:175
 
 				m.err = fmt.Errorf(ErrHostname+ColumnPositionTemplate, m.p)
 				(m.p)--
@@ -11764,6 +11965,8 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 				{
 					goto st607
 				}
+
+//line rfc5424/machine.go.rl:242
 
 				m.err = fmt.Errorf(ErrParse+ColumnPositionTemplate, m.p)
 				(m.p)--
@@ -11773,6 +11976,7 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 				}
 
 			case 10, 11, 260, 261, 262, 263, 264, 265, 266, 267, 268, 269, 270, 271, 272, 273, 274, 275, 276, 277, 278, 279, 280, 281, 282, 283, 284, 285, 286, 287, 288, 289, 290, 291, 292, 293, 294, 295, 296, 297, 298, 299, 300, 301, 302, 303, 304, 305, 306:
+//line rfc5424/machine.go.rl:181
 
 				m.err = fmt.Errorf(ErrAppname+ColumnPositionTemplate, m.p)
 				(m.p)--
@@ -11780,6 +11984,8 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 				{
 					goto st607
 				}
+
+//line rfc5424/machine.go.rl:242
 
 				m.err = fmt.Errorf(ErrParse+ColumnPositionTemplate, m.p)
 				(m.p)--
@@ -11789,6 +11995,7 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 				}
 
 			case 12, 13, 133, 134, 135, 136, 137, 138, 139, 140, 141, 142, 143, 144, 145, 146, 147, 148, 149, 150, 151, 152, 153, 154, 155, 156, 157, 158, 159, 160, 161, 162, 163, 164, 165, 166, 167, 168, 169, 170, 171, 172, 173, 174, 175, 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191, 192, 193, 194, 195, 196, 197, 198, 199, 200, 201, 202, 203, 204, 205, 206, 207, 208, 209, 210, 211, 212, 213, 214, 215, 216, 217, 218, 219, 220, 221, 222, 223, 224, 225, 226, 227, 228, 229, 230, 231, 232, 233, 234, 235, 236, 237, 238, 239, 240, 241, 242, 243, 244, 245, 246, 247, 248, 249, 250, 251, 252, 253, 254, 255, 256, 257, 258, 259:
+//line rfc5424/machine.go.rl:187
 
 				m.err = fmt.Errorf(ErrProcID+ColumnPositionTemplate, m.p)
 				(m.p)--
@@ -11796,6 +12003,8 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 				{
 					goto st607
 				}
+
+//line rfc5424/machine.go.rl:242
 
 				m.err = fmt.Errorf(ErrParse+ColumnPositionTemplate, m.p)
 				(m.p)--
@@ -11805,6 +12014,7 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 				}
 
 			case 14:
+//line rfc5424/machine.go.rl:193
 
 				m.err = fmt.Errorf(ErrMsgID+ColumnPositionTemplate, m.p)
 				(m.p)--
@@ -11812,6 +12022,8 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 				{
 					goto st607
 				}
+
+//line rfc5424/machine.go.rl:242
 
 				m.err = fmt.Errorf(ErrParse+ColumnPositionTemplate, m.p)
 				(m.p)--
@@ -11821,6 +12033,7 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 				}
 
 			case 24:
+//line rfc5424/machine.go.rl:205
 
 				delete(output.structuredData, m.currentelem)
 				if len(output.structuredData) == 0 {
@@ -11833,6 +12046,8 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 					goto st607
 				}
 
+//line rfc5424/machine.go.rl:199
+
 				m.err = fmt.Errorf(ErrStructuredData+ColumnPositionTemplate, m.p)
 				(m.p)--
 
@@ -11841,6 +12056,7 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 				}
 
 			case 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 62, 64, 65, 66, 67, 68, 69, 70:
+//line rfc5424/machine.go.rl:215
 
 				if len(output.structuredData) > 0 {
 					delete(output.structuredData[m.currentelem], m.currentparam)
@@ -11852,6 +12068,8 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 					goto st607
 				}
 
+//line rfc5424/machine.go.rl:199
+
 				m.err = fmt.Errorf(ErrStructuredData+ColumnPositionTemplate, m.p)
 				(m.p)--
 
@@ -11860,6 +12078,7 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 				}
 
 			case 17, 18, 19, 20, 21, 22, 23:
+//line rfc5424/machine.go.rl:224
 
 				// If error encountered within the message rule ...
 				if m.msgat > 0 {
@@ -11874,6 +12093,8 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 					goto st607
 				}
 
+//line rfc5424/machine.go.rl:242
+
 				m.err = fmt.Errorf(ErrParse+ColumnPositionTemplate, m.p)
 				(m.p)--
 
@@ -11882,14 +12103,20 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 				}
 
 			case 604:
+//line rfc5424/machine.go.rl:58
 
 				m.pb = m.p
 
+//line rfc5424/machine.go.rl:62
+
 				m.msgat = m.p
+
+//line rfc5424/machine.go.rl:147
 
 				output.message = string(m.text())
 
 			case 25, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100, 101:
+//line rfc5424/machine.go.rl:106
 
 				if _, ok := output.structuredData[string(m.text())]; ok {
 					// As per RFC5424 section 6.3.2 SD-ID MUST NOT exist more than once in a message
@@ -11906,6 +12133,8 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 					m.currentelem = id
 				}
 
+//line rfc5424/machine.go.rl:205
+
 				delete(output.structuredData, m.currentelem)
 				if len(output.structuredData) == 0 {
 					output.hasElements = false
@@ -11917,6 +12146,8 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 					goto st607
 				}
 
+//line rfc5424/machine.go.rl:199
+
 				m.err = fmt.Errorf(ErrStructuredData+ColumnPositionTemplate, m.p)
 				(m.p)--
 
@@ -11925,6 +12156,7 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 				}
 
 			case 2, 3, 600, 601, 602:
+//line rfc5424/machine.go.rl:151
 
 				m.err = fmt.Errorf(ErrPrival+ColumnPositionTemplate, m.p)
 				(m.p)--
@@ -11933,12 +12165,16 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 					goto st607
 				}
 
+//line rfc5424/machine.go.rl:157
+
 				m.err = fmt.Errorf(ErrPri+ColumnPositionTemplate, m.p)
 				(m.p)--
 
 				{
 					goto st607
 				}
+
+//line rfc5424/machine.go.rl:242
 
 				m.err = fmt.Errorf(ErrParse+ColumnPositionTemplate, m.p)
 				(m.p)--
@@ -11948,6 +12184,7 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 				}
 
 			case 598, 599:
+//line rfc5424/machine.go.rl:163
 
 				m.err = fmt.Errorf(ErrVersion+ColumnPositionTemplate, m.p)
 				(m.p)--
@@ -11956,7 +12193,11 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 					goto st607
 				}
 
+//line rfc5424/machine.go.rl:71
+
 				output.version = uint16(common.UnsafeUTF8DecimalCodePointsToInt(m.text()))
+
+//line rfc5424/machine.go.rl:242
 
 				m.err = fmt.Errorf(ErrParse+ColumnPositionTemplate, m.p)
 				(m.p)--
@@ -11966,6 +12207,7 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 				}
 
 			case 60, 61, 63:
+//line rfc5424/machine.go.rl:236
 
 				m.err = fmt.Errorf(ErrEscape+ColumnPositionTemplate, m.p)
 				(m.p)--
@@ -11973,6 +12215,8 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 				{
 					goto st607
 				}
+
+//line rfc5424/machine.go.rl:215
 
 				if len(output.structuredData) > 0 {
 					delete(output.structuredData[m.currentelem], m.currentparam)
@@ -11984,6 +12228,8 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 					goto st607
 				}
 
+//line rfc5424/machine.go.rl:199
+
 				m.err = fmt.Errorf(ErrStructuredData+ColumnPositionTemplate, m.p)
 				(m.p)--
 
@@ -11991,6 +12237,7 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 					goto st607
 				}
 
+//line rfc5424/machine.go:10886
 			}
 		}
 
@@ -11999,7 +12246,9 @@ func (m *machine) Parse(input []byte) (syslog.Message, error) {
 		}
 	}
 
-	if m.cs < firstFinal || m.cs == enFail {
+//line rfc5424/machine.go.rl:373
+
+	if m.cs < first_final || m.cs == en_fail {
 		if m.bestEffort && output.valid() {
 			// An error occurred but partial parsing is on and partial message is minimally valid
 			return output.export(), m.err

--- a/rfc5424/machine.go.rl
+++ b/rfc5424/machine.go.rl
@@ -4,8 +4,8 @@ import (
 	"time"
 	"fmt"
 	
-	"github.com/influxdata/go-syslog/v2"
-	"github.com/influxdata/go-syslog/v2/common"
+	"github.com/influxdata/go-syslog"
+	"github.com/influxdata/go-syslog/common"
 )
 
 // ColumnPositionTemplate is the template used to communicate the column where errors occur.

--- a/rfc5424/machine_test.go
+++ b/rfc5424/machine_test.go
@@ -5,8 +5,8 @@ import (
 	"math/rand"
 	"testing"
 
-	"github.com/influxdata/go-syslog/v2"
-	syslogtesting "github.com/influxdata/go-syslog/v2/testing"
+	"github.com/influxdata/go-syslog"
+	syslogtesting "github.com/influxdata/go-syslog/testing"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/rfc5424/options.go
+++ b/rfc5424/options.go
@@ -1,7 +1,7 @@
 package rfc5424
 
 import (
-	syslog "github.com/influxdata/go-syslog/v2"
+	syslog "github.com/influxdata/go-syslog"
 )
 
 // WithBestEffort enables the best effort mode.

--- a/rfc5424/parser.go
+++ b/rfc5424/parser.go
@@ -3,7 +3,7 @@ package rfc5424
 import (
 	"sync"
 
-	syslog "github.com/influxdata/go-syslog/v2"
+	syslog "github.com/influxdata/go-syslog"
 )
 
 // parser represent a RFC5424 parser with mutex capabilities.

--- a/rfc5424/parser_test.go
+++ b/rfc5424/parser_test.go
@@ -3,8 +3,8 @@ package rfc5424
 import (
 	"testing"
 
-	"github.com/influxdata/go-syslog/v2"
-	syslogtesting "github.com/influxdata/go-syslog/v2/testing"
+	"github.com/influxdata/go-syslog"
+	syslogtesting "github.com/influxdata/go-syslog/testing"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/rfc5424/performance_test.go
+++ b/rfc5424/performance_test.go
@@ -3,8 +3,8 @@ package rfc5424
 import (
 	"testing"
 
-	"github.com/influxdata/go-syslog/v2"
-	syslogtesting "github.com/influxdata/go-syslog/v2/testing"
+	"github.com/influxdata/go-syslog"
+	syslogtesting "github.com/influxdata/go-syslog/testing"
 )
 
 // This is here to avoid compiler optimizations that


### PR DESCRIPTION
Users cannot use octet parser due to go module name inconsistency.
Both `develop` branch and `v2.0.0` tag ( the one with octet parser ) are not usable due to `v2` being present in the module name.

This might be working fine locally / in development, but fails for external / Go dep users.
This PR fixes all v2 mentions and can be validated with Go dep using

```
[[constraint]]
  name = "github.com/influxdata/go-syslog"
  branch = "develop"
  source = "https://github.com/lxfontes/go-syslog"
```
