### PR TITLE
add support for RFC3164 streams

### DIFF
--- a/nontransparent/parser.go
+++ b/nontransparent/parser.go
@@ -4,6 +4,7 @@ import (
 	"io"
 
 	syslog "github.com/influxdata/go-syslog/v3"
+	"github.com/influxdata/go-syslog/v3/rfc3164"
 	"github.com/influxdata/go-syslog/v3/rfc5424"
 	parser "github.com/leodido/ragel-machinery/parser"
 )
@@ -213,6 +214,29 @@ func NewParser(options ...syslog.ParserOption) syslog.Parser {
 		m.internal = rfc5424.NewMachine(rfc5424.WithBestEffort())
 	} else {
 		m.internal = rfc5424.NewMachine()
+	}
+
+	return m
+}
+
+func NewParserRFC3164(options ...syslog.ParserOption) syslog.Parser {
+	m := &machine{
+		emit: func(*syslog.Result) { /* noop */ },
+	}
+
+	for _, opt := range options {
+		m = opt(m).(*machine)
+	}
+
+	// No error can happens since during its setting we check the trailer type passed in
+	trailer, _ := m.trailertyp.Value()
+	m.trailer = byte(trailer)
+
+	// Create internal parser depending on options
+	if m.bestEffort {
+		m.internal = rfc3164.NewMachine(rfc3164.WithBestEffort())
+	} else {
+		m.internal = rfc3164.NewMachine()
 	}
 
 	return m

--- a/octetcounting/parser.go
+++ b/octetcounting/parser.go
@@ -5,6 +5,7 @@ import (
 	"io"
 
 	syslog "github.com/influxdata/go-syslog/v3"
+	"github.com/influxdata/go-syslog/v3/rfc3164"
 	"github.com/influxdata/go-syslog/v3/rfc5424"
 )
 
@@ -38,6 +39,26 @@ func NewParser(opts ...syslog.ParserOption) syslog.Parser {
 		p.internal = rfc5424.NewMachine(rfc5424.WithBestEffort())
 	} else {
 		p.internal = rfc5424.NewMachine()
+	}
+
+	return p
+}
+
+func NewParserRFC3164(opts ...syslog.ParserOption) syslog.Parser {
+	p := &parser{
+		emit:             func(*syslog.Result) { /* noop */ },
+		maxMessageLength: 1024,
+	}
+
+	for _, opt := range opts {
+		p = opt(p).(*parser)
+	}
+
+	// Create internal parser depending on options
+	if p.bestEffort {
+		p.internal = rfc3164.NewMachine(rfc3164.WithBestEffort())
+	} else {
+		p.internal = rfc3164.NewMachine()
 	}
 
 	return p


### PR DESCRIPTION
This isn't a particularly fancy patch but adds RFC3164 support for streams.

My motivation is to use Lokis client tool [`promtail`](https://github.com/grafana/loki/blob/main/clients/pkg/promtail/targets/syslog/syslogparser/syslogparser.go) directly with RFC3164 devices without having a syslog-ng server in-between.

both nontransparent and octetcounting use RFC5424 which isn't used by many devices, i.e. OpenWrt or Ubiquiti routers.

Add a new function called NewParserRFC3164 to both.

Signed-off-by: Paul Spooren <mail@aparcar.org>