### PR TITLE
improve basic example + test fixes

### DIFF
--- a/nontransparent/parser_test.go
+++ b/nontransparent/parser_test.go
@@ -164,7 +164,7 @@ func TestParse(t *testing.T) {
 		var inputWithLF = tc.input
 		if tc.substitute {
 			lf, _ := LF.Value()
-			inputWithLF = fmt.Sprintf(tc.input, string(lf))
+			inputWithLF = fmt.Sprintf(tc.input, string(rune(lf)))
 		}
 		t.Run(fmt.Sprintf("strict/LF/%s", tc.descr), func(t *testing.T) {
 			t.Parallel()
@@ -193,7 +193,7 @@ func TestParse(t *testing.T) {
 		inputWithNUL := tc.input
 		if tc.substitute {
 			nul, _ := NUL.Value()
-			inputWithNUL = fmt.Sprintf(tc.input, string(nul))
+			inputWithNUL = fmt.Sprintf(tc.input, string(rune(nul)))
 		}
 		t.Run(fmt.Sprintf("strict/NL/%s", tc.descr), func(t *testing.T) {
 			t.Parallel()

--- a/rfc3164/example_test.go
+++ b/rfc3164/example_test.go
@@ -46,7 +46,7 @@ func Example_currentyear() {
 	//   Facility: (*uint8)(1),
 	//   Severity: (*uint8)(5),
 	//   Priority: (*uint8)(13),
-	//   Timestamp: (*time.Time)(2020-12-02 16:31:03 +0000 UTC),
+	//   Timestamp: (*time.Time)(2021-12-02 16:31:03 +0000 UTC),
 	//   Hostname: (*string)((len=4) "host"),
 	//   Appname: (*string)((len=3) "app"),
 	//   ProcID: (*string)(<nil>),

--- a/rfc5424/example_test.go
+++ b/rfc5424/example_test.go
@@ -17,6 +17,10 @@ func Example() {
 	p := NewParser()
 	m, _ := p.Parse(i)
 	output(m)
+	msg := m.(*SyslogMessage)
+	fmt.Println(*msg.Message)
+	fmt.Println(*msg.Hostname)
+	output(*msg.StructuredData)
 	// Output:
 	// (*rfc5424.SyslogMessage)({
 	//  Base: (syslog.Base) {
@@ -37,6 +41,13 @@ func Example() {
 	//   }
 	//  })
 	// })
+	// An application event log entry...
+	// mymach.it
+	// (map[string]map[string]string) (len=1) {
+	//  (string) (len=8) "ex@32473": (map[string]string) (len=1) {
+	//   (string) (len=3) "iut": (string) (len=1) "3"
+	//  }
+	// }
 }
 
 func Example_besteffort() {


### PR DESCRIPTION
Fixes #33

Shows how to access message, hostname, etc. from a parsing result message (`syslog.Message` interface).

Signed-off-by: Leonardo Di Donato <leodidonato@gmail.com>