### PR TITLE
return better error when message is too long

### DIFF
--- a/octetcounting/parser.go
+++ b/octetcounting/parser.go
@@ -86,6 +86,13 @@ func (p *parser) run() {
 			break
 		}
 
+		if int(p.s.msglen) > p.maxMessageLength {
+			p.emit(&syslog.Result{
+				Error: fmt.Errorf("message too long to parse. was size %d, max length %d", p.s.msglen, p.maxMessageLength),
+			})
+			break
+		}
+
 		// Next we MUST see a WS
 		if tok = p.scan(); tok.typ != WS {
 			p.emit(&syslog.Result{

--- a/octetcounting/parser_test.go
+++ b/octetcounting/parser_test.go
@@ -565,69 +565,15 @@ func getTestCases() []testCase {
 			},
 		},
 		{
-			descr: "1st ml//maxlen gt 8192", // maxlength greather than the buffer size
-			input: fmt.Sprintf(
-				"8193 <%d>%d %s %s %s %s %s - %s",
-				syslogtesting.MaxPriority,
-				syslogtesting.MaxVersion,
-				syslogtesting.MaxRFC3339MicroTimestamp,
-				string(syslogtesting.MaxHostname),
-				string(syslogtesting.MaxAppname),
-				string(syslogtesting.MaxProcID),
-				string(syslogtesting.MaxMsgID),
-				string(syslogtesting.MaxMessage),
-			),
-			// results w/o best effort
+			descr: "MSGLEN gt max message length",
+			input: "16 <1>1 - - - - - -",
 			results: []syslog.Result{
-				{
-					Error: fmt.Errorf(
-						"found %s after \"%s\", expecting a %s containing %d octets",
-						EOF,
-						fmt.Sprintf(
-							"<%d>%d %s %s %s %s %s - %s", syslogtesting.MaxPriority,
-							syslogtesting.MaxVersion,
-							syslogtesting.MaxRFC3339MicroTimestamp,
-							string(syslogtesting.MaxHostname),
-							string(syslogtesting.MaxAppname),
-							string(syslogtesting.MaxProcID),
-							string(syslogtesting.MaxMsgID),
-							string(syslogtesting.MaxMessage),
-						),
-						SYSLOGMSG,
-						8193,
-					),
-				},
+				{Error: fmt.Errorf("message too long to parse. was size %d, max length %d", 16, 10)},
 			},
-			// results with best effort
 			bestEffortResults: []syslog.Result{
-				{
-					Message: (&rfc5424.SyslogMessage{}).
-						SetPriority(syslogtesting.MaxPriority).
-						SetVersion(syslogtesting.MaxVersion).
-						SetTimestamp(syslogtesting.MaxRFC3339MicroTimestamp).
-						SetHostname(string(syslogtesting.MaxHostname)).
-						SetAppname(string(syslogtesting.MaxAppname)).
-						SetProcID(string(syslogtesting.MaxProcID)).
-						SetMsgID(string(syslogtesting.MaxMsgID)).
-						SetMessage(string(syslogtesting.MaxMessage)),
-					Error: fmt.Errorf(
-						"found %s after \"%s\", expecting a %s containing %d octets",
-						EOF,
-						fmt.Sprintf(
-							"<%d>%d %s %s %s %s %s - %s", syslogtesting.MaxPriority,
-							syslogtesting.MaxVersion,
-							syslogtesting.MaxRFC3339MicroTimestamp,
-							string(syslogtesting.MaxHostname),
-							string(syslogtesting.MaxAppname),
-							string(syslogtesting.MaxProcID),
-							string(syslogtesting.MaxMsgID),
-							string(syslogtesting.MaxMessage),
-						),
-						SYSLOGMSG,
-						8193,
-					),
-				},
+				{Error: fmt.Errorf("message too long to parse. was size %d, max length %d", 16, 10)},
 			},
+			maxMessageLength: 10,
 		},
 		{
 			descr: "1st uf/2nd ok//incomplete SYSLOGMSG/notdetectable",

--- a/octetcounting/scanner.go
+++ b/octetcounting/scanner.go
@@ -113,9 +113,6 @@ func (s *Scanner) scanMsgLen() Token {
 	msglen := buf.String()
 	s.msglen, _ = strconv.ParseUint(msglen, 10, 64)
 
-	// (todo) > return ILLEGAL if s.msglen > size (8192)
-	// (todo) > only when NOT in besteffort mode or always?
-
 	return Token{
 		typ: MSGLEN,
 		lit: buf.Bytes(),


### PR DESCRIPTION
This should clean up two todos and follows from being able to set max message size for octect parsing. 