### PR TITLE
Remove use of global vars for current id and param name

### DIFF
--- a/rfc3164/example_test.go
+++ b/rfc3164/example_test.go
@@ -46,7 +46,7 @@ func Example_currentyear() {
 	//   Facility: (*uint8)(1),
 	//   Severity: (*uint8)(5),
 	//   Priority: (*uint8)(13),
-	//   Timestamp: (*time.Time)(2021-12-02 16:31:03 +0000 UTC),
+	//   Timestamp: (*time.Time)(2023-12-02 16:31:03 +0000 UTC),
 	//   Hostname: (*string)((len=4) "host"),
 	//   Appname: (*string)((len=3) "app"),
 	//   ProcID: (*string)(<nil>),

--- a/rfc5424/builder.go
+++ b/rfc5424/builder.go
@@ -22,6 +22,8 @@ const builderEnSdpn int = 43
 const builderEnSdpv int = 582
 const builderEnMsg int = 52
 
+const emptyString string = ""
+
 type entrypoint int
 
 const (
@@ -61,10 +63,12 @@ func (e entrypoint) translate() int {
 	}
 }
 
-var currentid string
-var currentparamname string
-
 func (sm *SyslogMessage) set(from entrypoint, value string) *SyslogMessage {
+	return sm.setWithOptions(from, value, emptyString, emptyString)
+}
+
+// currentid and currentparamname are optional
+func (sm *SyslogMessage) setWithOptions(from entrypoint, value string, currentid string, currentparamname string) *SyslogMessage {
 	data := []byte(value)
 	p := 0
 	pb := 0
@@ -9330,12 +9334,10 @@ func (sm *SyslogMessage) SetParameter(id string, name string, value string) Buil
 	if sm.StructuredData != nil {
 		elements := *sm.StructuredData
 		if _, ok := elements[id]; ok {
-			currentid = id
-			sm.set(sdpn, name)
+			sm.setWithOptions(sdpn, name, id, emptyString)
 			// We can assign parameter value iff the given parameter key exists
 			if _, ok := elements[id][name]; ok {
-				currentparamname = name
-				sm.set(sdpv, value)
+				sm.setWithOptions(sdpv, value, id, name)
 			}
 		}
 	}

--- a/rfc5424/builder.go.rl
+++ b/rfc5424/builder.go.rl
@@ -112,6 +112,8 @@ msg := any* >mark %set_msg;
 write data noerror nofinal;
 }%%
 
+const emptyString string = ""
+
 type entrypoint int
 
 const (
@@ -151,10 +153,12 @@ func (e entrypoint) translate() int {
     }
 }
 
-var currentid string
-var currentparamname string
-
 func (sm *SyslogMessage) set(from entrypoint, value string) *SyslogMessage {
+	return sm.setWithOptions(from, value, emptyString, emptyString)
+}
+
+// currentid and currentparamname are optional
+func (sm *SyslogMessage) setWithOptions(from entrypoint, value string, currentid string, currentparamname string) *SyslogMessage {
     data := []byte(value)
     p := 0
     pb := 0
@@ -233,12 +237,10 @@ func (sm *SyslogMessage) SetParameter(id string, name string, value string) Buil
     if sm.StructuredData != nil {
         elements := *sm.StructuredData
         if _, ok := elements[id]; ok {
-            currentid = id
-            sm.set(sdpn, name)
+            sm.setWithOptions(sdpn, name, id, emptyString)
             // We can assign parameter value iff the given parameter key exists
             if _, ok := elements[id][name]; ok {
-                currentparamname = name
-                sm.set(sdpv, value)
+                sm.setWithOptions(sdpv, value, id, name)
             }
         }
     }


### PR DESCRIPTION
Fixes https://github.com/influxdata/go-syslog/issues/44

This avoids a race when trying to populate multiple SyslogMessages concurrently.

I've tested this out in a scenario with telegraf where we were seeing this issue frequently and now we don't.